### PR TITLE
Fixed: Updated digital surrogate formatting

### DIFF
--- a/collections/Ashmole/MS_Ashmole_304.xml
+++ b/collections/Ashmole/MS_Ashmole_304.xml
@@ -291,11 +291,17 @@
                   <surrogates>
                      <bibl type="digital-facsimile" subtype="full">
                         <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/b6391fb2-a52e-4c69-bc13-02c04a9256a7">
-                           <title>Digital Bodleian</title><note>(full digital facsimile)</note>
+                           <title>Digital Bodleian</title>
                         </ref>
+                        <note>(full digital facsimile)</note>
                      </bibl>
-                  <bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/5885f370-ffea-4c09-9d01-a0d4399e82af"><title>Digital Bodleian</title></ref> <note>(49 images from 35mm slides)</note></bibl></surrogates>
-                  
+                     <bibl type="digital-facsimile" subtype="partial">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/5885f370-ffea-4c09-9d01-a0d4399e82af">
+                           <title>Digital Bodleian</title>
+                        </ref>
+                        <note>(49 images from 35mm slides)</note>
+                     </bibl>
+                  </surrogates>
                   <listBibl type="WRAPPER">
                      <listBibl>
                         <bibl>Allegra Iafrate (ed.) <title>Matthieu Paris, Le moine et le hazard: Bodleian Library, MS Ashmole 304</title>, Textes littéraires du moyen âge 39, Série Divinatoria 5 (Paris, 2015) [colour facsimile with introduction]</bibl>


### PR DESCRIPTION
For MS Ashmole 304:

 - Fixed a missing space for the full digital facsimile
 - Moved the `note` outside of the link to be consistent with the partial link format.
 - Reformatted to consistent indentation for the digital surrogate section.