### PR TITLE
Launch Polonsky facsimile links

### DIFF
--- a/collections/Don/MS_Don_e_248.xml
+++ b/collections/Don/MS_Don_e_248.xml
@@ -269,6 +269,12 @@
                         <source>Description by Les Enluminures, 2015, supplemented by information from <bibl>H. Lähnemann, ‘The materiality of medieval manuscripts’, <title>Oxford German Studies</title>  45/2 (2016), 121-141</bibl>.</source>
                      </recordHist><availability status="restricted"><p>To ensure its availability to future readers, access to this item is restricted, and readers are asked to work from reproductions and published descriptions as far as possible. To apply to see the original, please send a message to <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>, outlining the subject of your research, the importance of this item to that research, and the resources you have already consulted.</p></availability>
                   </adminInfo>
+                  <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/b9cb9cfe-6eb4-47ac-aad1-c905379f6af7">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                     </bibl>
+                  </surrogates>
                </additional>
             </msDesc>
          </sourceDesc>

--- a/collections/Lat_liturg/MS_Lat_liturg_e_18.xml
+++ b/collections/Lat_liturg/MS_Lat_liturg_e_18.xml
@@ -165,7 +165,14 @@
                      <recordHist>
                         <source>Typescript description by Bodleian library staff, revised by Peter Kidd, late 1990s.</source>
                      </recordHist>
-                  </adminInfo><listBibl type="WRAPPER">
+                  </adminInfo>
+                  <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/80e3671d-b083-483e-be4d-52f79d0084e7">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                     </bibl>
+                  </surrogates>
+                  <listBibl type="WRAPPER">
                      <listBibl>
                         <bibl>Ulrike Hascher-Burger and Henrike Lähnemann, <title>Liturgie und Reform im Kloster Medingen: Edition und Untersuchung des Propst-Handbuchs Oxford, Bodleian Library, MS. Lat. liturg. e. 18</title> (2013) [study and edition]</bibl>
                      </listBibl>

--- a/collections/Laud_Misc/MS_Laud_Misc_126.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_126.xml
@@ -141,6 +141,10 @@
                      </recordHist><availability status="restricted"><p>To ensure its availability to future readers, access to this item is restricted, and readers are asked to work from reproductions and published descriptions as far as possible. To apply to see the original, please send a message to <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>, outlining the subject of your research, the importance of this item to that research, and the resources you have already consulted.</p></availability>
                   </adminInfo>
                   <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/9fed4442-f4b6-439d-b359-41df38d9c9d4">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                     </bibl>
                      <bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/02a0e323-5b3c-42c1-bc2f-47e9f6c2c77d"><title>Digital Bodleian</title></ref> <note>(22 images from 35mm slides)</note></bibl></surrogates><listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>

--- a/collections/Laud_Misc/MS_Laud_Misc_144.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_144.xml
@@ -136,7 +136,7 @@
                      </recordHist>
                   </adminInfo>
                <surrogates>
-                  <bibl type="digital-facsimile" subtype="partial">
+                  <bibl type="digital-facsimile" subtype="full">
                      <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/47b80ca0-69ed-441f-8bc4-040a0025462a">
                         <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
                   </bibl>

--- a/collections/Laud_Misc/MS_Laud_Misc_144.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_144.xml
@@ -136,6 +136,10 @@
                      </recordHist>
                   </adminInfo>
                <surrogates>
+                  <bibl type="digital-facsimile" subtype="partial">
+                     <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/47b80ca0-69ed-441f-8bc4-040a0025462a">
+                        <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                  </bibl>
                   <bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/0459b3c8-eac0-40c3-9603-3f33411a9073"><title>Digital Bodleian</title></ref> <note>(1 image from 35mm slides)</note></bibl></surrogates>
                <listBibl type="WRAPPER">
                   <listBibl>

--- a/collections/Laud_Misc/MS_Laud_Misc_153.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_153.xml
@@ -385,6 +385,12 @@
                         </source>
                      </recordHist>
                   </adminInfo>
+                  <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target = "https://digital.bodleian.ox.ac.uk/inquire/p/d9c479bb-3bd5-4182-b4b2-9a36535584e7">
+                           <title>Digital Bodleian</title></ref> <note>(full digital fascsimile)</note>
+                     </bibl>
+                  </surrogates>
                   <listBibl type="WRAPPER">
                      <listBibl type="PRINT">
                         <head>Published descriptions:</head>

