### PR TITLE
Polonsky links 6 aug 2019

### DIFF
--- a/collections/Laud_Misc/MS_Laud_Misc_101.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_101.xml
@@ -138,6 +138,18 @@
                         </source>
                      </recordHist>
                   </adminInfo>
+                  <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/afdadb3c-f5e7-48bf-bae2-a7066826fc8e">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>                     
+                     </bibl>
+                  </surrogates>
+                  <listBibl type="WRAPPER">
+                     <listBibl type="INTERNET">
+                        <head>Online resources:</head>
+                        <bibl><ref target="https://hab.bodleian.ox.ac.uk/en/"><title>Manuscripts from German-Speaking Lands – A Polonsky Foundation Digitization Project</title></ref></bibl>
+                     </listBibl>
+                  </listBibl>
                </additional>
             </msDesc>
          </sourceDesc>

--- a/collections/Laud_Misc/MS_Laud_Misc_106.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_106.xml
@@ -158,6 +158,18 @@
                         </source>
                      </recordHist>
                   </adminInfo>
+                  <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/bb7de790-2d3e-48c3-856f-c8524dca5a10">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>                     
+                     </bibl>
+                  </surrogates>
+                  <listBibl type="WRAPPER">
+                     <listBibl type="INTERNET">
+                        <head>Online resources:</head>
+                        <bibl><ref target="https://hab.bodleian.ox.ac.uk/en/"><title>Manuscripts from German-Speaking Lands – A Polonsky Foundation Digitization Project</title></ref></bibl>
+                     </listBibl>
+                  </listBibl>
                </additional>
             </msDesc>
          </sourceDesc>

--- a/collections/Laud_Misc/MS_Laud_Misc_121.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_121.xml
@@ -131,6 +131,18 @@
                         </source>
                      </recordHist>
                   </adminInfo>
+                  <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/cf8ebcc9-0611-48d1-b3a1-eb6c380c0a39">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>                     
+                     </bibl>
+                  </surrogates>
+                  <listBibl type="WRAPPER">
+                     <listBibl type="INTERNET">
+                        <head>Online resources:</head>
+                        <bibl><ref target="https://hab.bodleian.ox.ac.uk/en/"><title>Manuscripts from German-Speaking Lands – A Polonsky Foundation Digitization Project</title></ref></bibl>
+                     </listBibl>
+                  </listBibl>
                </additional>
             </msDesc>
          </sourceDesc>

--- a/collections/Laud_Misc/MS_Laud_Misc_122.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_122.xml
@@ -172,6 +172,18 @@
                         </source>
                      </recordHist>
                   </adminInfo>
+                  <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/ccae952b-7d47-46ba-a37f-e854b200a330">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>                     
+                     </bibl>
+                  </surrogates>
+                  <listBibl type="WRAPPER">
+                     <listBibl type="INTERNET">
+                        <head>Online resources:</head>
+                        <bibl><ref target="https://hab.bodleian.ox.ac.uk/en/"><title>Manuscripts from German-Speaking Lands – A Polonsky Foundation Digitization Project</title></ref></bibl>
+                     </listBibl>
+                  </listBibl>
                </additional>
             </msDesc>
          </sourceDesc>

--- a/collections/Laud_Misc/MS_Laud_Misc_124.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_124.xml
@@ -153,6 +153,18 @@
                         </source>
                      </recordHist>
                   </adminInfo>
+                  <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/e5cdc022-a42d-4e00-a0e9-cf2c9e567192">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>                     
+                     </bibl>
+                  </surrogates>
+                  <listBibl type="WRAPPER">
+                     <listBibl type="INTERNET">
+                        <head>Online resources:</head>
+                        <bibl><ref target="https://hab.bodleian.ox.ac.uk/en/"><title>Manuscripts from German-Speaking Lands – A Polonsky Foundation Digitization Project</title></ref></bibl>
+                     </listBibl>
+                  </listBibl>
                </additional>
             </msDesc>
          </sourceDesc>

--- a/collections/Laud_Misc/MS_Laud_Misc_134.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_134.xml
@@ -109,6 +109,18 @@
                         </source>
                      </recordHist>
                   </adminInfo>
