### PR TITLE
Fixed: Systematic typo in MS Tanner collection

### DIFF
--- a/collections/Tanner/MS_Tanner_1.xml
+++ b/collections/Tanner/MS_Tanner_1.xml
@@ -81,7 +81,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_10-star_R.xml
+++ b/collections/Tanner/MS_Tanner_10-star_R.xml
@@ -87,7 +87,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_10.xml
+++ b/collections/Tanner/MS_Tanner_10.xml
@@ -73,7 +73,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional><adminInfo>
                      <recordHist>
                         <source>Summary description by Elizabeth Solopova and Matthew Holford, based on the Quarto Catalogue (A. Hackman, <title>Catalogi codicum manuscriptorum Bibliothecæ Bodleianæ pars quarta codices viri admodum reverendi Thomæ Tanneri, S.T.P., episcopi Asaphensis, complectens</title>, Quarto Catalogues IV, repr. 1966, with corrections, from the ed. of 1860) and supplementary sources. 

--- a/collections/Tanner/MS_Tanner_11.xml
+++ b/collections/Tanner/MS_Tanner_11.xml
@@ -69,7 +69,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional><adminInfo>
                      <recordHist>
                         <source>Summary description by Elizabeth Solopova and Matthew Holford, based on the Quarto Catalogue (A. Hackman, <title>Catalogi codicum manuscriptorum Bibliothecæ Bodleianæ pars quarta codices viri admodum reverendi Thomæ Tanneri, S.T.P., episcopi Asaphensis, complectens</title>, Quarto Catalogues IV, repr. 1966, with corrections, from the ed. of 1860) and supplementary sources. 

--- a/collections/Tanner/MS_Tanner_110.xml
+++ b/collections/Tanner/MS_Tanner_110.xml
@@ -83,7 +83,7 @@
                   <origin>
                      <origDate calendar="Gregorian" notAfter="1500" notBefore="1100">12th century, 13th century, 14th century, 15th century </origDate>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional><adminInfo>
                      <recordHist>
                         <source>Summary description by Elizabeth Solopova and Matthew Holford, based on the Quarto Catalogue (A. Hackman, <title>Catalogi codicum manuscriptorum Bibliothecæ Bodleianæ pars quarta codices viri admodum reverendi Thomæ Tanneri, S.T.P., episcopi Asaphensis, complectens</title>, Quarto Catalogues IV, repr. 1966, with corrections, from the ed. of 1860) and supplementary sources. 

--- a/collections/Tanner/MS_Tanner_116.xml
+++ b/collections/Tanner/MS_Tanner_116.xml
@@ -102,7 +102,7 @@
                   <origin>
                      <origDate calendar="Gregorian" notAfter="1300" notBefore="1290">13th century, end</origDate>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_13.xml
+++ b/collections/Tanner/MS_Tanner_13.xml
@@ -72,7 +72,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_15.xml
+++ b/collections/Tanner/MS_Tanner_15.xml
@@ -75,7 +75,7 @@
                         <country key="place_1000070">French</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional><adminInfo>
                      <recordHist>
                         <source>Summary description by Elizabeth Solopova and Matthew Holford, based on the Quarto Catalogue (A. Hackman, <title>Catalogi codicum manuscriptorum Bibliothecæ Bodleianæ pars quarta codices viri admodum reverendi Thomæ Tanneri, S.T.P., episcopi Asaphensis, complectens</title>, Quarto Catalogues IV, repr. 1966, with corrections, from the ed. of 1860) and supplementary sources. 