--- a/collections/Laud_Misc/MS_Laud_Misc_153.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_153.xml
@@ -387,7 +387,7 @@
                   </adminInfo>
                   <surrogates>
                      <bibl type="digital-facsimile" subtype="full">
-                        <ref target = "https://digital.bodleian.ox.ac.uk/inquire/p/d9c479bb-3bd5-4182-b4b2-9a36535584e7">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/bae4974c-3e05-4dc9-8aed-d263b3572b34">
                            <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
                      </bibl>
                   </surrogates>

--- a/collections/Laud_Misc/MS_Laud_Misc_153.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_153.xml
@@ -388,7 +388,7 @@
                   <surrogates>
                      <bibl type="digital-facsimile" subtype="full">
                         <ref target = "https://digital.bodleian.ox.ac.uk/inquire/p/d9c479bb-3bd5-4182-b4b2-9a36535584e7">
-                           <title>Digital Bodleian</title></ref> <note>(full digital fascsimile)</note>
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
                      </bibl>
                   </surrogates>
                   <listBibl type="WRAPPER">

--- a/collections/Laud_Misc/MS_Laud_Misc_155b.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_155b.xml
@@ -764,6 +764,12 @@
                         </source>
                      </recordHist>
                   </adminInfo>
+                  <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/2b095de6-5f2d-48d9-860d-0e9c165a2209">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                     </bibl>
+                  </surrogates>
                   <listBibl type="WRAPPER"><listBibl type="PRINTED">
                      <bibl>Otto Pächt and J. J. G. Alexander, <title>Illuminated Manuscripts in the Bodleian Library Oxford</title>, I (1966), no. 89</bibl>
                   </listBibl></listBibl>

--- a/collections/Laud_Misc/MS_Laud_Misc_163.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_163.xml
@@ -276,6 +276,12 @@
                         </source>
                      </recordHist>
                   </adminInfo>
+                  <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/52a2062d-f398-491c-bae0-a93a1bbf53d0">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                     </bibl>
+                  </surrogates>
                </additional>
             </msDesc>
          </sourceDesc>

--- a/collections/Laud_Misc/MS_Laud_Misc_237.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_237.xml
@@ -100,7 +100,12 @@
                         </source>
                      </recordHist>
                   </adminInfo>
-                  <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/b38d1099-bdd4-4a82-bde6-771c8930d3bb"><title>Digital Bodleian</title></ref> <note>(12 images from 35mm slides)</note></bibl></surrogates>
+                  <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/71eabf20-160e-410e-97b5-8c6e47c0d503">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                     </bibl>
+                     <bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/b38d1099-bdd4-4a82-bde6-771c8930d3bb"><title>Digital Bodleian</title></ref> <note>(12 images from 35mm slides)</note></bibl></surrogates>
                   <listBibl type="WRAPPER">
                      <listBibl type="PRINT">
                         <head>Printed descriptions:</head>

--- a/collections/Laud_Misc/MS_Laud_Misc_244.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_244.xml
@@ -117,7 +117,12 @@
                         </source>
                      </recordHist>
                   </adminInfo>
-               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/a1be1378-6914-4683-84ae-035e2dbefee1"><title>Digital Bodleian</title></ref> <note>(5 images from 35mm slides)</note></bibl></surrogates>
+               <surrogates>
+                  <bibl type="digital-facsimile" subtype="full">
+                     <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/0427d82e-d458-4b9a-b59e-a76060b5afa8">
+                        <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                  </bibl>
+                  <bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/a1be1378-6914-4683-84ae-035e2dbefee1"><title>Digital Bodleian</title></ref> <note>(5 images from 35mm slides)</note></bibl></surrogates>
                <listBibl type="WRAPPER">
                   <listBibl type="PRINT">
                      <head>Printed descriptions:</head>

--- a/collections/Laud_Misc/MS_Laud_Misc_246.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_246.xml
@@ -151,6 +151,12 @@
                         </source>
                      </recordHist>
                   </adminInfo>
+                  <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/e49af215-5de1-4d61-a31a-5af4a9f5ec50">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                     </bibl>
+                  </surrogates>
                </additional>
             </msDesc>
          </sourceDesc>