+                  <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/0e661903-0943-4754-9509-af708323a128">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>                     
+                     </bibl>
+                  </surrogates>
+                  <listBibl type="WRAPPER">
+                     <listBibl type="INTERNET">
+                        <head>Online resources:</head>
+                        <bibl><ref target="https://hab.bodleian.ox.ac.uk/en/"><title>Manuscripts from German-Speaking Lands – A Polonsky Foundation Digitization Project</title></ref></bibl>
+                     </listBibl>
+                  </listBibl>                  
                </additional>
                
                <msPart>

--- a/collections/Laud_Misc/MS_Laud_Misc_135.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_135.xml
@@ -142,7 +142,22 @@
                            </listBibl>
                         </source>
                      </recordHist>
-                  </adminInfo><listBibl type="WRAPPER"><listBibl type="INTERNET"><head>Online resources:</head><bibl><ref target="https://glossen.germ-ling.uni-bamberg.de/manuscripts/12930"><title>BStK Online - Datenbank der althochdeutschen und altsächsischen Glossenhandschriften</title></ref></bibl><bibl><ref target="http://www.handschriftencensus.de/17911"><title>Handschriftencensus: Eine Bestandsaufnahme der handschriftlichen Überlieferung deutschsprachiger Texte des Mittelalters</title></ref></bibl></listBibl></listBibl></additional>
+                  </adminInfo>
+                  <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/06ddd2a1-f650-48bb-8efc-d77951e63ed0">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>                     
+                     </bibl>
+                  </surrogates>
+                  <listBibl type="WRAPPER">
+                     <listBibl type="INTERNET">
+                        <head>Online resources:</head>
+                        <bibl><ref target="https://hab.bodleian.ox.ac.uk/en/"><title>Manuscripts from German-Speaking Lands – A Polonsky Foundation Digitization Project</title></ref></bibl>
+                        <bibl><ref target="https://glossen.germ-ling.uni-bamberg.de/manuscripts/12930"><title>BStK Online - Datenbank der althochdeutschen und altsächsischen Glossenhandschriften</title></ref></bibl>
+                        <bibl><ref target="http://www.handschriftencensus.de/17911"><title>Handschriftencensus: Eine Bestandsaufnahme der handschriftlichen Überlieferung deutschsprachiger Texte des Mittelalters</title></ref></bibl>
+                     </listBibl>
+                  </listBibl>
+               </additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>       

--- a/collections/Laud_Misc/MS_Laud_Misc_157.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_157.xml
@@ -617,6 +617,18 @@
                         </source>
                      </recordHist>
                   </adminInfo>
+                  <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/b34abac1-053c-4ade-9b7a-12bc0c13ddf2">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>                     
+                     </bibl>
+                  </surrogates>
+                  <listBibl type="WRAPPER">
+                     <listBibl type="INTERNET">
+                        <head>Online resources:</head>
+                        <bibl><ref target="https://hab.bodleian.ox.ac.uk/en/"><title>Manuscripts from German-Speaking Lands – A Polonsky Foundation Digitization Project</title></ref></bibl>
+                     </listBibl>
+                  </listBibl>
                </additional>
             </msDesc>
          </sourceDesc>

--- a/collections/Laud_Misc/MS_Laud_Misc_421.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_421.xml
@@ -244,6 +244,18 @@
                         </source>
                      </recordHist>
                   </adminInfo>
+                  <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/15e4bce8-7ca9-4b30-aa96-40093b35a44c">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>                     
+                     </bibl>
+                  </surrogates>
+                  <listBibl type="WRAPPER">
+                     <listBibl type="INTERNET">
+                        <head>Online resources:</head>
+                        <bibl><ref target="https://hab.bodleian.ox.ac.uk/en/"><title>Manuscripts from German-Speaking Lands – A Polonsky Foundation Digitization Project</title></ref></bibl>
+                     </listBibl>
+                  </listBibl>
                </additional>
             </msDesc>
          </sourceDesc>


### PR DESCRIPTION
Adds digital facsimile and Polonsky German site links to items digitized in early August 2019.