### PR TITLE
Update Links to Digital Bodleian

### DIFF
--- a/collections/Canon_Ital/MS_Canon_Ital_108.xml
+++ b/collections/Canon_Ital/MS_Canon_Ital_108.xml
@@ -99,7 +99,7 @@
                   </adminInfo> 
                   <surrogates>
                         <bibl type="digital-fascimile" subtype="full">
-                           <ref target="https://iiif.bodleian.ox.ac.uk/iiif/viewer/b22739d8-d9c1-40f7-915a-8c1ce22f5a43">
+                           <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/b22739d8-d9c1-40f7-915a-8c1ce22f5a43">
                               <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
                         </bibl>
                      </surrogates>

--- a/collections/Holkham_misc/MS_Holkham_misc_48.xml
+++ b/collections/Holkham_misc/MS_Holkham_misc_48.xml
@@ -184,7 +184,7 @@
                   </adminInfo>
                   <surrogates>
                      <bibl type="digital-fascimile" subtype="full">
-                        <ref target="https://iiif.bodleian.ox.ac.uk/iiif/viewer/10974934-30a5-4495-857e-255760e5c5ff">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/10974934-30a5-4495-857e-255760e5c5ff">
                            <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
                      </bibl>
                   </surrogates>


### PR DESCRIPTION
After talking it over with Emma, it's best if we keep links to digitized copies as Digital Bodleian links. These are the canonical 'permanent' links, and the ones we are committing to preserving into the future, so using those links ensures we don't have to retroactively change them for any new deployments. 