--- a/collections/Laud_Misc/MS_Laud_Misc_257.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_257.xml
@@ -132,7 +132,12 @@
                         </source>
                      </recordHist>
                   </adminInfo>
-               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/3a9f8f01-ee35-438a-80b7-12d67d308a03"><title>Digital Bodleian</title></ref> <note>(4 images from 35mm slides)</note></bibl></surrogates>
+               <surrogates>
+                  <bibl type="digital-facsimile" subtype="full">
+                     <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/f4dbf8ff-d26b-4825-bafe-a9962b29849c">
+                        <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                  </bibl>
+                  <bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/3a9f8f01-ee35-438a-80b7-12d67d308a03"><title>Digital Bodleian</title></ref> <note>(4 images from 35mm slides)</note></bibl></surrogates>
                   <listBibl type="WRAPPER">
                      <listBibl type="PRINT">
                         <head>Printed descriptions:</head>

--- a/collections/Laud_Misc/MS_Laud_Misc_276.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_276.xml
@@ -185,7 +185,13 @@
                            </listBibl>
                         </source>
                      </recordHist>
-                  </adminInfo><surrogates><bibl type="digital-fascimile" subtype="full"><ref target="http://bibliotheca-laureshamensis-digital.de/view/bodleian_mslaudmisc276"><title>Bibliotheca Laureshamensis – digital</title></ref> <note>(full facsimile)</note></bibl></surrogates>
+                  </adminInfo>
+                  <surrogates>
+                     <bibl type="digital-fascimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/7f11d6f9-38a5-4a5d-9f32-406d6d911ca9"><title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                        <ref target="http://bibliotheca-laureshamensis-digital.de/view/bodleian_mslaudmisc276"><title>Bibliotheca Laureshamensis – digital</title></ref> <note>(full facsimile)</note>                        
+                     </bibl>
+                  </surrogates>
                <listBibl type="WRAPPER">
                   <listBibl type="PRINT">
                      <head>Published descriptions:</head>

--- a/collections/Laud_Misc/MS_Laud_Misc_76.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_76.xml
@@ -114,7 +114,12 @@
                         </source>
                      </recordHist>
                   </adminInfo>
-               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/e96d05e0-8946-4159-98f7-3da888845611"><title>Digital Bodleian</title></ref> <note>(1 image from 35mm slides)</note></bibl></surrogates></additional>
+               <surrogates>
+                  <bibl type="digital-facsimile" subtype="full">
+                     <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/ca68be33-cfc2-4759-b32a-5c1fe34a5b3a">
+                        <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                  </bibl>
+                  <bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/e96d05e0-8946-4159-98f7-3da888845611"><title>Digital Bodleian</title></ref> <note>(1 image from 35mm slides)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>       

--- a/collections/Laud_Misc/MS_Laud_Misc_92.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_92.xml
@@ -161,6 +161,12 @@
                         </source>
                      </recordHist>
                   </adminInfo>
+                  <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/851538db-a0c6-4911-a7e0-d7b803aab115">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                     </bibl>
+                  </surrogates>
                   <listBibl type="WRAPPER"><listBibl>
                      <bibl>Otto Pächt and J. J. G. Alexander, <title>Illuminated Manuscripts in the Bodleian Library Oxford</title>, I (1966), no. 15</bibl>
                   </listBibl></listBibl>

--- a/collections/Laud_lat/MS_Laud_Lat_100.xml
+++ b/collections/Laud_lat/MS_Laud_Lat_100.xml
@@ -91,6 +91,12 @@
                         </source>
                      </recordHist>
                   </adminInfo>
+                  <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/021a648e-ef92-4c37-8227-367ec5b8f1bf">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                     </bibl>
+                  </surrogates>
                </additional>
                <msPart>
                   <msIdentifier>

--- a/collections/Laud_lat/MS_Laud_Lat_101.xml
+++ b/collections/Laud_lat/MS_Laud_Lat_101.xml
@@ -183,6 +183,12 @@
                         </source>
                      </recordHist>
                   </adminInfo>
+                  <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/7afa32db-d4bb-4ca0-83db-fada4f5e57da">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                     </bibl>
+                  </surrogates>
                </additional>
             </msDesc>
          </sourceDesc>