--- a/collections/Tanner/MS_Tanner_16.xml
+++ b/collections/Tanner/MS_Tanner_16.xml
@@ -81,7 +81,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_165.xml
+++ b/collections/Tanner/MS_Tanner_165.xml
@@ -77,7 +77,7 @@
                         <!--ORIGINAL: English, Canterbury Christ Church-->
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional><adminInfo>
                      <recordHist>
                         <source>Summary description by Elizabeth Solopova and Matthew Holford, based on the Quarto Catalogue (A. Hackman, <title>Catalogi codicum manuscriptorum Bibliothecæ Bodleianæ pars quarta codices viri admodum reverendi Thomæ Tanneri, S.T.P., episcopi Asaphensis, complectens</title>, Quarto Catalogues IV, repr. 1966, with corrections, from the ed. of 1860) and supplementary sources. 

--- a/collections/Tanner/MS_Tanner_166.xml
+++ b/collections/Tanner/MS_Tanner_166.xml
@@ -73,7 +73,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional><adminInfo>
                      <recordHist>
                         <source>Summary description by Elizabeth Solopova and Matthew Holford, based on the Quarto Catalogue (A. Hackman, <title>Catalogi codicum manuscriptorum Bibliothecæ Bodleianæ pars quarta codices viri admodum reverendi Thomæ Tanneri, S.T.P., episcopi Asaphensis, complectens</title>, Quarto Catalogues IV, repr. 1966, with corrections, from the ed. of 1860) and supplementary sources. 

--- a/collections/Tanner/MS_Tanner_169-star.xml
+++ b/collections/Tanner/MS_Tanner_169-star.xml
@@ -54,7 +54,7 @@
                   <p n="composite">Composite: pp. 3-174 || pp. 1-2, 177-178 || pp.
 				175-176</p>
                </physDesc>
-               <history><provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history><additional><adminInfo>
+               <history><provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history><additional><adminInfo>
                      <recordHist>
                         <source>Summary description based on Elizabeth Solopova, <title>Latin Liturgical Psalters in the Bodleian Library: A Select Catalogue</title> (Oxford, 2013), pp. 57-63. Previously described in the Quarto Catalogue (A. Hackman, <title>Catalogi codicum manuscriptorum Bibliothecæ Bodleianæ pars quarta codices viri admodum reverendi Thomæ Tanneri, S.T.P., episcopi Asaphensis, complectens</title>, Quarto Catalogues IV, repr. 1966, with corrections, from the ed. of 1860) and supplementary sources. 
                             

--- a/collections/Tanner/MS_Tanner_17.xml
+++ b/collections/Tanner/MS_Tanner_17.xml
@@ -77,7 +77,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_170.xml
+++ b/collections/Tanner/MS_Tanner_170.xml
@@ -78,7 +78,7 @@
                   <origin>
                      <origDate calendar="Gregorian" notAfter="1400" notBefore="1390">14th century, end</origDate>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional><adminInfo>
                      <recordHist>
                         <source>Summary description by Elizabeth Solopova and Matthew Holford, based on the Quarto Catalogue (A. Hackman, <title>Catalogi codicum manuscriptorum Bibliothecæ Bodleianæ pars quarta codices viri admodum reverendi Thomæ Tanneri, S.T.P., episcopi Asaphensis, complectens</title>, Quarto Catalogues IV, repr. 1966, with corrections, from the ed. of 1860) and supplementary sources. 

--- a/collections/Tanner/MS_Tanner_18.xml
+++ b/collections/Tanner/MS_Tanner_18.xml
@@ -71,7 +71,7 @@
                      <origPlace>
                         <country key="place_7002445">English</country>, <settlement key="place_7012044">Canterbury</settlement>, <orgName key="org_158353196">Christ Church</orgName>.<!--ORIGINAL: English, Canterbury Christ Church.--></origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_184.xml
+++ b/collections/Tanner/MS_Tanner_184.xml
@@ -84,7 +84,7 @@
                      <origPlace cert="low">
                         <country key="place_7002445">English</country>, <settlement key="place_7018905">Westminster</settlement> (?)<!--ORIGINAL: English, Westminster (?)--></origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_187.xml
