### PR TITLE
Fixed: MLGB3 links for Bodl 272-3, 289

### DIFF
--- a/collections/Bodl/MSS_Bodl_272-3_289.xml
+++ b/collections/Bodl/MSS_Bodl_272-3_289.xml
@@ -98,15 +98,44 @@
                <additional><adminInfo>
                      <recordHist>
                         <source>Summary description by Elizabeth Solopova and Matthew Holford, based on the Summary Catalogue and supplementary sources. 
-                            
-                            
                             <listBibl>
                               <bibl type="SC" facs="aap0146.gif">Summary Catalogue, vol. 2, part 1, p. 125</bibl>
                               <bibl type="SC" facs="aap0544.gif">Summary Catalogue, vol. 2, part 1, p. 523</bibl>
                            </listBibl>
                         </source>
                      </recordHist>
-                  </adminInfo><listBibl type="WRAPPER"><listBibl type="INTERNET"><head>Online resources:</head><bibl><ref target="http://mlgb3.bodleian.ox.ac.uk/mlgb/book/77&#xA;            http://mlgb3.bodleian.ox.ac.uk/mlgb/book/2752"><title>MLGB3: Medieval Libraries of Great Britain</title></ref></bibl><bibl><ref target="http://mlgb3.bodleian.ox.ac.uk/mlgb/book/78"><title>MLGB3: Medieval Libraries of Great Britain</title></ref></bibl><bibl><ref target="http://mlgb3.bodleian.ox.ac.uk/mlgb/book/2753"><title>MLGB3: Medieval Libraries of Great Britain</title></ref></bibl><bibl><ref target="http://mlgb3.bodleian.ox.ac.uk/mlgb/book/83"><title>MLGB3: Medieval Libraries of Great Britain</title></ref></bibl><bibl><ref target="http://mlgb3.bodleian.ox.ac.uk/mlgb/book/2754"><title>MLGB3: Medieval Libraries of Great Britain</title></ref></bibl></listBibl></listBibl></additional>
+                  </adminInfo>
+                     <listBibl type="WRAPPER">
+                          <listBibl type="INTERNET">
+                             <head>Online resources:</head>
+                             <bibl>
+                                <ref target="http://mlgb3.bodleian.ox.ac.uk/mlgb/book/2752">
+                                    <title>MLGB3: Medieval Libraries of Great Britain</title>
+                                </ref>
+                             </bibl>
+                             <bibl>
+                                <ref target="http://mlgb3.bodleian.ox.ac.uk/mlgb/book/78">
+                                   <title>MLGB3: Medieval Libraries of Great Britain</title>
+                                </ref>
+                             </bibl>
+                             <bibl>
+                                <ref target="http://mlgb3.bodleian.ox.ac.uk/mlgb/book/2753">
+                                   <title>MLGB3: Medieval Libraries of Great Britain</title>
+                                </ref>
+                             </bibl>
+                             <bibl>
+                                <ref target="http://mlgb3.bodleian.ox.ac.uk/mlgb/book/83">
+                                   <title>MLGB3: Medieval Libraries of Great Britain</title>
+                                </ref>
+                             </bibl>
+                             <bibl>
+                                <ref target="http://mlgb3.bodleian.ox.ac.uk/mlgb/book/2754">
+                                   <title>MLGB3: Medieval Libraries of Great Britain</title>
+                                </ref>
+                             </bibl>
+                        </listBibl>
+                  </listBibl>
+               </additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>       


### PR DESCRIPTION
The links were not formatted correctly for display, so it broke the links to MLGB3. Additionally the link to book 77 on MLGB3 was a 404 Not Found, so it was removed.