--- a/collections/Laud_lat/MS_Laud_Lat_27.xml
+++ b/collections/Laud_lat/MS_Laud_Lat_27.xml
@@ -143,7 +143,7 @@
                   </adminInfo>
                   <surrogates>
                      <bibl type="digital-facsimile" subtype="full">
-                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/7fed02b5-098c-4201-bd26-626ade194717"><title>Digital Bodleian</title></ref> <note>(full digital fascsimile)</note>
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/7fed02b5-098c-4201-bd26-626ade194717"><title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
                      </bibl>
                      <bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/92b41c04-1ac3-4594-84f8-bfdce7a9cc4f"><title>Digital Bodleian</title></ref> <note>(6 images from 35mm slides)</note></bibl></surrogates>
                </additional>

--- a/collections/Laud_lat/MS_Laud_Lat_27.xml
+++ b/collections/Laud_lat/MS_Laud_Lat_27.xml
@@ -141,7 +141,11 @@
                         </source>
                      </recordHist>
                   </adminInfo>
-                  <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/92b41c04-1ac3-4594-84f8-bfdce7a9cc4f"><title>Digital Bodleian</title></ref> <note>(6 images from 35mm slides)</note></bibl></surrogates>
+                  <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/7fed02b5-098c-4201-bd26-626ade194717"><title>Digital Bodleian</title></ref> <note>(full digital fascsimile)</note>
+                     </bibl>
+                     <bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/92b41c04-1ac3-4594-84f8-bfdce7a9cc4f"><title>Digital Bodleian</title></ref> <note>(6 images from 35mm slides)</note></bibl></surrogates>
                </additional>
             </msDesc>
          </sourceDesc>

--- a/collections/Laud_lat/MS_Laud_Lat_32.xml
+++ b/collections/Laud_lat/MS_Laud_Lat_32.xml
@@ -114,7 +114,7 @@
                      </recordHist>
                   </adminInfo>
                <surrogates>
-                  <bibl type="digital-facsimile" subtype="partial">
+                  <bibl type="digital-facsimile" subtype="full">
                      <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/2a5f3139-f034-455d-95f3-fa0ebc2d6a7e">
                         <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
                   </bibl>

--- a/collections/Laud_lat/MS_Laud_Lat_32.xml
+++ b/collections/Laud_lat/MS_Laud_Lat_32.xml
@@ -113,7 +113,12 @@
                         </source>
                      </recordHist>
                   </adminInfo>
-               <surrogates><bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/1ce31cde-6126-4743-839c-144b9dba57af"><title>Digital Bodleian</title></ref> <note>(1 image from 35mm slides)</note></bibl></surrogates></additional>
+               <surrogates>
+                  <bibl type="digital-facsimile" subtype="partial">
+                     <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/2a5f3139-f034-455d-95f3-fa0ebc2d6a7e">
+                        <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                  </bibl>
+                  <bibl type="digital-facsimile" subtype="partial"><ref target="https://digital.bodleian.ox.ac.uk/inquire/p/1ce31cde-6126-4743-839c-144b9dba57af"><title>Digital Bodleian</title></ref> <note>(1 image from 35mm slides)</note></bibl></surrogates></additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>       

--- a/collections/Laud_lat/MS_Laud_Lat_68.xml
+++ b/collections/Laud_lat/MS_Laud_Lat_68.xml
@@ -165,6 +165,12 @@
                         </source>
                      </recordHist>
                   </adminInfo>
+                  <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/16b3b5e4-7aab-468a-be41-0a7515640938">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                     </bibl>
+                  </surrogates>
                </additional>
             </msDesc>
          </sourceDesc>

--- a/collections/Laud_lat/MS_Laud_Lat_98.xml
+++ b/collections/Laud_lat/MS_Laud_Lat_98.xml
@@ -150,6 +150,12 @@
                         </source>
                      </recordHist>
                   </adminInfo>
+                  <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/ea8bd773-7b2f-449b-bfad-8986da841acb">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>
+                     </bibl>
+                  </surrogates>
                </additional>
              
             </msDesc>


### PR DESCRIPTION
Adds links to the full Digital Bodleian facsimiles for the remaining Polonsky project "launch" items.