+++ b/collections/Tanner/MS_Tanner_187.xml
@@ -80,7 +80,7 @@
                      <origPlace cert="low">
                         <country key="place_1000070">French</country> (?)</origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_188.xml
+++ b/collections/Tanner/MS_Tanner_188.xml
@@ -73,7 +73,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_189.xml
+++ b/collections/Tanner/MS_Tanner_189.xml
@@ -78,7 +78,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_19.xml
+++ b/collections/Tanner/MS_Tanner_19.xml
@@ -79,7 +79,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_190.xml
+++ b/collections/Tanner/MS_Tanner_190.xml
@@ -82,7 +82,7 @@
                         <!--ORIGINAL: Italian, Venice-->
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_192.xml
+++ b/collections/Tanner/MS_Tanner_192.xml
@@ -84,7 +84,7 @@
                         <country key="place_1000070">French</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_194.xml
+++ b/collections/Tanner/MS_Tanner_194.xml
@@ -69,7 +69,7 @@
                   <origin>
                      <origDate calendar="Gregorian" notAfter="1600" notBefore="1500">16th century</origDate>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_195.xml
+++ b/collections/Tanner/MS_Tanner_195.xml
@@ -90,7 +90,7 @@
                   <origin>
                      <origDate calendar="Gregorian" notAfter="1310" notBefore="1300">14th century, beginning</origDate>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional><adminInfo>
                      <recordHist>
                         <source>Summary description by Elizabeth Solopova and Matthew Holford, based on the Quarto Catalogue (A. Hackman, <title>Catalogi codicum manuscriptorum Bibliothecæ Bodleianæ pars quarta codices viri admodum reverendi Thomæ Tanneri, S.T.P., episcopi Asaphensis, complectens</title>, Quarto Catalogues IV, repr. 1966, with corrections, from the ed. of 1860) and supplementary sources. 

--- a/collections/Tanner/MS_Tanner_196.xml
+++ b/collections/Tanner/MS_Tanner_196.xml
@@ -79,7 +79,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional><adminInfo>
                      <recordHist>
                         <source>Summary description by Elizabeth Solopova and Matthew Holford, based on the Quarto Catalogue (A. Hackman, <title>Catalogi codicum manuscriptorum Bibliothecæ Bodleianæ pars quarta codices viri admodum reverendi Thomæ Tanneri, S.T.P., episcopi Asaphensis, complectens</title>, Quarto Catalogues IV, repr. 1966, with corrections, from the ed. of 1860) and supplementary sources. 

--- a/collections/Tanner/MS_Tanner_197.xml
+++ b/collections/Tanner/MS_Tanner_197.xml
@@ -72,7 +72,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_198.xml
+++ b/collections/Tanner/MS_Tanner_198.xml
@@ -87,7 +87,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_2.xml
+++ b/collections/Tanner/MS_Tanner_2.xml
@@ -69,7 +69,7 @@
                   <origin>
                      <origDate calendar="Gregorian" notAfter="1510" notBefore="1500">16th century, beginning</origDate>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_201.xml
+++ b/collections/Tanner/MS_Tanner_201.xml
@@ -83,7 +83,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_210.xml
+++ b/collections/Tanner/MS_Tanner_210.xml
@@ -74,7 +74,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_221.xml
+++ b/collections/Tanner/MS_Tanner_221.xml
@@ -73,7 +73,7 @@
                         <!--ORIGINAL: English, London-->
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_223.xml
+++ b/collections/Tanner/MS_Tanner_223.xml
@@ -71,7 +71,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_224.xml
+++ b/collections/Tanner/MS_Tanner_224.xml
@@ -71,7 +71,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_242.xml
+++ b/collections/Tanner/MS_Tanner_242.xml
@@ -73,7 +73,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_256.xml
+++ b/collections/Tanner/MS_Tanner_256.xml
@@ -72,7 +72,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_263.xml
+++ b/collections/Tanner/MS_Tanner_263.xml
@@ -71,7 +71,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_3.xml
+++ b/collections/Tanner/MS_Tanner_3.xml
@@ -85,7 +85,7 @@
                      <origPlace cert="low">
                         <country key="place_7002445">English</country>, <region>West</region> (?)<!--ORIGINAL: English, West (?)--></origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional><adminInfo>
                      <recordHist>
                         <source>Summary description by Elizabeth Solopova and Matthew Holford, based on the Quarto Catalogue (A. Hackman, <title>Catalogi codicum manuscriptorum Bibliothecæ Bodleianæ pars quarta codices viri admodum reverendi Thomæ Tanneri, S.T.P., episcopi Asaphensis, complectens</title>, Quarto Catalogues IV, repr. 1966, with corrections, from the ed. of 1860) and supplementary sources. 

