### PR TITLE
Fixed: Duplicate links in Laud Misc 636

### DIFF
--- a/collections/Laud_Misc/MS_Laud_Misc_636.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_636.xml
@@ -78,11 +78,10 @@
                      </origPlace>
                   </origin>
                </history>
-               <additional><adminInfo>
+               <additional>
+                  <adminInfo>
                      <recordHist>
                         <source>Summary description by Elizabeth Solopova and Matthew Holford, based on the Quarto Catalogue (H. O. Coxe,  <title>Laudian Manuscripts</title>, Quarto Catalogues II, repr. with corrections, 1969, from the original ed. of 1858-1885) and supplementary sources. 
-                            
-                            
                             <listBibl>
                               <bibl type="QUARTO" facs="aby0278.gif">Quarto Catalogue, col. 459</bibl>
                               <bibl type="QUARTO" facs="aby0355.gif">Quarto Catalogue, p. 575</bibl>
@@ -90,7 +89,29 @@
                            </listBibl>
                         </source>
                      </recordHist>
-                  </adminInfo><listBibl type="WRAPPER"><listBibl type="INTERNET"><head>Online resources:</head><!--Existing bibliography in place: check sorting of entries--><bibl><ref target="http://jonas.irht.cnrs.fr/manuscrit/79026"><title>JONAS: Répertoire des textes et des manuscrits médiévaux d'oc et d'oïl</title></ref></bibl><bibl><ref target="http://mlgb3.bodleian.ox.ac.uk/mlgb/book/188"><title>MLGB3: Medieval Libraries of Great Britain</title></ref></bibl><bibl><ref target="http://jonas.irht.cnrs.fr/manuscrit/79026"><title>JONAS: Répertoire des textes et des manuscrits médiévaux d'oc et d'oïl</title></ref></bibl><bibl><ref target="https://www.le.ac.uk/english/em1060to1220/mss/EM.Ox.Laud.Misc.636.htm"><title>The Production and Use of English Manuscripts 1060 to 1220</title></ref></bibl></listBibl></listBibl></additional>
+                  </adminInfo>
+                  <listBibl type="WRAPPER">
+                      <listBibl type="INTERNET">
+                         <head>Online resources:</head>
+                         <!--Existing bibliography in place: check sorting of entries-->
+                         <bibl>
+                            <ref target="http://jonas.irht.cnrs.fr/manuscrit/79026">
+                               <title>JONAS: Répertoire des textes et des manuscrits médiévaux d'oc et d'oïl</title>
+                            </ref>
+                         </bibl>
+                         <bibl>
+                            <ref target="http://mlgb3.bodleian.ox.ac.uk/mlgb/book/188">
+                               <title>MLGB3: Medieval Libraries of Great Britain</title>
+                            </ref>
+                         </bibl>
+                         <bibl>
+                            <ref target="https://www.le.ac.uk/english/em1060to1220/mss/EM.Ox.Laud.Misc.636.htm">
+                               <title>The Production and Use of English Manuscripts 1060 to 1220</title>
+                            </ref>
+                         </bibl>
+                     </listBibl>
+                  </listBibl>
+               </additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>       


### PR DESCRIPTION
This patch removes duplicate entries for links to the JONAS database in Laud Misc. 636. It also has a bit of formatting cleanup.