--- a/collections/Tanner/MS_Tanner_335.xml
+++ b/collections/Tanner/MS_Tanner_335.xml
@@ -79,7 +79,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_336.xml
+++ b/collections/Tanner/MS_Tanner_336.xml
@@ -72,7 +72,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_337.xml
+++ b/collections/Tanner/MS_Tanner_337.xml
@@ -80,7 +80,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_346.xml
+++ b/collections/Tanner/MS_Tanner_346.xml
@@ -106,7 +106,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional><adminInfo>
                      <recordHist>
                         <source>Summary description by Elizabeth Solopova and Matthew Holford, based on the Quarto Catalogue (A. Hackman, <title>Catalogi codicum manuscriptorum Bibliothecæ Bodleianæ pars quarta codices viri admodum reverendi Thomæ Tanneri, S.T.P., episcopi Asaphensis, complectens</title>, Quarto Catalogues IV, repr. 1966, with corrections, from the ed. of 1860) and supplementary sources. 

--- a/collections/Tanner/MS_Tanner_347.xml
+++ b/collections/Tanner/MS_Tanner_347.xml
@@ -76,7 +76,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_348.xml
+++ b/collections/Tanner/MS_Tanner_348.xml
@@ -80,7 +80,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_388.xml
+++ b/collections/Tanner/MS_Tanner_388.xml
@@ -78,7 +78,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_398.xml
+++ b/collections/Tanner/MS_Tanner_398.xml
@@ -73,7 +73,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional><adminInfo>
                      <recordHist>
                         <source>Summary description by Elizabeth Solopova and Matthew Holford, based on the Quarto Catalogue (A. Hackman, <title>Catalogi codicum manuscriptorum Bibliothecæ Bodleianæ pars quarta codices viri admodum reverendi Thomæ Tanneri, S.T.P., episcopi Asaphensis, complectens</title>, Quarto Catalogues IV, repr. 1966, with corrections, from the ed. of 1860) and supplementary sources. 

--- a/collections/Tanner/MS_Tanner_4.xml
+++ b/collections/Tanner/MS_Tanner_4.xml
@@ -83,7 +83,7 @@
                   <origin>
                      <origDate calendar="Gregorian" notBefore="1290" notAfter="1400">13th century, end, and 14th century</origDate>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional><adminInfo>
                      <recordHist>
                         <source>Summary description by Elizabeth Solopova and Matthew Holford, based on the Quarto Catalogue (A. Hackman, <title>Catalogi codicum manuscriptorum Bibliothecæ Bodleianæ pars quarta codices viri admodum reverendi Thomæ Tanneri, S.T.P., episcopi Asaphensis, complectens</title>, Quarto Catalogues IV, repr. 1966, with corrections, from the ed. of 1860) and supplementary sources. 

--- a/collections/Tanner/MS_Tanner_400.xml
+++ b/collections/Tanner/MS_Tanner_400.xml
@@ -83,7 +83,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_405.xml
+++ b/collections/Tanner/MS_Tanner_405.xml
@@ -76,7 +76,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_407.xml
+++ b/collections/Tanner/MS_Tanner_407.xml
@@ -76,7 +76,7 @@
                         <!--ORIGINAL: English, Norfolk-->
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_408.xml
+++ b/collections/Tanner/MS_Tanner_408.xml
@@ -80,7 +80,7 @@
                   <origin>
                      <origDate calendar="Gregorian" notAfter="1400" notBefore="1390">14th century, end</origDate>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_419.xml
+++ b/collections/Tanner/MS_Tanner_419.xml
@@ -80,7 +80,7 @@
                         <country key="place_1000070">French</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional><adminInfo>
                      <recordHist>
                         <source>Summary description by Elizabeth Solopova and Matthew Holford, based on the Quarto Catalogue (A. Hackman, <title>Catalogi codicum manuscriptorum Bibliothecæ Bodleianæ pars quarta codices viri admodum reverendi Thomæ Tanneri, S.T.P., episcopi Asaphensis, complectens</title>, Quarto Catalogues IV, repr. 1966, with corrections, from the ed. of 1860) and supplementary sources. 

--- a/collections/Tanner/MS_Tanner_425.xml
+++ b/collections/Tanner/MS_Tanner_425.xml
@@ -73,7 +73,7 @@
                         <!--ORIGINAL: English, Norfolk-->
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_439.xml
+++ b/collections/Tanner/MS_Tanner_439.xml
@@ -74,7 +74,7 @@
                   <origin>
                      <origDate calendar="Gregorian" notAfter="1400" notBefore="1300">14th century</origDate>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_440.xml
+++ b/collections/Tanner/MS_Tanner_440.xml
@@ -77,7 +77,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_450.xml
+++ b/collections/Tanner/MS_Tanner_450.xml
@@ -81,7 +81,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_5.xml
+++ b/collections/Tanner/MS_Tanner_5.xml
@@ -71,7 +71,7 @@
                         <country key="place_7002445">English</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_6.xml
+++ b/collections/Tanner/MS_Tanner_6.xml
@@ -90,7 +90,7 @@
                   <origin>
                      <origDate calendar="Gregorian" notAfter="1200" notBefore="1190">12th century, end</origDate>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_8.xml
+++ b/collections/Tanner/MS_Tanner_8.xml
@@ -54,7 +54,7 @@
                <physDesc>
                   <p n="composite">Composite: fols. 1-300 || fols. 301-723</p>
                </physDesc>
-               <history><provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history><additional>
+               <history><provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history><additional>
                   <adminInfo>
                      <recordHist>
                         <source>Summary description by Elizabeth Solopova and Matthew Holford, based on the Quarto Catalogue (A. Hackman, <title>Catalogi codicum manuscriptorum Bibliothecæ Bodleianæ pars quarta codices viri admodum reverendi Thomæ Tanneri, S.T.P., episcopi Asaphensis, complectens</title>, Quarto Catalogues IV, repr. 1966, with corrections, from the ed. of 1860) and supplementary sources. 

--- a/collections/Tanner/MS_Tanner_86.xml
+++ b/collections/Tanner/MS_Tanner_86.xml
@@ -68,7 +68,7 @@
                   <origin>
                      <origDate calendar="Gregorian" notAfter="1500" notBefore="1400">15th century</origDate>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>

--- a/collections/Tanner/MS_Tanner_9.xml
+++ b/collections/Tanner/MS_Tanner_9.xml
@@ -90,7 +90,7 @@
                         <country key="place_1000070">French</country>
                      </origPlace>
                   </origin>
-               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735..</acquisition></history>
+               <provenance notBefore="1674" notAfter="1735" resp="#MMM"><persName role="fmo" key="person_11058091">Thomas Tanner, 1674-1735</persName></provenance><acquisition when="1735" resp="#MMM">Bequeathed by him to the Bodleian in 1735.</acquisition></history>
                <additional>
                   <adminInfo>
                      <recordHist>


### PR DESCRIPTION
An extra full stop was present in the provenance information and was removed.