### PR TITLE
VIAF Lookup on organizations in June 2020

### DIFF
--- a/places.xml
+++ b/places.xml
@@ -11,6 +11,9 @@
             <publicationStmt>
                 <p>Publication Information</p>
             </publicationStmt>
+            <notesStmt>
+                <note xml:id="VL1">Elements with source attributes of "#VL1" were retrieved from VIAF by lookup-viaf-info.xsl on 2020-06-30</note>
+            </notesStmt>
             <sourceDesc>
                 <p>Information about the source</p>
             </sourceDesc>
@@ -9252,24 +9255,39 @@
            
               
             </listPlace>
-            
-            
-            
+
+
             
             <listOrg type="VIAF">
-                
+
                 <head>
                     <note type="source">This record contains information from <ref target="http://viaf.org/">VIAF (Virtual International Authority File)</ref> which is made available under the <ref target="http://opendatacommons.org/licenses/by/1.0/">ODC Attribution License</ref>.</note>
                 </head>
-                
+
                 <!-- new -->
-                
+
                 <org xml:id="org_313181544">
                     <orgName type="display" source="bodl">London, <affiliation>Carthusian</affiliation> abbey</orgName>
                     <orgName type="variant">London charterhouse</orgName>
-                    <location source="https://www.wikidata.org/wiki/Q6670230"><geo>51.521389, -0.099722</geo></location>
+                    <location source="https://www.wikidata.org/wiki/Q6670230">
+                        <geo>51.521389, -0.099722</geo>
+                    </location>
                     <note>Co-ordinates from Wikidata.</note>
                     <!-- https://www.wikidata.org/wiki/Q6670230 -->
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/313181544">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://catalogue.bnf.fr/ark:/12148/cb157997570">
+                                    <title>BNF</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
                 
                 <org xml:id="org_133893958">
@@ -9277,14 +9295,41 @@
                     <note>Founded in 997 as a Benedictine abbey; from 1484 onward a Carthusian monastery, dissolved 1803.</note>
                     <note type="links">
                         <list type="links">
-                            <item><ref target="http://viaf.org/viaf/133893958"><title>VIAF</title></ref></item>
-                            <item><ref target="http://klosterdatenbank.germania-sacra.de/gsn/60321"><title>Germania Sacra</title></ref></item>
+                            <item>
+                                <ref target="http://viaf.org/viaf/133893958">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item>
+                                <ref target="http://klosterdatenbank.germania-sacra.de/gsn/60321">
+                                    <title>Germania Sacra</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
                 <org xml:id="org_159512263">
                     <orgName type="display" source="bodl">Xanten, Cathedral</orgName>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/n85148996">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/159512263">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q566680">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
                 
                 <org xml:id="org_17149233273676510291">
@@ -9292,8 +9337,19 @@
                     <note type="links">
                         <list type="links">
                             <item>
-                                <ref target="https://www2.fgw.vu.nl/oz/monasteries/kdetails.php?ID=H06">
+                                <ref
+                                    target="https://www2.fgw.vu.nl/oz/monasteries/kdetails.php?ID=H06">
                                     <title>Medieval Monasteries in the Netherlands until 1800: A Census</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/no2017045728">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/17149233273676510291">
+                                    <title>VIAF</title>
                                 </ref>
                             </item>
                         </list>
@@ -9309,16 +9365,69 @@
                     <note>Founded 1293, dissolved 1786.</note>
                     <note type="links">
                         <list type="links">
-                            <item><ref target="http://viaf.org/viaf/148392609"></ref><title>VIAF</title></item>
+                            <item>
+                                <ref target="http://viaf.org/viaf/148392609">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_128973719">
                     <orgName type="display" source="bodl">Lincoln, cathedral church</orgName>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000106595883">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/n50056837">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/128973719">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q390169">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
                 
                 <org xml:id="org_150825867">
                     <orgName type="display" source="bold">Winchester College</orgName>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000122486740">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/n50038080">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/150825867">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q1059517">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
                 
                 <org xml:id="org_272891581">
@@ -9334,33 +9443,166 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/n85238709">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/272891581">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
                 <org xml:id="org_146831170">
                     <orgName type="display" source="bodl">Leominster, <affiliation>Benedictine</affiliation> priory of St Peter</orgName>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/nb2004308666">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/146831170">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
                 
                 <org xml:id="org_126774004">
                     <orgName type="display" source="bodl">Missenden, <affiliation>Augustinian (Arrouaisian)</affiliation> priory of St Mary the Virgin</orgName>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/n88126753">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/126774004">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q6878233">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
-
+                
                 <org xml:id="org_139803826">
-                    <orgName type="display" source="bodl">Hexham, <affiliation>Augustinian</affiliation> priory of St Andrew</orgName></org>
+                    <orgName type="display" source="bodl">Hexham, <affiliation>Augustinian</affiliation> priory of St Andrew</orgName>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/nb2004303056">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/139803826">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q950037">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
+                </org>
                 
                 <org xml:id="org_125482319">
-                    <orgName type="display" source="bodl">Chichester, <affiliation>cathedral church</affiliation></orgName>
+                    <orgName type="display" source="bodl">Chichester, <affiliation>cathedral church</affiliation> </orgName>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000121077013">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/n79145751">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/125482319">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q1736182">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
                 
-
                 <org xml:id="org_158933429">
                     <orgName type="display" source="VIAF">Fürstlich Stolberg-Wernigerodesche Bibliothek</orgName>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/nr00019962">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/158933429">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q2351220">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
                 
-
                 <org xml:id="org_158983524">
                     <orgName type="display" source="bodl">Oxford, St Edmund Hall</orgName>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000121946055">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/n85313215">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/158983524">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://catalogue.bnf.fr/ark:/12148/cb12211920b">
+                                    <title>BNF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q973884">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
                 
                 <org xml:id="org_295127444">
@@ -9369,12 +9611,42 @@
                         <geo source="https://de.wikipedia.org/wiki/Kloster_Sambucina">39.445133, 16.321017</geo>
                     </location>
                     <note>Co-ordinates from Wikipedia.</note>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/n87908729">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/295127444">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q766259">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
                 
                 <org xml:id="org_310514352">
                     <orgName type="display" source="bodl">Venice, <affiliation>Augustinian nunnery</affiliation> of Santa Maria delle Vergini</orgName>
-                    <location><geo source="http://www.venipedia.org/wiki/index.php?title=Demolished_Church_of_Santa_Maria_delle_Vergini">45.435183,12.35795</geo></location>
+                    <location>
+                        <geo source="http://www.venipedia.org/wiki/index.php?title=Demolished_Church_of_Santa_Maria_delle_Vergini">45.435183,12.35795</geo>
+                    </location>
                     <note>Co-ordinates from Venipedia.</note>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/310514352">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
                 
                 <org xml:id="org_122611272">
@@ -9383,8 +9655,31 @@
                         <geo source="https://en.wikipedia.org/wiki/Jesus_College,_Oxford">51.7534, -1.2569</geo>
                     </location>
                     <note>Co-ordinates from Wikipedia.</note>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000084992780">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/n88196450">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/122611272">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q81174">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
-                
                 
                 <org xml:id="org_124680895">
                     <orgName type="display" source="bodl">Pershore, <affiliation>Benedictine</affiliation> abbey of St Edburga</orgName>
@@ -9392,19 +9687,95 @@
                         <geo source="https://en.wikipedia.org/wiki/Pershore_Abbey">52.110556, -2.077778</geo>
                     </location>
                     <note>Co-ordinates from Wikipedia.</note>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/no2003077544">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/124680895">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q7170186">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
                 
                 <org xml:id="org_138184325">
                     <orgName type="display" source="bodl">Wye, Kent, College of St Gregory and St Martin</orgName>
                     <orgName type="variant">Wye College</orgName>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000406391081">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/n80036573">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/138184325">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://catalogue.bnf.fr/ark:/12148/cb12288535d">
+                                    <title>BNF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q3570204">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
                 
                 <org xml:id="org_159672632">
                     <orgName type="display" source="bodl">La Crête, <affiliation>Cistercian</affiliation> abbey</orgName>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/n2008066542">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/159672632">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q1775467">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
                 
                 <org xml:id="org_246264651">
                     <orgName type="display" source="bodl">Otterberg, <affiliation>Cistercian</affiliation> abbey</orgName>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/246264651">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
                 
                 <org xml:id="org_168521834">
@@ -9413,38 +9784,137 @@
                         <geo source="https://en.wikipedia.org/wiki/Clairvaux_Abbey">48.147222, 4.788889</geo>
                     </location>
                     <note>Co-ordinates from Wikipedia.</note>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000122041303">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/n81086807">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/168521834">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://catalogue.bnf.fr/ark:/12148/cb11937173n">
+                                    <title>BNF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q647070">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
-                
                 
                 <org xml:id="org_251338225">
                     <orgName type="display" source="bodl">Muchelney, <affiliation>Benedictine</affiliation> abbey</orgName>
                     <note type="links">
                         <list type="links">
-                            <item><ref target="http://viaf.org/viaf/251338225"><title>VIAF</title></ref></item>
+                            <item>
+                                <ref target="http://viaf.org/viaf/251338225">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
                         </list>
                         <!--<list type="links">
-                            <item><ref target="http://viaf.org/viaf/135337488"><title>VIAF</title></ref></item>
-                        </list>-->
+                               <item><ref target="http://viaf.org/viaf/135337488"><title>VIAF</title></ref></item>
+                            </list>-->
                     </note>
                 </org>
                 
                 <org xml:id="org_122726162">
                     <orgName type="display" source="bodl">Rome, Collegium Romanum Societatis Jesu</orgName>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000117025050">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/n81097177">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/122726162">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q2157592">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
                 
                 <org xml:id="org_140790558">
                     <orgName type="display" source="cul">Cambridge University, Library</orgName>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000122930063">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/n81070793">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/140790558">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://catalogue.bnf.fr/ark:/12148/cb11871536r">
+                                    <title>BNF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q1028334">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
-                
                 
                 <org xml:id="org_135319659">
                     <orgName type="display" source="bodl">Erfurt, Benedictine abbey of SS Peter and Paul</orgName>
-                    <orgName type="variant" source="http://klosterdatenbank.germania-sacra.de/gsn/776">Benediktinerkloster St. Peter, Erfurt (zuvor Kollegiatstift)</orgName>
+                    <orgName type="variant" source="http://klosterdatenbank.germania-sacra.de/gsn/776" >Benediktinerkloster St. Peter, Erfurt (zuvor Kollegiatstift)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
                                 <ref target="http://klosterdatenbank.germania-sacra.de/gsn/776">
                                     <title>Germania Sacra</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/nr97002978">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/135319659">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q2079676">
+                                    <title>Wikidata</title>
                                 </ref>
                             </item>
                         </list>
@@ -9457,27 +9927,71 @@
                         <geo>50.879, -1.357</geo>
                     </location>
                     <note>Co-ordinates from Wikipedia</note>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/no2018024002">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/247467479">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q846514">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
                 
                 <org xml:id="org_158803227">
                     <orgName type="display" source="bodl">Jumièges, <affiliation>Benedictine</affiliation> abbey of Saint-Pierre</orgName>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000121941318">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/n80146317">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/158803227">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://catalogue.bnf.fr/ark:/12148/cb11940988d">
+                                    <title>BNF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q333980">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
-                
                 <!--  -->
-                
                 <org xml:id="org_241899093">
                     <orgName type="display" source="bodl">Thornholme, <affiliation>Augustinian</affiliation> priory</orgName>
                     <!-- record originally created from https://viaf.org/viaf/241899093/viaf.xml at 2019-03-29 13:19:38.882869 -->
                     <orgName type="variant" subtype="corporate" source="DNB">Stift Thornholme</orgName>
                     <orgName type="variant" subtype="corporate" source="DNB">Thorneholm Priory</orgName>
                     <orgName type="variant" subtype="corporate" source="DNB">Thornholme Priory</orgName>
-                    <orgName type="variant" subtype="corporate" source="DNB">Thornholme Priory,
-                        Thornholme</orgName>
-                        <location source="https://en.wikipedia.org/wiki/Thornholme_Priory">
-                            <geo>53.600556, -0.5425</geo>
-                        </location>
+                    <orgName type="variant" subtype="corporate" source="DNB">Thornholme Priory, Thornholme</orgName>
+                    <location source="https://en.wikipedia.org/wiki/Thornholme_Priory">
+                        <geo>53.600556, -0.5425</geo>
+                    </location>
                     <note>Co-ordinates from Wikipedia.</note>
-                   
                     <note type="links">
                         <list type="links">
                             <item>
@@ -9495,6 +10009,7 @@
                 </org>
                 
                 <org xml:id="org_159532915">
+<!-- ***** Old VIAF ID now redirects to 135801795 ***** -->
                     <orgName type="display" source="bodl">Cambridge, Pembroke College</orgName>
                     <location source="https://en.wikipedia.org/wiki/Pembroke_College,_Cambridge">
                         <geo>52.202, 0.12</geo>
@@ -9522,21 +10037,32 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000122904834">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/nb2006026375">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/135801795">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                     <!-- some entries also in  https://viaf.org/viaf/173025472/ -->
                 </org>
                 
-                
-                
                 <org xml:id="org_304919952">
                     <!-- record originally created from https://viaf.org/viaf/304919952/viaf.xml at 2017-03-20 15:51:44.154668 -->
-                    <orgName type="display" subtype="unknownOrder" source="bodl">Pistoia, cathedral
-                        of San Zeno (Pistoia)</orgName>
+                    <orgName type="display" subtype="unknownOrder" source="bodl">Pistoia, cathedral of San Zeno (Pistoia)</orgName>
                     <settlement>Pistoia</settlement>
                     <country key="place_1000080">Italy</country>
-                    <orgName type="variant" subtype="unknownOrder" source="BAV">Cattedrale di San
-                        Zeno (Pistoia)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BAV">Cattedrale di San Zeno (Pistoia)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -9547,47 +10073,30 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_149780348">
                     <!-- record originally created from https://viaf.org/viaf/149780348/viaf.xml at 2017-03-20 15:51:46.707668 -->
-                    <orgName type="display" source="bodl">Carrión de los Condes,
-                            <affiliation>Benedictine</affiliation> monastery of San Zoilo de Carrión</orgName>
+                    <orgName type="display" source="bodl">Carrión de los Condes, <affiliation>Benedictine</affiliation> monastery of San Zoilo de Carrión</orgName>
                     <settlement>Carrión de los Condes</settlement>
                     <country key="place_1000095">Spain</country>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Monasterio de San
-                        Zoilo de Carrión (Carrión de los Condes, Spain)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Benediktinerkloster</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Carrión de los
-                        Condes (Espagne), Monasterio de San Zoilo</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Carrión de los
-                        Condes (Espagne), Monasterio de San Zoilo</orgName>
-                    <orgName type="variant" subtype="surnameFirst" source="LC">Carrión de los Condes
-                        (Spain)., Monasterio de San Zoilo</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Kloster Carrión de
-                        los Condes, Ehemalige Vorzugsbenennung SWD</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Monasterio de Carrión
-                        (Carrión de los Condes, Spain)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Monasterio de San
-                        Zoil (Carrión de los Condes, Spain)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Monasterio de San
-                        Zoil de Carrión</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Monasterio de San
-                        Zoilo</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Monasterio de San
-                        Zoilo (Carrión de los Condes, Spain)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Monasterio de San
-                        Zoilo de Carrión</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Monasterio de San
-                        Zoilo y San Félix</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Monasterio de Sant
-                        Zoil, Carrión de los Condes, Espagne</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Real Monasterio de
-                        San Zoil</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Real Monasterio de
-                        San Zoil (Carrión de los Condes, Spain)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">San Zoil de Carrión
-                        de los Condes (Monastery)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">San Zoilo (Monastery
-                        : Carrión de los Condes, Spain)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Monasterio de San Zoilo de Carrión (Carrión de los Condes, Spain)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB" >Benediktinerkloster</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Carrión de los Condes (Espagne), Monasterio de San Zoilo</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Carrión de los Condes (Espagne), Monasterio de San Zoilo</orgName>
+                    <orgName type="variant" subtype="surnameFirst" source="LC">Carrión de los Condes (Spain)., Monasterio de San Zoilo</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Kloster Carrión de los Condes, Ehemalige Vorzugsbenennung SWD</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Monasterio de Carrión (Carrión de los Condes, Spain)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Monasterio de San Zoil (Carrión de los Condes, Spain)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Monasterio de San Zoil de Carrión</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Monasterio de San Zoilo</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Monasterio de San Zoilo (Carrión de los Condes, Spain)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Monasterio de San Zoilo de Carrión</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Monasterio de San Zoilo y San Félix</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Monasterio de Sant Zoil, Carrión de los Condes, Espagne</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Real Monasterio de San Zoil</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Real Monasterio de San Zoil (Carrión de los Condes, Spain)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">San Zoil de Carrión de los Condes (Monastery)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">San Zoilo (Monastery : Carrión de los Condes, Spain)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -9623,18 +10132,15 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_243863172">
                     <!-- record originally created from https://viaf.org/viaf/243863172/viaf.xml at 2017-03-20 15:51:49.256668 -->
-                    <orgName type="display" source="bodl">Padua, monastery of San Giovanni di
-                        Verdara (<affiliation>Benedictine</affiliation>, later
-                            <affiliation>Augustinian canons</affiliation>)</orgName>
+                    <orgName type="display" source="bodl">Padua, monastery of San Giovanni di Verdara (<affiliation>Benedictine</affiliation>, later <affiliation>Augustinian canons</affiliation>)</orgName>
                     <settlement>Padua</settlement>
                     <country key="place_1000080">Italy</country>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">San Giovanni di
-                        Verdara, Kloster</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Convento di San
-                        Giovanni di Verdara</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Lateranenserkonvent</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">San Giovanni di Verdara, Kloster</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Convento di San Giovanni di Verdara</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB" >Lateranenserkonvent</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -9650,24 +10156,18 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_49145542365096640921">
                     <!-- record originally created from https://viaf.org/viaf/49145542365096640921/viaf.xml at 2017-03-20 15:51:51.790668 -->
-                    <orgName type="display" source="bodl">Fiesole,
-                            <affiliation>Dominican</affiliation> Convent of San Domenico</orgName>
+                    <orgName type="display" source="bodl">Fiesole, <affiliation>Dominican</affiliation> Convent of San Domenico</orgName>
                     <settlement>Fiesole</settlement>
                     <country key="place_1000080">Italy</country>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">San Domenico di
-                        Fiesole (Monastery)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Complesso conventuale
-                        e chiesastico di San Domenico di Fiesole</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Convent of San
-                        Domenico (Fiesole, Italy)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Convento di San
-                        Domenico di Fiesole</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">S. Domenico di
-                        Fiesole (Monastery)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">San Domenico
-                        (Monastery : Fiesole, Italy)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">San Domenico di Fiesole (Monastery)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Complesso conventuale e chiesastico di San Domenico di Fiesole</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Convent of San Domenico (Fiesole, Italy)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Convento di San Domenico di Fiesole</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">S. Domenico di Fiesole (Monastery)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">San Domenico (Monastery : Fiesole, Italy)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -9683,10 +10183,10 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_132571192">
                     <!-- record originally created from https://viaf.org/viaf/132571192/viaf.xml at 2017-03-20 15:51:54.385668 -->
-                    <orgName type="display" source="bodl">Egmond,
-                            <affiliation>Benedictine</affiliation> monastery</orgName>
+                    <orgName type="display" source="bodl">Egmond, <affiliation>Benedictine</affiliation> monastery</orgName>
                     <settlement>Egmond</settlement>
                     <country key="place_7016845">Netherlands</country>
                     <orgName type="variant" subtype="unknownOrder" source="LC">Abdij van Egmond</orgName>
@@ -9694,14 +10194,10 @@
                     <orgName type="variant" subtype="unknownOrder" source="BNF">Abbaye d'Egmond</orgName>
                     <orgName type="variant" subtype="unknownOrder" source="LC">Abbey of Egmond</orgName>
                     <orgName type="variant" subtype="unknownOrder" source="BNF">Abdij van Egmond</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Adelbertabdij,
-                        Bergen, Pays-Bas</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Egmond (Benedictine
-                        monastery)</orgName>
-                    <orgName type="variant" subtype="surnameFirst" source="LC">Egmond
-                        (Netherlands)., Abdij</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Egmond (Pays-Bas),
-                        Abbaye</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Adelbertabdij, Bergen, Pays-Bas</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Egmond (Benedictine monastery)</orgName>
+                    <orgName type="variant" subtype="surnameFirst" source="LC">Egmond (Netherlands)., Abdij</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Egmond (Pays-Bas), Abbaye</orgName>
                     <orgName type="variant" subtype="unknownOrder" source="LC">Egmond Abbey</orgName>
                     <orgName type="variant" subtype="unknownOrder" source="SUDOC">Egmondse klooster</orgName>
                     <orgName type="variant" subtype="unknownOrder" source="LC">Klooster Egmond</orgName>
@@ -9730,22 +10226,17 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_147596326">
                     <!-- record originally created from https://viaf.org/viaf/147596326/viaf.xml at 2017-03-20 15:51:56.855668 -->
-                    <orgName type="display" source="bodl">Lyon (Rhône), convent of
-                            <affiliation>Augustins déchaussés</affiliation>
-                   </orgName>
+                    <orgName type="display" source="bodl">Lyon (Rhône), convent of <affiliation>Augustins déchaussés</affiliation> </orgName>
                     <settlement>Lyon (Rhône)</settlement>
                     <country key="place_1000070">France</country>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">ba0yba0y, fre, 20,
-                        Couvent de la Croix-Rousse, Lyon</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">ba0yba0y, fre, 20, Couvent de la Croix-Rousse, Lyon</orgName>
                     <orgName type="variant" subtype="unknownOrder" source="BNF">Augustins de Lyon</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Augustins déchaussés
-                        de la Croix-Rousse, Lyon</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Augustins
-                        déchaussés, France, Couvent de la Croix-Rousse</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Lyon (Rhône),
-                        Couvent des Frères Prêcheurs</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Augustins déchaussés de la Croix-Rousse, Lyon</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Augustins déchaussés, France, Couvent de la Croix-Rousse</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Lyon (Rhône), Couvent des Frères Prêcheurs</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -9761,30 +10252,21 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_150107857">
                     <!-- record originally created from https://viaf.org/viaf/150107857/viaf.xml at 2017-03-20 15:51:59.562668 -->
-                    <orgName type="display" source="bodl">Bury St Edmunds,
-                            <affiliation>Benedictine</affiliation> abbey</orgName>
+                    <orgName type="display" source="bodl">Bury St Edmunds, <affiliation>Benedictine</affiliation> abbey</orgName>
                     <settlement>Bury St. Edmunds</settlement>
                     <country key="place_7002445">England</country>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Abbey of Bury St.
-                        Edmunds</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Abbey, Bury Saint
-                        Edmunds</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Abbey, Saint
-                        Edmunds</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Abbey of Bury St
-                        Edmunds</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Benedictine Abbey
-                        of Bury St. Edmunds</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Benedictine Abbey of
-                        Bury St. Edmunds</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Bury St Edmunds
-                        (GB), abbey</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Bury St. Edmunds
-                        Abbey</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Bury St. Edmunds
-                        Abbey</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Abbey of Bury St. Edmunds</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Abbey, Bury Saint Edmunds</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Abbey, Saint Edmunds</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Abbey of Bury St Edmunds</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Benedictine Abbey of Bury St. Edmunds</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Benedictine Abbey of Bury St. Edmunds</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Bury St Edmunds (GB), abbey</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Bury St. Edmunds Abbey</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Bury St. Edmunds Abbey</orgName>
                     <orgName type="variant" subtype="unknownOrder" source="BNF">Bury abbey</orgName>
                     <orgName type="variant" subtype="unknownOrder" source="DNB">Saint Edmunds Abbey</orgName>
                     <note type="links">
@@ -9819,15 +10301,17 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000119576681">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
-                
-              
                 <org xml:id="org_304912099">
-                    <orgName type="display">Winchester, Nunnaminster (St Mary's Abbey),
-                            <affiliation>Benedictine</affiliation> nunnery</orgName>
+                    <orgName type="display">Winchester, Nunnaminster (St Mary's Abbey), <affiliation>Benedictine</affiliation> nunnery</orgName>
                     <settlement>Winchester</settlement>
                     <country key="place_7002445">England</country>
                     <orgName type="crossref">Nunnaminster</orgName>
@@ -9843,40 +10327,31 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q7594237">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
-             
-                
                 <org xml:id="org_123429486">
                     <!-- record originally created from https://viaf.org/viaf/123429486/viaf.xml at 2017-03-20 16:30:29.583780 -->
-                    <orgName type="display" source="bodl">Lyre (La Vieille-Lyre, Eure), Abbaye
-                        Notre-Dame de Lyre (<affiliation>Benedictine</affiliation>)</orgName>
+                    <orgName type="display" source="bodl">Lyre (La Vieille-Lyre, Eure), Abbaye Notre-Dame de Lyre (<affiliation>Benedictine</affiliation>)</orgName>
                     <settlement>La Vieille-Lyre</settlement>
                     <country key="place_1000070">France</country>
-                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Abbaye Notre-Dame
-                        de Lyre (La Vieille-Lyre, Eure)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Abbaye Notre-Dame
-                        de Lire</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Abbaye Notre-Dame de
-                        Lire</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Abbaye de
-                        Bénédictins (La Vieille-Lyre, Eure ; Notre-Dame de Lyre) (1046-179.)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Abbaye de
-                        Bénédictins, La Vieille-Lyre, Eure ; Notre-Dame de Lyre), 1046-179.</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Abbaye de
-                        Lire</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Abbaye de
-                        Lire</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Abbaye de
-                        Lyre</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Abbaye de
-                        Lyre</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Abbaye de N.-D. de
-                        Lyre</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Abbaye de N.-D. de
-                        Lyre</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Abbaye Notre-Dame de Lyre (La Vieille-Lyre, Eure)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Abbaye Notre-Dame de Lire</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Abbaye Notre-Dame de Lire</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Abbaye de Bénédictins (La Vieille-Lyre, Eure ; Notre-Dame de Lyre) (1046-179.)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Abbaye de Bénédictins, La Vieille-Lyre, Eure ; Notre-Dame de Lyre), 1046-179.</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Abbaye de Lire</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Abbaye de Lire</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Abbaye de Lyre</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Abbaye de Lyre</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Abbaye de N.-D. de Lyre</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Abbaye de N.-D. de Lyre</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -9899,26 +10374,24 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/nb2019021736">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
-              
                 <org xml:id="org_270753550">
                     <!-- record originally created from https://viaf.org/viaf/270753550/viaf.xml at 2017-03-20 16:30:26.893753 -->
                     <orgName type="display" source="bodl">Canterbury, diocese</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Church of England.,
-                        Diocese of Canterbury</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Archbishop of
-                        Canterbury</orgName>
-                    <orgName type="variant" subtype="surnameFirst" source="LC">Canterbury (England :
-                        Diocese : Church of England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Diocese of
-                        Canterbury</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Diocese of
-                        Canterbury, Church of England</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Diocese,
-                        Canterbury</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Church of England., Diocese of Canterbury</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Archbishop of Canterbury</orgName>
+                    <orgName type="variant" subtype="surnameFirst" source="LC">Canterbury (England : Diocese : Church of England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Diocese of Canterbury</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Diocese of Canterbury, Church of England</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Diocese, Canterbury</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -9949,20 +10422,16 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_313198488">
                     <!-- record originally created from https://viaf.org/viaf/313198488/viaf.xml at 2017-03-20 16:30:24.353727 -->
-                    <orgName type="display" source="bodl">Leicester,
-                            <affiliation>Augustinian</affiliation> Abbey</orgName>
+                    <orgName type="display" source="bodl">Leicester, <affiliation>Augustinian</affiliation> Abbey</orgName>
                     <settlement>Leicester</settlement>
                     <country key="place_7002445">England</country>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Leicester,
-                        Abbey</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Abbey of St. Mary of
-                        the Meadows (Leicester, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Abbey of St. Mary
-                        of the Meadows (Leicester, GB)</orgName>
-                    <orgName type="variant" subtype="surnameFirst" source="LC">Leicester (England).,
-                        Abbey</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Leicester, Abbey</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Abbey of St. Mary of the Meadows (Leicester, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Abbey of St. Mary of the Meadows (Leicester, GB)</orgName>
+                    <orgName type="variant" subtype="surnameFirst" source="LC">Leicester (England)., Abbey</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -9988,32 +10457,22 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_127077483">
                     <!-- record originally created from https://viaf.org/viaf/127077483/viaf.xml at 2017-03-20 16:30:19.153675 -->
-                    <orgName type="display" source="bodl">Bermondsey,
-                            <affiliation>Benedictine</affiliation> Abbey of St Saviour</orgName>
+                    <orgName type="display" source="bodl">Bermondsey, <affiliation>Benedictine</affiliation> Abbey of St Saviour</orgName>
                     <settlement>Bermondsey</settlement>
                     <country key="place_7002445">England</country>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Bermondsey Abbey
-                        (London, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Abbey of St. Saviour
-                        (London, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Bermondsey Priory
-                        (London, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Monasterium de
-                        Bermundeseia (London, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Monasterium de
-                        Bermundesia (London, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Monastery of
-                        Bermondsey (London, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Priory of St.
-                        Saviour, Bermondsey (London, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">St. Saviour
-                        Bermondsey (Abbey : London, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">St. Saviour's Abbey
-                        (London, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">St. Saviour's Priory
-                        (London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Bermondsey Abbey (London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Abbey of St. Saviour (London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Bermondsey Priory (London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Monasterium de Bermundeseia (London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Monasterium de Bermundesia (London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Monastery of Bermondsey (London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Priory of St. Saviour, Bermondsey (London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">St. Saviour Bermondsey (Abbey : London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">St. Saviour's Abbey (London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">St. Saviour's Priory (London, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -10026,18 +10485,21 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q822030">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_151542893">
                     <!-- record originally created from https://viaf.org/viaf/151542893/viaf.xml at 2017-03-20 16:30:16.563649 -->
                     <orgName type="display" source="bodl">Winchester, <affiliation>Benedictine</affiliation> abbey of New Minster, afterwards Hyde Abbey</orgName>
-                    <orgName type="crossref" subtype="unknownOrder" source="LC">Hyde Abbey
-                        (Winchester, England)</orgName>
-                    <orgName type="crossref" subtype="unknownOrder" source="LC">New Minster and Hyde
-                        Abbey (Winchester, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">New Minster and Hyde
-                        Abbey, Winchester, England</orgName>
+                    <orgName type="crossref" subtype="unknownOrder" source="LC">Hyde Abbey (Winchester, England)</orgName>
+                    <orgName type="crossref" subtype="unknownOrder" source="LC">New Minster and Hyde Abbey (Winchester, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">New Minster and Hyde Abbey, Winchester, England</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -10055,30 +10517,37 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000123535938">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://catalogue.bnf.fr/ark:/12148/cb14402856q">
+                                    <title>BNF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q5953503">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_217095146">
                     <!-- record originally created from https://viaf.org/viaf/217095146/viaf.xml at 2017-03-20 16:30:14.052624 -->
-                    <orgName type="display" source="bodl">Sheen (Richmond upon Thames),
-                            <affiliation>Charterhouse</affiliation>
-                   </orgName>
+                    <orgName type="display" source="bodl">Sheen (Richmond upon Thames), <affiliation>Charterhouse</affiliation> </orgName>
                     <settlement>Sheen</settlement>
                     <country key="place_7002445">England</country>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">House of Jesus of
-                        Bethlehem (Monastery : Richmond upon Thames, London, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">House of Jesus of
-                        Bethlehem (Richmond upon Thames, GB)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">House of Jesus of
-                        Bethlehem, Richmond upon Thames, GB</orgName>
-                    <orgName type="variant" subtype="surnameFirst" source="LC">London, England.,
-                        Richmond upon Thames., Sheen Charterhouse</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Richmond upon Thames
-                        (GB), Sheen Charterhouse</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Richmond upon
-                        Thames (GB), Sheen Charterhouse</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Sheen (Monastery :
-                        Richmond upon Thames, London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">House of Jesus of Bethlehem (Monastery : Richmond upon Thames, London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">House of Jesus of Bethlehem (Richmond upon Thames, GB)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">House of Jesus of Bethlehem, Richmond upon Thames, GB</orgName>
+                    <orgName type="variant" subtype="surnameFirst" source="LC">London, England., Richmond upon Thames., Sheen Charterhouse</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Richmond upon Thames (GB), Sheen Charterhouse</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Richmond upon Thames (GB), Sheen Charterhouse</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Sheen (Monastery : Richmond upon Thames, London, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -10101,19 +10570,22 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q7492364">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_151354181">
                     <!-- record originally created from https://viaf.org/viaf/151354181/viaf.xml at 2017-03-20 16:30:11.542599 -->
-                    <orgName type="display" source="bodl">Jarrow,
-                            <affiliation>Benedictine</affiliation> abbey</orgName>
+                    <orgName type="display" source="bodl">Jarrow, <affiliation>Benedictine</affiliation> abbey</orgName>
                     <settlement>Jarrow</settlement>
                     <country key="place_7002445">England</country>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Abbey of Jarrow
-                        (Jarrow, England)</orgName>
-                    <orgName type="variant" subtype="surnameFirst" source="LC">Jarrow (England).,
-                        Jarrow (Abbey)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Abbey of Jarrow (Jarrow, England)</orgName>
+                    <orgName type="variant" subtype="surnameFirst" source="LC">Jarrow (England)., Jarrow (Abbey)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -10129,51 +10601,49 @@
                         </list>
                     </note>
                 </org>
-               <!-- <org xml:id="org_62147095006925080412">
-                    <!-\- deprecated, 12.9.17. use org_129111728 -\->
-                    <!-\- record originally created from https://viaf.org/viaf/62147095006925080412/viaf.xml at 2017-03-20 16:30:06.132545 -\->
-                    <orgName type="display" source="bodl">Lichfield, diocese</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Church of England,
-                        Lichfield Diocese</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Diocese of
-                        Lichfield</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Lichfield (England :
-                        Diocese : Church of England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Lichfield
-                        Diocese</orgName>
-                    <note type="links">
-                        <list type="links">
-                            <item>
-                                <ref target="http://d-nb.info/gnd/1109771207">
-                                    <title>GND</title>
-                                </ref>
-                            </item>
-                            <item>
-                                <ref target="http://www.wikidata.org/entity/Q3028579">
-                                    <title>Wikidata</title>
-                                </ref>
-                            </item>
-                            <item>
-                                <ref target="http://id.loc.gov/authorities/names/nb2007002973">
-                                    <title>LC</title>
-                                </ref>
-                            </item>
-                            <item>
-                                <ref target="https://viaf.org/viaf/62147095006925080412">
-                                    <title>VIAF</title>
-                                </ref>
-                            </item>
-                        </list>
-                    </note>
-                </org>-->
+                <!-- <org xml:id="org_62147095006925080412">
+                       <!-\- deprecated, 12.9.17. use org_129111728 -\->
+                       <!-\- record originally created from https://viaf.org/viaf/62147095006925080412/viaf.xml at 2017-03-20 16:30:06.132545 -\->
+                       <orgName type="display" source="bodl">Lichfield, diocese</orgName>
+                       <orgName type="variant" subtype="unknownOrder" source="DNB">Church of England,
+                           Lichfield Diocese</orgName>
+                       <orgName type="variant" subtype="unknownOrder" source="DNB">Diocese of
+                           Lichfield</orgName>
+                       <orgName type="variant" subtype="unknownOrder" source="LC">Lichfield (England :
+                           Diocese : Church of England)</orgName>
+                       <orgName type="variant" subtype="unknownOrder" source="DNB">Lichfield
+                           Diocese</orgName>
+                       <note type="links">
+                            <list type="links">
+                               <item>
+                                   <ref target="http://d-nb.info/gnd/1109771207">
+                                       <title>GND</title>
+                                   </ref>
+                               </item>
+                               <item>
+                                   <ref target="http://www.wikidata.org/entity/Q3028579">
+                                       <title>Wikidata</title>
+                                   </ref>
+                               </item>
+                               <item>
+                                   <ref target="http://id.loc.gov/authorities/names/nb2007002973">
+                                       <title>LC</title>
+                                   </ref>
+                               </item>
+                               <item>
+                                   <ref target="https://viaf.org/viaf/62147095006925080412">
+                                       <title>VIAF</title>
+                                   </ref>
+                               </item>
+                            </list>
+                       </note>
+                   </org>-->
                 <org xml:id="org_235558512">
                     <!-- record originally created from https://viaf.org/viaf/235558512/viaf.xml at 2017-03-20 16:29:27.422158 -->
-                    <orgName type="display" source="bodl">Wearmouth,
-                            <affiliation>Benedictine</affiliation> abbey</orgName>
+                    <orgName type="display" source="bodl">Wearmouth, <affiliation>Benedictine</affiliation> abbey</orgName>
                     <settlement>Wearmouth</settlement>
                     <country key="place_7002445">England</country>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Kloster
-                        Wearmouth</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Kloster Wearmouth</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -10189,18 +10659,15 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_239193232">
                     <!-- record originally created from https://viaf.org/viaf/239193232/viaf.xml at 2017-03-20 16:29:30.032184 -->
-                    <orgName type="display" source="bodl">Dover,
-                            <affiliation>Benedictine</affiliation> abbey of St Martin</orgName>
+                    <orgName type="display" source="bodl">Dover, <affiliation>Benedictine</affiliation> abbey of St Martin</orgName>
                     <settlement>Dover</settlement>
                     <country key="place_7002445">England</country>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Kloster
-                        Dover</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Benediktinerabtei
-                        Saint Martin</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Saint Martin's
-                        Priory</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Kloster Dover</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Benediktinerabtei Saint Martin</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Saint Martin's Priory</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -10216,56 +10683,34 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_132460849">
                     <!-- record originally created from https://viaf.org/viaf/132460849/viaf.xml at 2017-03-20 16:29:32.982213 -->
-                    <orgName type="display" source="bodl">Westminster,
-                            <affiliation>Benedictine</affiliation> Abbey</orgName>
+                    <orgName type="display" source="bodl">Westminster, <affiliation>Benedictine</affiliation> Abbey</orgName>
                     <settlement>Wesminster</settlement>
                     <country key="place_7002445">England</country>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Abbaye de
-                        Westminster</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Abbey Church of
-                        Westminster (London, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Abbey of Saint Peter
-                        (Westminster, London, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Abbey of St. Peter
-                        (Westminster, London, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Abby Church of
-                        Westminster (London, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Church of St. Peter
-                        (Westminster, London, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Collegiate Church of
-                        St. Peter (Westminster, London, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Collegiate Church of
-                        St. Peter at Westminster (London, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Collegiate Church of
-                        St. Peter in Westminster (London, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Dean and Chapter of
-                        Westminster (London, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Ecclesia Abbatiae
-                        Westmonasteriensis (London, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Ecclesia Collegiata
-                        B. Petri Westmonasterii (London, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Londres (G.B.),
-                        Westminster abbey</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Saint Peter's
-                        (Westminster, London, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">St. Peter's
-                        (Westminster, London, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Westminster Abbey
-                        Church (London, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Westminster Cathedral
-                        (London, England : 1540-1556)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Westminster
-                        abbey</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Westminster,
-                        Abbaye de</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB"
-                        >Westminster-Abtei</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Westmonasterium
-                        (Londres)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Westmonasterium,
-                        Londres</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Abbaye de Westminster</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Abbey Church of Westminster (London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Abbey of Saint Peter (Westminster, London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Abbey of St. Peter (Westminster, London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Abby Church of Westminster (London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Church of St. Peter (Westminster, London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Collegiate Church of St. Peter (Westminster, London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Collegiate Church of St. Peter at Westminster (London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Collegiate Church of St. Peter in Westminster (London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Dean and Chapter of Westminster (London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Ecclesia Abbatiae Westmonasteriensis (London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Ecclesia Collegiata B. Petri Westmonasterii (London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Londres (G.B.), Westminster abbey</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Saint Peter's (Westminster, London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">St. Peter's (Westminster, London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Westminster Abbey Church (London, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Westminster Cathedral (London, England : 1540-1556)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Westminster abbey</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Westminster, Abbaye de</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB" >Westminster-Abtei</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Westmonasterium (Londres)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Westmonasterium, Londres</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -10298,13 +10743,18 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000123083054">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_148943477">
                     <!-- record originally created from https://viaf.org/viaf/148943477/viaf.xml at 2017-03-20 16:29:38.562269 -->
-                    <orgName type="display" subtype="unknownOrder" source="LC">Worcester,
-                            <affiliation>Benedictine</affiliation> cathedral priory of St Mary</orgName>
+                    <orgName type="display" subtype="unknownOrder" source="LC">Worcester, <affiliation>Benedictine</affiliation> cathedral priory of St Mary</orgName>
                     <settlement>Worcester</settlement>
                     <country key="place_7002445">England</country>
                     <note type="links">
@@ -10339,16 +10789,21 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="https://catalogue.bnf.fr/ark:/12148/cb11868180m">
+                                    <title>BNF</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_292385856">
                     <!-- record originally created from https://viaf.org/viaf/292385856/viaf.xml at 2017-03-20 16:29:41.132295 -->
                     <orgName type="display" source="bodl">Oxford, Gloucester College</orgName>
                     <settlement>Oxford</settlement>
                     <country key="place_7002445">England</country>
-                    <orgName type="crossref" subtype="unknownOrder" source="LC">Gloucester College
-                        (University of Oxford)</orgName>
+                    <orgName type="crossref" subtype="unknownOrder" source="LC">Gloucester College (University of Oxford)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -10364,10 +10819,10 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_134872490">
                     <!-- record originally created from https://viaf.org/viaf/134872490/viaf.xml at 2017-03-20 16:29:46.562349 -->
-                    <orgName type="display" subtype="unknownOrder" source="LC">Malmesbury,
-                            <affiliation>Benedictine</affiliation> Abbey</orgName>
+                    <orgName type="display" subtype="unknownOrder" source="LC">Malmesbury, <affiliation>Benedictine</affiliation> Abbey</orgName>
                     <settlement>Malmesbury</settlement>
                     <country key="place_7002445">England</country>
                     <note type="links">
@@ -10390,26 +10845,19 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_158353196">
                     <!-- record originally created from https://viaf.org/viaf/158353196/viaf.xml at 2017-03-20 16:29:49.262376 -->
-                    <orgName type="display" subtype="unknownOrder" source="bodl">Canterbury, Christ
-                        Church Cathedral Priory (<affiliation>Benedictine</affiliation>)</orgName>
+                    <orgName type="display" subtype="unknownOrder" source="bodl">Canterbury, Christ Church Cathedral Priory (<affiliation>Benedictine</affiliation>)</orgName>
                     <settlement>Canterbury</settlement>
                     <country key="place_7002445">England</country>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Christ Church Priory
-                        (Canterbury, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Canterbury Cathedral
-                        Priory</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Canterbury
-                        Cathedral., Priory</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Christ Church
-                        Monastery Canterbury</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Christ Church Priory
-                        Canterbury</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Christchurch Priory
-                        Canterbury</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Priory of Christ
-                        Canterbury</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Christ Church Priory (Canterbury, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Canterbury Cathedral Priory</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Canterbury Cathedral., Priory</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Christ Church Monastery Canterbury</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Christ Church Priory Canterbury</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Christchurch Priory Canterbury</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Priory of Christ Canterbury</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -10427,25 +10875,25 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q46098131">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_135211427">
                     <!-- record originally created from https://viaf.org/viaf/135211427/viaf.xml at 2017-03-20 16:29:54.652430 -->
-                    <orgName type="display" source="bodl">York,
-                            <affiliation>Benedictine</affiliation> Abbey of St. Mary</orgName>
+                    <orgName type="display" source="bodl">York, <affiliation>Benedictine</affiliation> Abbey of St. Mary</orgName>
                     <settlement>York</settlement>
                     <country key="place_7002445">England</country>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">St. Mary's Abbey
-                        (York, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Abbey of Saint Mary
-                        (York, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Monasterium Beate
-                        Marie Eboracensis</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Monastery of St. Mary
-                        (York, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Saint Mary's Abbey
-                        (York, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">St. Mary's Abbey (York, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Abbey of Saint Mary (York, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Monasterium Beate Marie Eboracensis</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Monastery of St. Mary (York, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Saint Mary's Abbey (York, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -10458,63 +10906,43 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q1426965">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_142129514">
                     <!-- record originally created from https://viaf.org/viaf/142129514/viaf.xml at 2017-03-20 16:29:57.922463 -->
-                    <orgName type="display" subtype="unknownOrder" source="bodl">Oxford,
-                        university</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">University of
-                        Oxford</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB_LC">Academia
-                        Oxoniensis</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Daigaku,
-                        Oxford</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Daxue,
-                        Oxford</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Ǧāmiʿat Uksfurd
-                        Inǧiltira</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Jāmiʻat
-                        Uksfūrd</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Niujin da
-                        xue</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB"
-                        >Niujin-Daxue</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB"
-                        >Okkusufōdo-Daigaku</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Oxford (GB),
-                        University of Oxford</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Oxford (GB),
-                        University of Oxford</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB_LC_SUDOC">Oxford
-                        University</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Oxford
-                        university</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Prifysgol
-                        Rhydychen</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Univ.
-                        Oxford</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Universitas
-                        Oxoniensis</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Universitas
-                        oxoniensis</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Universitas
-                        oxoniensis</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Universität
-                        Oxford</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Universität Oxford,
-                        Ehemalige Vorzugsbenennung SWD</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB_SUDOC">Université
-                        d'Oxford</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Université
-                        d'Oxford</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Université,
-                        Oxford</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">University,
-                        Oxford</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">جامعة
-                        أكسفورد</orgName>
+                    <orgName type="display" subtype="unknownOrder" source="bodl">Oxford, university</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">University of Oxford</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB_LC">Academia Oxoniensis</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Daigaku, Oxford</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Daxue, Oxford</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Ǧāmiʿat Uksfurd Inǧiltira</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Jāmiʻat Uksfūrd</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Niujin da xue</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB" >Niujin-Daxue</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB" >Okkusufōdo-Daigaku</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Oxford (GB), University of Oxford</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Oxford (GB), University of Oxford</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB_LC_SUDOC">Oxford University</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Oxford university</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Prifysgol Rhydychen</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Univ. Oxford</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Universitas Oxoniensis</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Universitas oxoniensis</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Universitas oxoniensis</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Universität Oxford</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Universität Oxford, Ehemalige Vorzugsbenennung SWD</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB_SUDOC">Université d'Oxford</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Université d'Oxford</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Université, Oxford</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">University, Oxford</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">جامعة أكسفورد</orgName>
                     <orgName type="variant" subtype="unknownOrder" source="LC">牛津大学</orgName>
                     <note type="links">
                         <list type="links">
@@ -10548,13 +10976,18 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000419368948">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_151430091">
                     <!-- record originally created from https://viaf.org/viaf/151430091/viaf.xml at 2017-03-20 16:30:00.532489 -->
-                    <orgName type="display" subtype="unknownOrder" source="LC">Eynsham,
-                            <affiliation>Benedictine</affiliation> Abbey</orgName>
+                    <orgName type="display" subtype="unknownOrder" source="LC">Eynsham, <affiliation>Benedictine</affiliation> Abbey</orgName>
                     <settlement>Eynsham</settlement>
                     <country key="place_7002445">England</country>
                     <note type="links">
@@ -10584,43 +11017,34 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q2820517">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_138255873">
                     <!-- record originally created from https://viaf.org/viaf/138255873/viaf.xml at 2017-03-20 16:30:03.132515 -->
-                    <orgName type="display" source="bodl">Florence, Hospital of Santa Maria
-                        Nuova</orgName>
+                    <orgName type="display" source="bodl">Florence, Hospital of Santa Maria Nuova</orgName>
                     <settlement>Florence</settlement>
                     <country key="place_1000080">Italy</country>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Arcispedale di Santa
-                        Maria Nuova e stabilimenti riuniti (Florence, Italy)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Arcispedale di S.
-                        Maria Nuova di Firenze</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Arcispedale di
-                        Santa Maria Nuova (Florence, Italie)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Aricispedale di S.
-                        Maria Nuova (Forence, Italy)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Florence (Italie),
-                        Arcispedale di Santa Maria Nuova e stabilimenti riuniti</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Florence (Italie),
-                        Ospedale di Santa Maria Nuova</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Ospedale Santa Maria
-                        Nuova di Firenze</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Ospedale di S. Maria
-                        Nuova, Florence, Italie</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Ospedale di Santa
-                        Maria Nuova (Florence, Italie)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Ospedale di Santa
-                        Maria Nuova, Florence, Italie</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">R. Arcispedale di S.
-                        M. Nuova (Florence, Italy)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">R. Arcispedale di
-                        Santa Maria Nuova e stabilimenti riuniti (Florence, Italy)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Spedale di Santa
-                        Maria Nuova, Florence, Italie</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Stabilimenti riuniti
-                        di Santa Maria Nuova di Firenze</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Arcispedale di Santa Maria Nuova e stabilimenti riuniti (Florence, Italy)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Arcispedale di S. Maria Nuova di Firenze</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Arcispedale di Santa Maria Nuova (Florence, Italie)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Aricispedale di S. Maria Nuova (Forence, Italy)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Florence (Italie), Arcispedale di Santa Maria Nuova e stabilimenti riuniti</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Florence (Italie), Ospedale di Santa Maria Nuova</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Ospedale Santa Maria Nuova di Firenze</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Ospedale di S. Maria Nuova, Florence, Italie</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Ospedale di Santa Maria Nuova (Florence, Italie)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Ospedale di Santa Maria Nuova, Florence, Italie</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">R. Arcispedale di S. M. Nuova (Florence, Italy)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">R. Arcispedale di Santa Maria Nuova e stabilimenti riuniti (Florence, Italy)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Spedale di Santa Maria Nuova, Florence, Italie</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Stabilimenti riuniti di Santa Maria Nuova di Firenze</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -10656,34 +11080,23 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_165174766">
                     <!-- record originally created from https://viaf.org/viaf/165174766/viaf.xml at 2017-03-20 16:29:43.982323 -->
-                    <orgName type="display" subtype="unknownOrder" source="bodl">Canterbury,
-                            <affiliation>Benedictine</affiliation> abbey of St. Augustine</orgName>
+                    <orgName type="display" subtype="unknownOrder" source="bodl">Canterbury, <affiliation>Benedictine</affiliation> abbey of St. Augustine</orgName>
                     <settlement>Canterbury</settlement>
                     <country key="place_7002445">England</country>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">St. Augustine's Abbey
-                        (Canterbury, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Benediktinerkloster
-                        Saint Augustine Canterbury</orgName>
-                    <orgName type="variant" subtype="surnameFirst" source="LC">Canterbury
-                        (England)., St. Augustine's Abbey</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Canterbury (GB), St.
-                        Augustine's Abbey</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Canterbury (GB),
-                        St. Augustine's Abbey</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Saint Augustine's
-                        Abbey (Canterbury, England)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Saint Augustine's
-                        Abbey (Canterbury, GB)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Saint Augustine's
-                        Abbey Canterbury</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Saint Augustine's
-                        Abbey, Canterbury, GB</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">St. Augustine's
-                        Abbey, Canterbury, Eng.</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">St. Augustine's
-                        Abbey, Canterbury</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">St. Augustine's Abbey (Canterbury, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Benediktinerkloster Saint Augustine Canterbury</orgName>
+                    <orgName type="variant" subtype="surnameFirst" source="LC">Canterbury (England)., St. Augustine's Abbey</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Canterbury (GB), St. Augustine's Abbey</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Canterbury (GB), St. Augustine's Abbey</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Saint Augustine's Abbey (Canterbury, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="SUDOC">Saint Augustine's Abbey (Canterbury, GB)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Saint Augustine's Abbey Canterbury</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Saint Augustine's Abbey, Canterbury, GB</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">St. Augustine's Abbey, Canterbury, Eng.</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">St. Augustine's Abbey, Canterbury</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -10716,17 +11129,21 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000121978479">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_313492968">
                     <!-- record originally created from https://viaf.org/viaf/313492968/viaf.xml at 2017-03-20 17:36:01.860182 -->
-                    <orgName type="display" source="bodl">Langley (Norfolk),
-                            <affiliation>Premonstratensian</affiliation> Abbey</orgName>
+                    <orgName type="display" source="bodl">Langley (Norfolk), <affiliation>Premonstratensian</affiliation> Abbey</orgName>
                     <settlement>Langley</settlement>
                     <country key="place_7002445">England</country>
-                    <orgName type="variant" subtype="unknownOrder" source="LC">Langley Abbey
-                        (Langley with Hardley, England)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="LC">Langley Abbey (Langley with Hardley, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -10742,22 +11159,14 @@
                         </list>
                     </note>
                 </org>
-              
-                
-                
                 
                 <org xml:id="org_129471242">
                     <!-- record originally created from https://viaf.org/viaf/129471242/viaf.xml at 2017-05-09 12:26:25.299454 -->
-                    <orgName type="display"  source="LC bodl">Montebourg
-                        (France), Abbaye de Montebourg</orgName>
-                    <orgName type="variant"  source="LC">Abadía de Montebourg
-                        (Montebourg, France)</orgName>
-                    <orgName type="crossref"  source="LC">Abbaye Sainte-Marie de
-                        Montebourg (Montebourg, France)</orgName>
-                    <orgName type="variant"  source="LC">Montebourg Abbey
-                        (Montebourg, France)</orgName>
-                    <orgName type="crossref"  source="LC">Nostre Dame de
-                        Montebourg (Abbey : Montebourg, France)</orgName>
+                    <orgName type="display" source="LC bodl">Montebourg (France), Abbaye de Montebourg</orgName>
+                    <orgName type="variant" source="LC">Abadía de Montebourg (Montebourg, France)</orgName>
+                    <orgName type="crossref" source="LC">Abbaye Sainte-Marie de Montebourg (Montebourg, France)</orgName>
+                    <orgName type="variant" source="LC">Montebourg Abbey (Montebourg, France)</orgName>
+                    <orgName type="crossref" source="LC">Nostre Dame de Montebourg (Abbey : Montebourg, France)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -10778,12 +11187,11 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_135387394">
                     <!-- record originally created from https://viaf.org/viaf/135387394/viaf.xml at 2017-05-09 12:44:37.610397 -->
-                    <orgName type="display"  source="bodl">Pontigny,
-                            <affiliation>Cisterican</affiliation> abbey</orgName>
-                    <orgName type="crossref"  source="DNB">Abbaye Cistercienne de
-                        l'Etoile, Pontigny</orgName>
+                    <orgName type="display" source="bodl">Pontigny, <affiliation>Cisterican</affiliation> abbey</orgName>
+                    <orgName type="crossref" source="DNB">Abbaye Cistercienne de l'Etoile, Pontigny</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -10816,13 +11224,18 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000121627337">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_129279786">
                     <!-- record originally created from https://viaf.org/viaf/129279786/viaf.xml at 2017-05-09 12:45:46.863238 -->
-                    <orgName type="display"  source="bodl">Vauluisant,
-                            <affiliation>Cisterican</affiliation> abbey (near Courgenay, France)</orgName>
+                    <orgName type="display" source="bodl">Vauluisant, <affiliation>Cisterican</affiliation> abbey (near Courgenay, France)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -10854,62 +11267,58 @@
                     </note>
                 </org>
                 <!--<org xml:id="org_140674505">
-                    <!-\- deprecated: no longer used. w -\->
-                    <!-\- record originally created from https://viaf.org/viaf/140674505/viaf.xml at 2017-05-09 11:29:20.094807 -\->
-                    <orgName type="display"  source="LC">St. Augustine's Abbey
-                        (Ramsgate, England)</orgName>
-                    <orgName type="crossref"  source="DNB">Abbaye
-                        Saint-Augustin, Ramsgate</orgName>
-                    <orgName type="variant"  source="DNB">Abbaye de
-                        Saint-Augustin, Ramsgate</orgName>
-                    <orgName type="variant"  source="DNB">Abbey Saint Augustin,
-                        Ramsgate</orgName>
-                    <orgName type="variant"  source="DNB">Abbey,
-                        Ramsgate</orgName>
-                    <orgName type="crossref"  source="DNB">Bénédictins de
-                        Ramsgate</orgName>
-                    <orgName type="variant"  source="DNB">St. Augustine's Abbey,
-                        Ramsgate</orgName>
-                    <note type="links">
-                        <list type="links">
-                            <item>
-                                <ref target="http://d-nb.info/gnd/5046701-3">
-                                    <title>GND</title>
-                                </ref>
-                            </item>
-                            <item>
-                                <ref target="http://id.loc.gov/authorities/names/n85375980">
-                                    <title>LC</title>
-                                </ref>
-                            </item>
-                            <item>
-                                <ref target="http://www.idref.fr/030809770/id">
-                                    <title>SUDOC</title>
-                                </ref>
-                            </item>
-                            <item>
-                                <ref target="http://catalogue.bnf.fr/ark:/12148/cb12215008z">
-                                    <title>BNF</title>
-                                </ref>
-                            </item>
-                            <item>
-                                <ref target="https://viaf.org/viaf/140674505">
-                                    <title>VIAF</title>
-                                </ref>
-                            </item>
-                        </list>
-                    </note>
-                </org>-->
+                       <!-\- deprecated: no longer used. w -\->
+                       <!-\- record originally created from https://viaf.org/viaf/140674505/viaf.xml at 2017-05-09 11:29:20.094807 -\->
+                       <orgName type="display"  source="LC">St. Augustine's Abbey
+                           (Ramsgate, England)</orgName>
+                       <orgName type="crossref"  source="DNB">Abbaye
+                           Saint-Augustin, Ramsgate</orgName>
+                       <orgName type="variant"  source="DNB">Abbaye de
+                           Saint-Augustin, Ramsgate</orgName>
+                       <orgName type="variant"  source="DNB">Abbey Saint Augustin,
+                           Ramsgate</orgName>
+                       <orgName type="variant"  source="DNB">Abbey,
+                           Ramsgate</orgName>
+                       <orgName type="crossref"  source="DNB">Bénédictins de
+                           Ramsgate</orgName>
+                       <orgName type="variant"  source="DNB">St. Augustine's Abbey,
+                           Ramsgate</orgName>
+                       <note type="links">
+                            <list type="links">
+                               <item>
+                                   <ref target="http://d-nb.info/gnd/5046701-3">
+                                       <title>GND</title>
+                                   </ref>
+                               </item>
+                               <item>
+                                   <ref target="http://id.loc.gov/authorities/names/n85375980">
+                                       <title>LC</title>
+                                   </ref>
+                               </item>
+                               <item>
+                                   <ref target="http://www.idref.fr/030809770/id">
+                                       <title>SUDOC</title>
+                                   </ref>
+                               </item>
+                               <item>
+                                   <ref target="http://catalogue.bnf.fr/ark:/12148/cb12215008z">
+                                       <title>BNF</title>
+                                   </ref>
+                               </item>
+                               <item>
+                                   <ref target="https://viaf.org/viaf/140674505">
+                                       <title>VIAF</title>
+                                   </ref>
+                               </item>
+                            </list>
+                       </note>
+                   </org>-->
                 <org xml:id="org_148042626">
                     <!-- record originally created from https://viaf.org/viaf/148042626/viaf.xml at 2017-05-09 11:31:11.199007 -->
-                    <orgName type="display"  source="bodl">Saint-Laumer de Blois,
-                            <affiliation>Benedictine</affiliation> abbey</orgName>
-                    <orgName type="variant"  source="SUDOC">Abbaye de Bénédictins
-                        (Blois ; Saint-Laumer) (0874-179.)</orgName>
-                    <orgName type="variant"  source="SUDOC">Abbaye de
-                        Saint-Laumer de Blois</orgName>
-                    <orgName type="variant"  source="SUDOC">Abbaye de Saint-Lomer
-                        de Blois</orgName>
+                    <orgName type="display" source="bodl">Saint-Laumer de Blois, <affiliation>Benedictine</affiliation> abbey</orgName>
+                    <orgName type="variant" source="SUDOC">Abbaye de Bénédictins (Blois ; Saint-Laumer) (0874-179.)</orgName>
+                    <orgName type="variant" source="SUDOC">Abbaye de Saint-Laumer de Blois</orgName>
+                    <orgName type="variant" source="SUDOC">Abbaye de Saint-Lomer de Blois</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -10935,31 +11344,21 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_172327788">
                     <!-- record originally created from https://viaf.org/viaf/172327788/viaf.xml at 2017-05-09 12:11:52.176799 -->
-                    <orgName type="display"  source="bodl">Ghent,
-                        Sint-Pietersabdij, <affiliation>Benedictine</affiliation> abbey</orgName>
-                    <orgName type="crossref"  source="LC">Abbatia Sancti-Petri
-                        Blandiniensis</orgName>
-                    <orgName type="variant"  source="LC">Abbaye Saint-Pierre
-                        (Ghent, Belgium)</orgName>
-                    <orgName type="variant"  source="LC">Abbaye de Blandin</orgName>
-                    <orgName type="variant"  source="LC">Abbaye de Saint-Pierre
-                        (Ghent, Belgium)</orgName>
-                    <orgName type="crossref" subtype="surnameFirst" source="LC">Ghent (Belgium).,
-                        Sint-Pietersabdij</orgName>
-                    <orgName type="variant" subtype="surnameFirst" source="LC">Ghent., Saint-Pierre
-                        (Benedictine abbey)</orgName>
-                    <orgName type="variant"  source="LC">Saint Peter (Abbey :
-                        Ghent, Belgium)</orgName>
-                    <orgName type="variant"  source="LC">Saint Peters (Abbey :
-                        Ghent, Belgium)</orgName>
-                    <orgName type="variant"  source="LC">Saint-Pierre (Abbey :
-                        Ghent, Belgium)</orgName>
-                    <orgName type="variant"  source="LC">Saint-Pierre au Mont
-                        Blandin à Gand (Abbey)</orgName>
-                    <orgName type="variant"  source="LC">Saint-Pierre de Gand
-                        (Abbey)</orgName>
+                    <orgName type="display" source="bodl">Ghent, Sint-Pietersabdij, <affiliation>Benedictine</affiliation> abbey</orgName>
+                    <orgName type="crossref" source="LC">Abbatia Sancti-Petri Blandiniensis</orgName>
+                    <orgName type="variant" source="LC">Abbaye Saint-Pierre (Ghent, Belgium)</orgName>
+                    <orgName type="variant" source="LC">Abbaye de Blandin</orgName>
+                    <orgName type="variant" source="LC">Abbaye de Saint-Pierre (Ghent, Belgium)</orgName>
+                    <orgName type="crossref" subtype="surnameFirst" source="LC">Ghent (Belgium)., Sint-Pietersabdij</orgName>
+                    <orgName type="variant" subtype="surnameFirst" source="LC">Ghent., Saint-Pierre (Benedictine abbey)</orgName>
+                    <orgName type="variant" source="LC">Saint Peter (Abbey : Ghent, Belgium)</orgName>
+                    <orgName type="variant" source="LC">Saint Peters (Abbey : Ghent, Belgium)</orgName>
+                    <orgName type="variant" source="LC">Saint-Pierre (Abbey : Ghent, Belgium)</orgName>
+                    <orgName type="variant" source="LC">Saint-Pierre au Mont Blandin à Gand (Abbey)</orgName>
+                    <orgName type="variant" source="LC">Saint-Pierre de Gand (Abbey)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -10985,14 +11384,14 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_143145136">
+<!-- ***** Old VIAF ID now redirects to 173026705 ***** -->
                     <!-- incorporates 173026705 -->
                     <!-- record originally created from https://viaf.org/viaf/143145136/viaf.xml at 2017-05-09 12:12:42.035038 -->
-                    <orgName type="display"  source="bodl">Fountains Abbey
-                            (<affiliation>Cistercian</affiliation>)</orgName>
-                    <orgName type="variant"  source="LC">Fountains Abbey</orgName>
-                    <orgName type="variant"  source="LC">Fountains Abbey (West
-                        Riding of Yorkshire, England)</orgName>
+                    <orgName type="display" source="bodl">Fountains Abbey (<affiliation>Cistercian</affiliation>)</orgName>
+                    <orgName type="variant" source="LC">Fountains Abbey</orgName>
+                    <orgName type="variant" source="LC">Fountains Abbey (West Riding of Yorkshire, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -11020,16 +11419,20 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/173026705">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_155912077">
                     <!-- record originally created from https://viaf.org/viaf/155912077/viaf.xml at 2017-05-09 12:20:14.330454 -->
-                    <orgName type="display"  source="LC bodl">Steinfeld (in
-                        Kall), <affiliation>Premonstratensian</affiliation> abbey</orgName>
-                    <orgName type="crossref"  source="LC">Abtei Steinfeld</orgName>
-                    <orgName type="crossref"  source="LC">Prämonstratenserabtei
-                        Steinfeld</orgName>
+                    <orgName type="display" source="LC bodl">Steinfeld (in Kall), <affiliation>Premonstratensian</affiliation> abbey</orgName>
+                    <orgName type="crossref" source="LC">Abtei Steinfeld</orgName>
+                    <orgName type="crossref" source="LC">Prämonstratenserabtei Steinfeld</orgName>
                     <location source="http://klosterdatenbank.germania-sacra.de/gsn/50357">
                         <geo>50.5025,6.5638888888889</geo>
                     </location>
@@ -11053,15 +11456,12 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_313493631">
                     <!-- record originally created from https://viaf.org/viaf/313493631/viaf.xml at 2017-05-09 12:25:02.900254 -->
-                    <orgName type="display"  source="LC">Faversham,
-                            <affiliation>Cluniac</affiliation> (later
-                            <affiliation>Benedictine</affiliation>) Abbey</orgName>
-                    <orgName type="crossref"  source="LC">Saint Saviours Abbey
-                        (Faversham, England)</orgName>
-                    <orgName type="variant"  source="LC">St. Saviours Abbey
-                        (Faversham, England)</orgName>
+                    <orgName type="display" source="LC">Faversham, <affiliation>Cluniac</affiliation> (later <affiliation>Benedictine</affiliation>) Abbey</orgName>
+                    <orgName type="crossref" source="LC">Saint Saviours Abbey (Faversham, England)</orgName>
+                    <orgName type="variant" source="LC">St. Saviours Abbey (Faversham, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -11077,19 +11477,17 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_205808165">
                     <!-- record originally created from https://viaf.org/viaf/205808165/viaf.xml at 2017-05-09 12:25:20.341054 -->
-                    <orgName type="display"  source="abbey">London,
-                            <affiliation>Cistercian</affiliation> Abbey of St Mary Graces</orgName>
-                    <orgName type="variant"  source="DNB">Cistercian Abbey of St.
-                        Mary Graces</orgName>
-                    <orgName type="crossref"  source="DNB">Eastminster</orgName>
-                    <orgName type="variant"  source="DNB">Eastminster Abbey</orgName>
-                    <orgName type="crossref"  source="DNB">Kloster Saint Mary
-                        Graces London</orgName>
-                    <orgName type="crossref"  source="DNB">St. Mary Grace's Abbey</orgName>
-                    <orgName type="variant"  source="DNB">St. Mary Graces</orgName>
-                    <orgName type="variant"  source="DNB">St. Mary de Graces</orgName>
+                    <orgName type="display" source="abbey">London, <affiliation>Cistercian</affiliation> Abbey of St Mary Graces</orgName>
+                    <orgName type="variant" source="DNB">Cistercian Abbey of St. Mary Graces</orgName>
+                    <orgName type="crossref" source="DNB">Eastminster</orgName>
+                    <orgName type="variant" source="DNB">Eastminster Abbey</orgName>
+                    <orgName type="crossref" source="DNB">Kloster Saint Mary Graces London</orgName>
+                    <orgName type="crossref" source="DNB">St. Mary Grace's Abbey</orgName>
+                    <orgName type="variant" source="DNB">St. Mary Graces</orgName>
+                    <orgName type="variant" source="DNB">St. Mary de Graces</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -11115,11 +11513,11 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_121821230">
                     <!-- record originally created from https://viaf.org/viaf/121821230/viaf.xml at 2017-05-09 12:25:47.703454 -->
-                    <orgName type="display"  source="LC bodl">Ramsey,
-                            <affiliation>Benedictine</affiliation> Abbey</orgName>
-                    <orgName type="crossref"  source="DNB">Abbatia Rameseiensis</orgName>
+                    <orgName type="display" source="LC bodl">Ramsey, <affiliation>Benedictine</affiliation> Abbey</orgName>
+                    <orgName type="crossref" source="DNB">Abbatia Rameseiensis</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -11152,19 +11550,21 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000106563793">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_145388823">
                     <!-- record originally created from https://viaf.org/viaf/145388823/viaf.xml at 2017-05-09 12:25:56.486254 -->
-                    <orgName type="display"  source="LC bodl">Shrewsbury,
-                            <affiliation>Benedictine</affiliation> Abbey of St. Peter and St. Paul</orgName>
-                    <orgName type="variant"  source="LC">Abbey of Saint Peter and
-                        Saint Paul (Shrewsbury, England)</orgName>
-                    <orgName type="crossref"  source="LC">Shrewsbury Abbey
-                        (Shrewsbury, England)</orgName>
-                    <orgName type="variant" subtype="surnameFirst" source="LC">Shrewsbury, Eng.,
-                        Abbey of St. Peter and St. Paul</orgName>
+                    <orgName type="display" source="LC bodl">Shrewsbury, <affiliation>Benedictine</affiliation> Abbey of St. Peter and St. Paul</orgName>
+                    <orgName type="variant" source="LC">Abbey of Saint Peter and Saint Paul (Shrewsbury, England)</orgName>
+                    <orgName type="crossref" source="LC">Shrewsbury Abbey (Shrewsbury, England)</orgName>
+                    <orgName type="variant" subtype="surnameFirst" source="LC">Shrewsbury, Eng., Abbey of St. Peter and St. Paul</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -11182,15 +11582,19 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q2507390">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_134950157">
                     <!-- record originally created from https://viaf.org/viaf/134950157/viaf.xml at 2017-05-09 12:33:49.343021 -->
-                    <orgName type="display"  source="LC bodl">Selby,
-                            <affiliation>Benedictine</affiliation> Abbey</orgName>
-                    <orgName type="variant" subtype="surnameFirst" source="LC">Selby (England).,
-                        Selby Abbey</orgName>
+                    <orgName type="display" source="LC bodl">Selby, <affiliation>Benedictine</affiliation> Abbey</orgName>
+                    <orgName type="variant" subtype="surnameFirst" source="LC">Selby (England)., Selby Abbey</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -11206,10 +11610,10 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_138242961">
                     <!-- record originally created from https://viaf.org/viaf/138242961/viaf.xml at 2017-05-09 12:37:31.423652 -->
-                    <orgName type="display"  source="LC bodl">London, Syon Abbey
-                            (<affiliation>Bridgettine</affiliation>)</orgName>
+                    <orgName type="display" source="LC bodl">London, Syon Abbey (<affiliation>Bridgettine</affiliation>)</orgName>
                     <orgName type="crossref">Syon Abbey</orgName>
                     <note type="links">
                         <list type="links">
@@ -11248,23 +11652,24 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q17533562">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_133214228">
                     <!-- record originally created from https://viaf.org/viaf/133214228/viaf.xml at 2017-05-09 12:40:24.655397 -->
-                    <orgName type="display"  source="LC bodl">Eberbach,
-                            <affiliation>Cistercian</affiliation> Abbey of the Virgin Mary</orgName>
-                    <orgName type="variant" subtype="surnameFirst" source="LC">Eberbach (Germany).,
-                        Abtei Eberbach</orgName>
-                    <orgName type="variant"  source="LC">Eberbach, Ger.
-                        (Cistercian abbey)</orgName>
-                    <orgName type="crossref"  source="LC">Kloster Eberbach</orgName>
-                    <orgName type="crossref"  source="LC">Zisterzienskloster
-                        Eberbach</orgName>
+                    <orgName type="display" source="LC bodl">Eberbach, <affiliation>Cistercian</affiliation> Abbey of the Virgin Mary</orgName>
+                    <orgName type="variant" subtype="surnameFirst" source="LC">Eberbach (Germany)., Abtei Eberbach</orgName>
+                    <orgName type="variant" source="LC">Eberbach, Ger. (Cistercian abbey)</orgName>
+                    <orgName type="crossref" source="LC">Kloster Eberbach</orgName>
+                    <orgName type="crossref" source="LC">Zisterzienskloster Eberbach</orgName>
                     <note type="links">
                         <list type="links">
-                            
                             <item>
                                 <ref target="http://d-nb.info/gnd/805130-6">
                                     <title>DNB</title>
@@ -11293,12 +11698,11 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_144397095">
                     <!-- record originally created from https://viaf.org/viaf/144397095/viaf.xml at 2017-05-09 12:42:10.727597 -->
-                    <orgName type="display"  source="LC">Dore,
-                            <affiliation>Cistercian</affiliation> Abbey</orgName>
-                    <orgName type="crossref"  source="LC">Abbey Dore
-                        (Herefordshire, England)</orgName>
+                    <orgName type="display" source="LC">Dore, <affiliation>Cistercian</affiliation> Abbey</orgName>
+                    <orgName type="crossref" source="LC">Abbey Dore (Herefordshire, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -11314,18 +11718,15 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_154518343">
                     <!-- record originally created from https://viaf.org/viaf/154518343/viaf.xml at 2017-05-09 12:44:08.937397 -->
-                    <orgName type="crossref"  source="LC">Stift Melk</orgName>
-                    <orgName type="variant"  source="LC">Benediktinerstift Melk
-                        a.d. Donau/N.Ö.</orgName>
-                    <orgName type="variant"  source="LC">Kloster Melk</orgName>
-                    <orgName type="crossref" subtype="surnameFirst" source="LC">Melk (Austria).,
-                        Stift</orgName>
-                    <orgName type="display"  source="LC">Melk,
-                            <affiliation>Benedictine</affiliation> Abbey</orgName>
-                    <orgName type="variant"  source="LC">Melk, Austria
-                        (Benedictine monastery)</orgName>
+                    <orgName type="crossref" source="LC">Stift Melk</orgName>
+                    <orgName type="variant" source="LC">Benediktinerstift Melk a.d. Donau/N.Ö.</orgName>
+                    <orgName type="variant" source="LC">Kloster Melk</orgName>
+                    <orgName type="crossref" subtype="surnameFirst" source="LC">Melk (Austria)., Stift</orgName>
+                    <orgName type="display" source="LC">Melk, <affiliation>Benedictine</affiliation> Abbey</orgName>
+                    <orgName type="variant" source="LC">Melk, Austria (Benedictine monastery)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -11353,13 +11754,18 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000110919908">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_127695584">
                     <!-- record originally created from https://viaf.org/viaf/127695584/viaf.xml at 2017-05-09 12:44:43.213397 -->
-                    <orgName type="display"  source="LC bodl">Barking,
-                            <affiliation>Benedictine</affiliation> Abbey</orgName>
+                    <orgName type="display" source="LC bodl">Barking, <affiliation>Benedictine</affiliation> Abbey</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -11385,14 +11791,13 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_148894515">
                     <!-- record originally created from https://viaf.org/viaf/148894515/viaf.xml at 2017-05-09 12:44:51.425397 -->
-                    <orgName type="display"  source="LC bodl">St. Albans,
-                            <affiliation>Benedictine</affiliation> Abbey</orgName>
-                    <orgName type="crossref"  source="DNB">Abbey, Saint Albans</orgName>
-                    <orgName type="crossref"  source="DNB">Monastery, Saint
-                        Albans</orgName>
-                    <orgName type="variant"  source="DNB">Saint Albans Abbey</orgName>
+                    <orgName type="display" source="LC bodl">St. Albans, <affiliation>Benedictine</affiliation> Abbey</orgName>
+                    <orgName type="crossref" source="DNB">Abbey, Saint Albans</orgName>
+                    <orgName type="crossref" source="DNB">Monastery, Saint Albans</orgName>
+                    <orgName type="variant" source="DNB">Saint Albans Abbey</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -11425,15 +11830,19 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000100153216">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_211447911">
                     <!-- record originally created from https://viaf.org/viaf/211447911/viaf.xml at 2017-05-09 12:45:33.478095 -->
-                    <orgName type="display"  source="DNB">Cirencester,
-                            <affiliation>Augustinian</affiliation> Abbey</orgName>
-                    <orgName type="crossref"  source="DNB">Abbey,
-                        Cirencester</orgName>
+                    <orgName type="display" source="DNB">Cirencester, <affiliation>Augustinian</affiliation> Abbey</orgName>
+                    <orgName type="crossref" source="DNB">Abbey, Cirencester</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -11456,13 +11865,18 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="https://catalogue.bnf.fr/ark:/12148/cb11580871j">
+                                    <title>BNF</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_315944440">
                     <!-- record originally created from https://viaf.org/viaf/315944440/viaf.xml at 2017-05-09 10:50:44.068528 -->
-                    <orgName type="display"  source="LC">Chertsey,
-                            <affiliation>Benedictine</affiliation> Abbey</orgName>
+                    <orgName type="display" source="LC">Chertsey, <affiliation>Benedictine</affiliation> Abbey</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -11488,12 +11902,11 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_134870077">
                     <!-- record originally created from https://viaf.org/viaf/134870077/viaf.xml at 2017-05-09 11:23:02.840607 -->
-                    <orgName type="display"  source="LC">Glastonbury,
-                            <affiliation>Benedictine</affiliation> Abbey</orgName>
-                    <orgName type="variant" subtype="surnameFirst" source="LC">Glastonbury
-                        (England)., Glastonbury Abbey</orgName>
+                    <orgName type="display" source="LC">Glastonbury, <affiliation>Benedictine</affiliation> Abbey</orgName>
+                    <orgName type="variant" subtype="surnameFirst" source="LC">Glastonbury (England)., Glastonbury Abbey</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -11524,16 +11937,13 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_124540557">
                     <!-- record originally created from https://viaf.org/viaf/124540557/viaf.xml at 2017-05-09 11:23:05.430207 -->
-                    <orgName type="display"  source="LC bodl">Tewkesbury,
-                            <affiliation>Benedictine</affiliation> Abbey</orgName>
-                    <orgName type="crossref"  source="LC">Abbey Church of St.
-                        Mary the Virgin (Tewkesbury, England)</orgName>
-                    <orgName type="crossref"  source="LC">St. Mary (Tewkesbury,
-                        England)</orgName>
-                    <orgName type="variant"  source="LC">St. Mary the Virgin
-                        Abbey Church (Tewkesbury, England)</orgName>
+                    <orgName type="display" source="LC bodl">Tewkesbury, <affiliation>Benedictine</affiliation> Abbey</orgName>
+                    <orgName type="crossref" source="LC">Abbey Church of St. Mary the Virgin (Tewkesbury, England)</orgName>
+                    <orgName type="crossref" source="LC">St. Mary (Tewkesbury, England)</orgName>
+                    <orgName type="variant" source="LC">St. Mary the Virgin Abbey Church (Tewkesbury, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -11549,24 +11959,17 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_147036231">
                     <!-- record originally created from https://viaf.org/viaf/147036231/viaf.xml at 2017-05-09 11:27:49.396407 -->
-                    <orgName type="crossref"  source="LC">St. Peter's Abbey
-                        (Gloucester, England)</orgName>
-                    <orgName type="crossref"  source="LC">Abbey of Gloucester
-                        (Gloucester, England)</orgName>
-                    <orgName type="variant"  source="LC">Abbey of St. Peter
-                        Gloucester (Gloucester, England)</orgName>
-                    <orgName type="display"  source="LC">Gloucester,
-                            <affiliation>Benedictine</affiliation> Abbey of St. Peter</orgName>
-                    <orgName type="crossref"  source="LC">Monastery of St. Peter
-                        Gloucester (Gloucester, England)</orgName>
-                    <orgName type="variant"  source="LC">S. Peter's Abbey
-                        (Gloucester, England)</orgName>
-                    <orgName type="variant"  source="LC">Saint Peter's Abbey
-                        (Gloucester, England)</orgName>
-                    <orgName type="variant"  source="LC">St. Peter's Gloucester
-                        (Gloucester, England)</orgName>
+                    <orgName type="crossref" source="LC">St. Peter's Abbey (Gloucester, England)</orgName>
+                    <orgName type="crossref" source="LC">Abbey of Gloucester (Gloucester, England)</orgName>
+                    <orgName type="variant" source="LC">Abbey of St. Peter Gloucester (Gloucester, England)</orgName>
+                    <orgName type="display" source="LC">Gloucester, <affiliation>Benedictine</affiliation> Abbey of St. Peter</orgName>
+                    <orgName type="crossref" source="LC">Monastery of St. Peter Gloucester (Gloucester, England)</orgName>
+                    <orgName type="variant" source="LC">S. Peter's Abbey (Gloucester, England)</orgName>
+                    <orgName type="variant" source="LC">Saint Peter's Abbey (Gloucester, England)</orgName>
+                    <orgName type="variant" source="LC">St. Peter's Gloucester (Gloucester, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -11582,14 +11985,12 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_142884282">
                     <!-- record originally created from https://viaf.org/viaf/142884282/viaf.xml at 2017-05-09 11:31:49.029007 -->
-                    <orgName type="display"  source="LC bodl">Monteoliveto
-                        Maggiore, <affiliation>Benedictine</affiliation> Abbey</orgName>
-                    <orgName type="crossref"  source="DNB">Abbazia Monte Oliveto
-                        Maggiore, Siena</orgName>
-                    <orgName type="variant"  source="DNB">Monte Oliveto Maggiore,
-                        Siena</orgName>
+                    <orgName type="display" source="LC bodl">Monteoliveto Maggiore, <affiliation>Benedictine</affiliation> Abbey</orgName>
+                    <orgName type="crossref" source="DNB">Abbazia Monte Oliveto Maggiore, Siena</orgName>
+                    <orgName type="variant" source="DNB">Monte Oliveto Maggiore, Siena</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -11622,17 +12023,26 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/000000012293438X">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/no2008010466">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_128466393">
                     <!-- record originally created from https://viaf.org/viaf/128466393/viaf.xml at 2017-05-09 11:34:40.800607 -->
-                    <orgName type="crossref"  source="LC">Stift Admont</orgName>
-                    <orgName type="display"  source="LC">Admont, Austria,
-                            <affiliation>Benedictine</affiliation> abbey</orgName>
-                    <orgName type="crossref"  source="LC">Benediktinerstift
-                        Admont</orgName>
-                    <orgName type="crossref"  source="LC">Klöster Admont</orgName>
+                    <orgName type="crossref" source="LC">Stift Admont</orgName>
+                    <orgName type="display" source="LC">Admont, Austria, <affiliation>Benedictine</affiliation> abbey</orgName>
+                    <orgName type="crossref" source="LC">Benediktinerstift Admont</orgName>
+                    <orgName type="crossref" source="LC">Klöster Admont</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -11650,44 +12060,48 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000088374939">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 <!--
-                <org xml:id="org_173026705">
-                    <!-\- merged with 143145136 -\->
-                    <!-\- record originally created from https://viaf.org/viaf/173026705/viaf.xml at 2017-05-09 11:36:26.164007 -\->
-                    <orgName type="display" subtype="unknownOrder" source="DNB">Fountains
-                        Abbey</orgName>
-                    <note type="links">
-                        <list type="links">
-                            <item>
-                                <ref target="http://catalogue.bnf.fr/ark:/12148/cb120817724">
-                                    <title>BNF</title>
-                                </ref>
-                            </item>
-                            <item>
-                                <ref target="http://d-nb.info/gnd/4253283-8">
-                                    <title>GND</title>
-                                </ref>
-                            </item>
-                            <item>
-                                <ref target="http://www.wikidata.org/entity/Q540237">
-                                    <title>Wikidata</title>
-                                </ref>
-                            </item>
-                            <item>
-                                <ref target="https://viaf.org/viaf/173026705">
-                                    <title>VIAF</title>
-                                </ref>
-                            </item>
-                        </list>
-                    </note>
-                </org>-->
+                   <org xml:id="org_173026705">
+                       <!-\- merged with 143145136 -\->
+                       <!-\- record originally created from https://viaf.org/viaf/173026705/viaf.xml at 2017-05-09 11:36:26.164007 -\->
+                       <orgName type="display" subtype="unknownOrder" source="DNB">Fountains
+                           Abbey</orgName>
+                       <note type="links">
+                            <list type="links">
+                               <item>
+                                   <ref target="http://catalogue.bnf.fr/ark:/12148/cb120817724">
+                                       <title>BNF</title>
+                                   </ref>
+                               </item>
+                               <item>
+                                   <ref target="http://d-nb.info/gnd/4253283-8">
+                                       <title>GND</title>
+                                   </ref>
+                               </item>
+                               <item>
+                                   <ref target="http://www.wikidata.org/entity/Q540237">
+                                       <title>Wikidata</title>
+                                   </ref>
+                               </item>
+                               <item>
+                                   <ref target="https://viaf.org/viaf/173026705">
+                                       <title>VIAF</title>
+                                   </ref>
+                               </item>
+                            </list>
+                       </note>
+                   </org>-->
                 <org xml:id="org_146807988">
                     <!-- record originally created from https://viaf.org/viaf/146807988/viaf.xml at 2017-05-09 12:10:32.833607 -->
-                    <orgName type="display"  source="LC bodl">Rewley (Oxford),
-                            <affiliation>Cistercian</affiliation> Abbey</orgName>
+                    <orgName type="display" source="LC bodl">Rewley (Oxford), <affiliation>Cistercian</affiliation> Abbey</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -11703,10 +12117,10 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_126774688">
                     <!-- record originally created from https://viaf.org/viaf/126774688/viaf.xml at 2017-05-09 12:11:02.724207 -->
-                    <orgName type="display"  source="LC bodl">Darley,
-                            <affiliation>Augustinian</affiliation> Abbey</orgName>
+                    <orgName type="display" source="LC bodl">Darley, <affiliation>Augustinian</affiliation> Abbey</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -11722,16 +12136,13 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_135872409">
                     <!-- record originally created from https://viaf.org/viaf/135872409/viaf.xml at 2017-05-09 12:42:44.314397 -->
-                    <orgName type="display"  source="LC bodl">Constance, Council
-                        of (1414-1418)</orgName>
-                    <orgName type="variant"  source="DNB">Concilium
-                        Constanciense, 1414-1418</orgName>
-                    <orgName type="variant"  source="DNB">Concilium
-                        Constantiense, 1414-1418</orgName>
-                    <orgName type="variant"  source="DNB">Konzil, 1414-1418,
-                        Konstanz</orgName>
+                    <orgName type="display" source="LC bodl">Constance, Council of (1414-1418)</orgName>
+                    <orgName type="variant" source="DNB">Concilium Constanciense, 1414-1418</orgName>
+                    <orgName type="variant" source="DNB">Concilium Constantiense, 1414-1418</orgName>
+                    <orgName type="variant" source="DNB">Konzil, 1414-1418, Konstanz</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -11764,6 +12175,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000121640013">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -11771,14 +12187,10 @@
                 <!-- 1780 -->
                 <org xml:id="org_123972117">
                     <!-- record originally created from https://viaf.org/viaf/123972117/viaf.xml at 2017-05-09 11:30:34.710607 -->
-                    <orgName type="crossref"  source="LC">Signet Library (Great
-                        Britain)</orgName>
-                    <orgName type="display"  source="bodl">Edinburgh, Library of
-                        the Society of Writers to H. M. Signet</orgName>
-                    <orgName type="variant"  source="DNB">Society of Writers to
-                        His Majesty's Signet, Library</orgName>
-                    <orgName type="variant"  source="DNB">Society of Writers to
-                        His Majesty's Signet, Signet Library</orgName>
+                    <orgName type="crossref" source="LC">Signet Library (Great Britain)</orgName>
+                    <orgName type="display" source="bodl">Edinburgh, Library of the Society of Writers to H. M. Signet</orgName>
+                    <orgName type="variant" source="DNB">Society of Writers to His Majesty's Signet, Library</orgName>
+                    <orgName type="variant" source="DNB">Society of Writers to His Majesty's Signet, Signet Library</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -11796,6 +12208,16 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000106810272">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q17570649">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -11803,7 +12225,7 @@
                 <!-- 2026 -->
                 <org xml:id="org_128555824">
                     <!-- record originally created from https://viaf.org/viaf/128555824/viaf.xml at 2017-05-09 12:10:10.572407 -->
-                    <orgName type="display"  source="LC">Bristol, Baptist College</orgName>
+                    <orgName type="display" source="LC">Bristol, Baptist College</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -11821,6 +12243,16 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000106843648">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q26514873">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -11828,14 +12260,10 @@
                 <!-- 2132 -->
                 <org xml:id="org_167567629">
                     <!-- record originally created from https://viaf.org/viaf/167567629/viaf.xml at 2017-05-09 12:15:07.429902 -->
-                    <orgName type="display"  source="bodl">Louvain, Park
-                        abbey</orgName>
-                    <orgName type="crossref"  source="LC">Abdij van Park (Park,
-                        Heverlee, Belgium)</orgName>
-                    <orgName type="variant"  source="DNB">Abdij van 't Park,
-                        Löwen</orgName>
-                    <orgName type="variant"  source="DNB">Abdij van Park,
-                        Heverlee</orgName>
+                    <orgName type="display" source="bodl">Louvain, Park abbey</orgName>
+                    <orgName type="crossref" source="LC">Abdij van Park (Park, Heverlee, Belgium)</orgName>
+                    <orgName type="variant" source="DNB">Abdij van 't Park, Löwen</orgName>
+                    <orgName type="variant" source="DNB">Abdij van Park, Heverlee</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -11868,6 +12296,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/000000012116095X">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -11875,22 +12308,15 @@
                 <!-- 2419 -->
                 <org xml:id="org_147193963">
                     <!-- record originally created from https://viaf.org/viaf/147193963/viaf.xml at 2017-05-09 12:28:31.144782 -->
-                    <orgName type="display"  source="LC bodl">Basel, Council of
-                        (1431-1449)</orgName>
-                    <orgName type="variant"  source="DNB">Basler Konzil,
-                        Ehemalige Vorzugsbenennung SWD</orgName>
-                    <orgName type="variant"  source="DNB">Concilio ecumenico
-                        Fiorentino</orgName>
-                    <orgName type="variant"  source="DNB">Concilium</orgName>
-                    <orgName type="variant"  source="DNB">Concilium Basileense,
-                        1431-1449</orgName>
-                    <orgName type="variant"  source="DNB">Concilium Basiliense,
-                        1431-1449</orgName>
-                    <orgName type="variant"  source="DNB">Concilium Florentinum</orgName>
-                    <orgName type="variant"  source="DNB">Concilium, 1431-1449,
-                        Basel</orgName>
-                    <orgName type="variant"  source="DNB">Konzil, 1431-1449,
-                        Basel</orgName>
+                    <orgName type="display" source="LC bodl">Basel, Council of (1431-1449)</orgName>
+                    <orgName type="variant" source="DNB">Basler Konzil, Ehemalige Vorzugsbenennung SWD</orgName>
+                    <orgName type="variant" source="DNB">Concilio ecumenico Fiorentino</orgName>
+                    <orgName type="variant" source="DNB">Concilium</orgName>
+                    <orgName type="variant" source="DNB">Concilium Basileense, 1431-1449</orgName>
+                    <orgName type="variant" source="DNB">Concilium Basiliense, 1431-1449</orgName>
+                    <orgName type="variant" source="DNB">Concilium Florentinum</orgName>
+                    <orgName type="variant" source="DNB">Concilium, 1431-1449, Basel</orgName>
+                    <orgName type="variant" source="DNB">Konzil, 1431-1449, Basel</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -11923,25 +12349,24 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000107257798">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 <!-- 1640 -->
                 <org xml:id="org_246265108">
                     <!-- record originally created from https://viaf.org/viaf/246265108/viaf.xml at 2017-05-09 11:23:53.930607 -->
-                    <orgName type="display"  source="DNB bodl">Sankt Goar,
-                        Abbey</orgName>
-                    <orgName type="crossref"  source="DNB">Chorherrenstift St.
-                        Goar</orgName>
-                    <orgName type="crossref"  source="DNB">Evangelisches Stift
-                        Sankt Goar</orgName>
-                    <orgName type="variant"  source="DNB">Evangelisches Stift St.
-                        Goar</orgName>
-                    <orgName type="variant"  source="DNB">Evangelisches Stift zu
-                        Sankt Goar</orgName>
-                    <orgName type="variant"  source="DNB">Evangelisches Stift zu
-                        St. Goar</orgName>
-                    <orgName type="variant"  source="DNB">Stift St. Goar</orgName>
+                    <orgName type="display" source="DNB bodl">Sankt Goar, Abbey</orgName>
+                    <orgName type="crossref" source="DNB">Chorherrenstift St. Goar</orgName>
+                    <orgName type="crossref" source="DNB">Evangelisches Stift Sankt Goar</orgName>
+                    <orgName type="variant" source="DNB">Evangelisches Stift St. Goar</orgName>
+                    <orgName type="variant" source="DNB">Evangelisches Stift zu Sankt Goar</orgName>
+                    <orgName type="variant" source="DNB">Evangelisches Stift zu St. Goar</orgName>
+                    <orgName type="variant" source="DNB">Stift St. Goar</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -11960,13 +12385,10 @@
                 <!-- 1641 -->
                 <org xml:id="org_125552867">
                     <!-- record originally created from https://viaf.org/viaf/125552867/viaf.xml at 2017-05-09 11:23:56.442207 -->
-                    <orgName type="display"  source="LC bodl">Fürstenfeld,
-                            <affiliation>Cistercian</affiliation> Abbey (Fürstenfeldbruck, Germany)</orgName>
-                    <orgName type="crossref"  source="DNB">Kloster Fürstenfeld,
-                        Fürstenfeldbruck</orgName>
-                    <orgName type="variant"  source="DNB">Zisterzienserkloster</orgName>
-                    <orgName type="variant"  source="DNB">Zisterzienserkloster,
-                        Fürstenfeld, Fürstenfeldbruck</orgName>
+                    <orgName type="display" source="LC bodl">Fürstenfeld, <affiliation>Cistercian</affiliation> Abbey (Fürstenfeldbruck, Germany)</orgName>
+                    <orgName type="crossref" source="DNB">Kloster Fürstenfeld, Fürstenfeldbruck</orgName>
+                    <orgName type="variant" source="DNB">Zisterzienserkloster</orgName>
+                    <orgName type="variant" source="DNB">Zisterzienserkloster, Fürstenfeld, Fürstenfeldbruck</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12005,8 +12427,7 @@
                 <!-- 2130 -->
                 <org xml:id="org_122361676">
                     <!-- record originally created from https://viaf.org/viaf/122361676/viaf.xml at 2017-05-09 12:15:01.065021 -->
-                    <orgName type="display"  source="LC">Hereford,
-                        Cathedral</orgName>
+                    <orgName type="display" source="LC">Hereford, Cathedral</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12029,18 +12450,20 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000081908168">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 <!-- 2169 -->
                 <org xml:id="org_127815410">
                     <!-- record originally created from https://viaf.org/viaf/127815410/viaf.xml at 2017-05-09 12:16:51.576254 -->
-                    <orgName type="display"  source="LC">Exeter,
-                        Cathedral</orgName>
-                    <orgName type="crossref"  source="LC">Cathedral Church of St.
-                        Peter, Exeter (Exeter, England)</orgName>
-                    <orgName type="crossref"  source="LC">St. Peter's Cathedral,
-                        Exeter (Exeter, England)</orgName>
+                    <orgName type="display" source="LC">Exeter, Cathedral</orgName>
+                    <orgName type="crossref" source="LC">Cathedral Church of St. Peter, Exeter (Exeter, England)</orgName>
+                    <orgName type="crossref" source="LC">St. Peter's Cathedral, Exeter (Exeter, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12058,13 +12481,18 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000087953189">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 <!-- 2184 -->
                 <org xml:id="org_144679410">
                     <!-- record originally created from https://viaf.org/viaf/144679410/viaf.xml at 2017-05-09 12:17:35.646254 -->
-                    <orgName type="display"  source="L bodl">Durham, <affiliation>Benedictine</affiliation> Cathedral Priory</orgName>
+                    <orgName type="display" source="L bodl">Durham, <affiliation>Benedictine</affiliation> Cathedral Priory</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12087,18 +12515,35 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000114113768">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/n50075775">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://catalogue.bnf.fr/ark:/12148/cb12207771x">
+                                    <title>BNF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q746207">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 <!-- 2208 -->
                 <org xml:id="org_131409984">
                     <!-- record originally created from https://viaf.org/viaf/131409984/viaf.xml at 2017-05-09 12:18:40.557854 -->
-                    <orgName type="display"  source="LC bodl">Venice, church of
-                        SS Giovanni e Paolo</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Chiesa degli Angeli
-                        Custodi, Ravenna</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Chiesa dei Santi
-                        Giovanni e Paolo, Ravenna</orgName>
+                    <orgName type="display" source="LC bodl">Venice, church of SS Giovanni e Paolo</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Chiesa degli Angeli Custodi, Ravenna</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Chiesa dei Santi Giovanni e Paolo, Ravenna</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12137,8 +12582,7 @@
                 <!-- 2242 -->
                 <org xml:id="org_138814996">
                     <!-- record originally created from https://viaf.org/viaf/138814996/viaf.xml at 2017-05-09 12:20:16.920054 -->
-                    <orgName type="display"  source="BAV bodl">Rome, church of
-                        San Saba</orgName>
+                    <orgName type="display" source="BAV bodl">Rome, church of San Saba</orgName>
                     <!-- no variants found in preferred sources -->
                     <note type="links">
                         <list type="links">
@@ -12154,7 +12598,7 @@
                 <!-- check: delete? -->
                 <org xml:id="org_126047237">
                     <!-- record originally created from https://viaf.org/viaf/126047237/viaf.xml at 2017-05-09 11:24:13.593007 -->
-                    <orgName type="display"  source="NLI">Lateran, Council, Lateran IV (1215)</orgName>
+                    <orgName type="display" source="NLI">Lateran, Council, Lateran IV (1215)</orgName>
                     <!-- no variants found in preferred sources -->
                     <note type="links">
                         <list type="links">
@@ -12169,9 +12613,8 @@
                 <!-- 1721 -->
                 <org xml:id="org_415145858126223022295">
                     <!-- record originally created from https://viaf.org/viaf/415145858126223022295/viaf.xml at 2017-05-09 11:27:46.806807 -->
-                    <orgName type="display"  source="DNB bodl">Erfurt,
-                            <affiliation>Carthusian</affiliation> abbey of St. Salvator</orgName>
-                    <orgName type="variant"  source="DNB">Kartäuserkloster</orgName>
+                    <orgName type="display" source="DNB bodl">Erfurt, <affiliation>Carthusian</affiliation> abbey of St. Salvator</orgName>
+                    <orgName type="variant" source="DNB">Kartäuserkloster</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12204,15 +12647,18 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q1734672">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 <!-- 1738 -->
                 <org xml:id="org_130206490">
                     <!-- record originally created from https://viaf.org/viaf/130206490/viaf.xml at 2017-05-09 11:28:35.463207 -->
-                    <orgName type="display"  source="LC bodl">Rome, church of
-                        Santa Cecilia in Trastevere</orgName>
+                    <orgName type="display" source="LC bodl">Rome, church of Santa Cecilia in Trastevere</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12244,9 +12690,9 @@
                     <orgName type="display" subtype="surnameFirst" source="LC">England, Parliament</orgName>
                     <orgName type="variant" subtype="surnameFirst" source="DNB">England, Parlament</orgName>
                     <orgName type="variant" subtype="surnameFirst" source="DNB">England, Parlement</orgName>
-                    <orgName type="crossref"  source="DNB">Parlament, England</orgName>
-                    <orgName type="variant"  source="DNB">Parlement, England</orgName>
-                    <orgName type="variant"  source="DNB">Parliament, England</orgName>
+                    <orgName type="crossref" source="DNB">Parlament, England</orgName>
+                    <orgName type="variant" source="DNB">Parlement, England</orgName>
+                    <orgName type="variant" source="DNB">Parliament, England</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12270,21 +12716,15 @@
                 <!-- 1773 -->
                 <org xml:id="org_245287151">
                     <!-- record originally created from https://viaf.org/viaf/245287151/viaf.xml at 2017-05-09 11:30:13.088007 -->
-                    <orgName type="display"  source="LC">Göttweig Abbey
-                            (<affiliation>Benedictine</affiliation>) (Steinaweg, Austria)</orgName>
-                    <orgName type="crossref"  source="DNB">Abtei Göttweig</orgName>
-                    <orgName type="variant"  source="DNB">Benediktiner Göttweig</orgName>
-                    <orgName type="variant"  source="DNB">Benediktinerabtei
-                        Göttweig</orgName>
-                    <orgName type="variant"  source="DNB">Benediktinerabtei,
-                        Göttweig, Ehemalige Vorzugsbenennung GKD</orgName>
-                    <orgName type="variant"  source="DNB">Benediktinerstift
-                        Göttweig, Unveraenderte Form</orgName>
-                    <orgName type="variant"  source="DNB">Benediktinerstift,
-                        Göttweig</orgName>
-                    <orgName type="variant"  source="DNB">Stift Göttweig,
-                        Unveraenderte Form</orgName>
-                    <orgName type="crossref"  source="DNB">Stift, Göttweig</orgName>
+                    <orgName type="display" source="LC">Göttweig Abbey (<affiliation>Benedictine</affiliation>) (Steinaweg, Austria)</orgName>
+                    <orgName type="crossref" source="DNB">Abtei Göttweig</orgName>
+                    <orgName type="variant" source="DNB">Benediktiner Göttweig</orgName>
+                    <orgName type="variant" source="DNB">Benediktinerabtei Göttweig</orgName>
+                    <orgName type="variant" source="DNB">Benediktinerabtei, Göttweig, Ehemalige Vorzugsbenennung GKD</orgName>
+                    <orgName type="variant" source="DNB">Benediktinerstift Göttweig, Unveraenderte Form</orgName>
+                    <orgName type="variant" source="DNB">Benediktinerstift, Göttweig</orgName>
+                    <orgName type="variant" source="DNB">Stift Göttweig, Unveraenderte Form</orgName>
+                    <orgName type="crossref" source="DNB">Stift, Göttweig</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12308,7 +12748,7 @@
                 <!-- 1776 -->
                 <org xml:id="org_158244517">
                     <!-- record originally created from https://viaf.org/viaf/158244517/viaf.xml at 2017-05-09 11:30:21.777207 -->
-                    <orgName type="display"  source="LC">Ely Cathedral</orgName>
+                    <orgName type="display" source="LC">Ely Cathedral</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12326,18 +12766,20 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000105567477">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 <!-- 1796 -->
                 <org xml:id="org_129065993">
                     <!-- record originally created from https://viaf.org/viaf/129065993/viaf.xml at 2017-05-09 11:31:19.576207 -->
-                    <orgName type="display" subtype="surnameFirst" source="LC">England and Wales.,
-                        Court of Wards and Liveries</orgName>
-                    <orgName type="crossref"  source="LC">Court of Wards and
-                        Liveries (England and Wales)</orgName>
-                    <orgName type="variant" subtype="surnameFirst" source="LC">England and Wales.,
-                        Court de Gards</orgName>
+                    <orgName type="display" subtype="surnameFirst" source="LC">England and Wales., Court of Wards and Liveries</orgName>
+                    <orgName type="crossref" source="LC">Court of Wards and Liveries (England and Wales)</orgName>
+                    <orgName type="variant" subtype="surnameFirst" source="LC">England and Wales., Court de Gards</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12355,20 +12797,21 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q1137766">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 <!-- 1825 -->
                 <org xml:id="org_145804112">
                     <!-- record originally created from https://viaf.org/viaf/145804112/viaf.xml at 2017-05-09 11:32:39.167407 -->
-                    <orgName type="display"  source="LC bodl">Great Yarmouth, St.
-                        Mary's Hospital</orgName>
-                    <orgName type="crossref"  source="LC">Hospital of Saint Mary
-                        (Great Yarmouth, England)</orgName>
-                    <orgName type="variant"  source="LC">Hospital of St. Mary
-                        (Great Yarmouth, England)</orgName>
-                    <orgName type="crossref"  source="LC">Saint Mary's Hospital
-                        (Great Yarmouth, England)</orgName>
+                    <orgName type="display" source="LC bodl">Great Yarmouth, St. Mary's Hospital</orgName>
+                    <orgName type="crossref" source="LC">Hospital of Saint Mary (Great Yarmouth, England)</orgName>
+                    <orgName type="variant" source="LC">Hospital of St. Mary (Great Yarmouth, England)</orgName>
+                    <orgName type="crossref" source="LC">Saint Mary's Hospital (Great Yarmouth, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12387,7 +12830,7 @@
                 <!-- 1874 -->
                 <org xml:id="org_243886719">
                     <!-- record originally created from https://viaf.org/viaf/243886719/viaf.xml at 2017-05-09 11:34:57.009007 -->
-                    <orgName type="display"  source="DNB">Snowshill Manor</orgName>
+                    <orgName type="display" source="DNB">Snowshill Manor</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12411,9 +12854,8 @@
                 <!-- 1883 -->
                 <org xml:id="org_240542197">
                     <!-- record originally created from https://viaf.org/viaf/240542197/viaf.xml at 2017-05-09 11:35:22.937207 -->
-                    <orgName type="display"  source="DNB bodl">Tückelhausen,
-                            <affiliation>Carthusian</affiliation> monastery (Ochsenfurt)</orgName>
-                    <orgName type="variant"  source="DNB">Kartause</orgName>
+                    <orgName type="display" source="DNB bodl">Tückelhausen, <affiliation>Carthusian</affiliation> monastery (Ochsenfurt)</orgName>
+                    <orgName type="variant" source="DNB">Kartause</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12437,12 +12879,9 @@
                 <!-- 1914 -->
                 <org xml:id="org_245037741">
                     <!-- record originally created from https://viaf.org/viaf/245037741/viaf.xml at 2017-05-09 11:36:48.830807 -->
-                    <orgName type="display"  source="DNB">Klarenthal, convent of
-                            <affiliation>Poor Clares</affiliation>
-                   </orgName>
-                    <orgName type="variant"  source="DNB">Klarissenkloster</orgName>
-                    <orgName type="variant"  source="DNB">Klarissenkloster
-                        Clarenthal</orgName>
+                    <orgName type="display" source="DNB">Klarenthal, convent of <affiliation>Poor Clares</affiliation> </orgName>
+                    <orgName type="variant" source="DNB">Klarissenkloster</orgName>
+                    <orgName type="variant" source="DNB">Klarissenkloster Clarenthal</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12466,16 +12905,11 @@
                 <!-- 1925 -->
                 <org xml:id="org_173532247">
                     <!-- record originally created from https://viaf.org/viaf/173532247/viaf.xml at 2017-05-09 11:37:18.799206 -->
-                    <orgName type="display"  source="LC bodl">Orléans, collegiate
-                        church of Saint-Aignan</orgName>
-                    <orgName type="crossref"  source="LC">Collégiale Saint-Aignan
-                        d'Orléans (Orléans, France)</orgName>
-                    <orgName type="crossref"  source="LC">Église Saint-Aignan
-                        (Orléans, France)</orgName>
-                    <orgName type="crossref"  source="LC">Kirche Saint-Aignan
-                        (Orléans, France)</orgName>
-                    <orgName type="variant"  source="LC">Saint-Aignan d'Orléans
-                        (Orléans, France)</orgName>
+                    <orgName type="display" source="LC bodl">Orléans, collegiate church of Saint-Aignan</orgName>
+                    <orgName type="crossref" source="LC">Collégiale Saint-Aignan d'Orléans (Orléans, France)</orgName>
+                    <orgName type="crossref" source="LC">Église Saint-Aignan (Orléans, France)</orgName>
+                    <orgName type="crossref" source="LC">Kirche Saint-Aignan (Orléans, France)</orgName>
+                    <orgName type="variant" source="LC">Saint-Aignan d'Orléans (Orléans, France)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12497,46 +12931,43 @@
                     </note>
                 </org>
                 <!-- 1938 -->
-               <!-- <org xml:id="org_147766659">
-                    use 148943477 for the prereformation and postreformatoin cathedral
-                    <!-\- record originally created from https://viaf.org/viaf/147766659/viaf.xml at 2017-05-09 11:37:56.989475 -\->
-                    <!-\- check. this entity may be retained for the post-Dissolution cathedral. cf. 148943477 for the pre-Dissolution priory.  -\->
-                    <orgName type="display"  source="LC">Worcester
-                        Cathedral</orgName>
-                    <orgName type="crossref"  source="LC">Cathedral Church of
-                        Christ and the Blessed Mary the Virgin (Worcester, England)</orgName>
-                    <orgName type="variant"  source="LC">Cathedral Church of
-                        Christ and the Blessed Virgin Mary (Worcester, England)</orgName>
-                    <orgName type="variant"  source="LC">Cathédrale de Worcester</orgName>
-                    <note type="links">
-                        <list type="links">
-                            <item>
-                                <ref target="http://id.loc.gov/authorities/names/n82052305">
-                                    <title>LC</title>
-                                </ref>
-                            </item>
-                            <item>
-                                <ref target="http://www.wikidata.org/entity/Q1630367">
-                                    <title>Wikidata</title>
-                                </ref>
-                            </item>
-                            <item>
-                                <ref target="https://viaf.org/viaf/147766659">
-                                    <title>VIAF</title>
-                                </ref>
-                            </item>
-                        </list>
-                    </note>
-                </org>-->
+                <!-- <org xml:id="org_147766659">
+                       use 148943477 for the prereformation and postreformatoin cathedral
+                       <!-\- record originally created from https://viaf.org/viaf/147766659/viaf.xml at 2017-05-09 11:37:56.989475 -\->
+                       <!-\- check. this entity may be retained for the post-Dissolution cathedral. cf. 148943477 for the pre-Dissolution priory.  -\->
+                       <orgName type="display"  source="LC">Worcester
+                           Cathedral</orgName>
+                       <orgName type="crossref"  source="LC">Cathedral Church of
+                           Christ and the Blessed Mary the Virgin (Worcester, England)</orgName>
+                       <orgName type="variant"  source="LC">Cathedral Church of
+                           Christ and the Blessed Virgin Mary (Worcester, England)</orgName>
+                       <orgName type="variant"  source="LC">Cathédrale de Worcester</orgName>
+                       <note type="links">
+                            <list type="links">
+                               <item>
+                                   <ref target="http://id.loc.gov/authorities/names/n82052305">
+                                       <title>LC</title>
+                                   </ref>
+                               </item>
+                               <item>
+                                   <ref target="http://www.wikidata.org/entity/Q1630367">
+                                       <title>Wikidata</title>
+                                   </ref>
+                               </item>
+                               <item>
+                                   <ref target="https://viaf.org/viaf/147766659">
+                                       <title>VIAF</title>
+                                   </ref>
+                               </item>
+                            </list>
+                       </note>
+                   </org>-->
                 <!-- 1962 -->
                 <org xml:id="org_173408842">
                     <!-- record originally created from https://viaf.org/viaf/173408842/viaf.xml at 2017-05-09 11:39:02.466193 -->
-                    <orgName type="display"  source="LC">Rochester
-                        Cathedral</orgName>
-                    <orgName type="crossref"  source="LC">Cathedral Church of
-                        Christ and the Blessed Virgin Mary (Rochester, Kent, England)</orgName>
-                    <orgName type="variant"  source="LC">Cathedral Church of
-                        Rochester (Rochester, Kent, England)</orgName>
+                    <orgName type="display" source="LC">Rochester Cathedral</orgName>
+                    <orgName type="crossref" source="LC">Cathedral Church of Christ and the Blessed Virgin Mary (Rochester, Kent, England)</orgName>
+                    <orgName type="variant" source="LC">Cathedral Church of Rochester (Rochester, Kent, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12565,10 +12996,8 @@
                 <!-- 1976 -->
                 <org xml:id="org_167950502">
                     <!-- record originally created from https://viaf.org/viaf/167950502/viaf.xml at 2017-05-09 11:39:40.781266 -->
-                    <orgName type="display"  source="LC bodl">Venice,
-                        Procuratoria di San Marco</orgName>
-                    <orgName type="crossref"  source="DNB">Procuratoria di San
-                        Marco, Venezia</orgName>
+                    <orgName type="display" source="LC bodl">Venice, Procuratoria di San Marco</orgName>
+                    <orgName type="crossref" source="DNB">Procuratoria di San Marco, Venezia</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12591,15 +13020,24 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000122008554">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q65038247">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 <!-- 1979 -->
                 <org xml:id="org_126666939">
                     <!-- record originally created from https://viaf.org/viaf/126666939/viaf.xml at 2017-05-09 11:39:48.706371 -->
-                    <orgName type="display"  source="DNB bodl">Cluny, Collège de
-                        Cluny</orgName>
-                    <orgName type="variant"  source="DNB">Collegium Cluniacense</orgName>
+                    <orgName type="display" source="DNB bodl">Cluny, Collège de Cluny</orgName>
+                    <orgName type="variant" source="DNB">Collegium Cluniacense</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12633,10 +13071,8 @@
                 <!-- 1991 -->
                 <org xml:id="org_139250894">
                     <!-- record originally created from https://viaf.org/viaf/139250894/viaf.xml at 2017-05-09 11:40:22.388067 -->
-                    <orgName type="display"  source="LC bodl">Oxford, Oriel
-                        College</orgName>
-                    <orgName type="crossref"  source="LC">University of Oxford.,
-                        Oriel College</orgName>
+                    <orgName type="display" source="LC bodl">Oxford, Oriel College</orgName>
+                    <orgName type="crossref" source="LC">University of Oxford., Oriel College</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12664,14 +13100,18 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000094590611">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 <!-- 2047 -->
                 <org xml:id="org_241197056">
                     <!-- record originally created from https://viaf.org/viaf/241197056/viaf.xml at 2017-05-09 12:11:11.163873 -->
-                    <orgName type="display"  source="DNB bodl">Chiaravalle della
-                        Colomba, <affiliation>Cistercian</affiliation> abbey (Alseno)</orgName>
+                    <orgName type="display" source="DNB bodl">Chiaravalle della Colomba, <affiliation>Cistercian</affiliation> abbey (Alseno)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12700,12 +13140,9 @@
                 <!-- 2254 -->
                 <org xml:id="org_135393460">
                     <!-- record originally created from https://viaf.org/viaf/135393460/viaf.xml at 2017-05-09 12:20:51.006054 -->
-                    <orgName type="display"  source="LC bodl">York, diocese
-                        of</orgName>
-                    <orgName type="crossref"  source="DNB">Diocese of York,
-                        Ecclesia Catholica</orgName>
-                    <orgName type="variant"  source="DNB">Diocesis Eboracensis,
-                        Ecclesia Catholica</orgName>
+                    <orgName type="display" source="LC bodl">York, diocese of</orgName>
+                    <orgName type="crossref" source="DNB">Diocese of York, Ecclesia Catholica</orgName>
+                    <orgName type="variant" source="DNB">Diocesis Eboracensis, Ecclesia Catholica</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12728,14 +13165,18 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="https://catalogue.bnf.fr/ark:/12148/cb120502241">
+                                    <title>BNF</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 <!-- 2270 -->
                 <org xml:id="org_123624907">
                     <!-- record originally created from https://viaf.org/viaf/123624907/viaf.xml at 2017-05-09 12:21:35.934054 -->
-                    <orgName type="display"  source="LC bodl">Milan, church of
-                        San Giovanni in Conca</orgName>
+                    <orgName type="display" source="LC bodl">Milan, church of San Giovanni in Conca</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12764,21 +13205,14 @@
                 <!-- 2287 -->
                 <org xml:id="org_150122851">
                     <!-- record originally created from https://viaf.org/viaf/150122851/viaf.xml at 2017-05-09 12:22:24.028854 -->
-                    <orgName type="display"  source="LC">Köln,
-                            <affiliation>Carthusian</affiliation> abbey</orgName>
-                    <orgName type="crossref"  source="DNB">Carthusia domus
-                        Sanctae Barbarae in Colonia</orgName>
-                    <orgName type="variant"  source="DNB">Kartause Sankt Barbara
-                        Köln</orgName>
-                    <orgName type="variant"  source="DNB">Kartause St. Barbara
-                        Köln</orgName>
-                    <orgName type="variant"  source="DNB">Kartäuserkloster Sankt
-                        Barbara Köln</orgName>
-                    <orgName type="variant"  source="DNB">Kartäuserkloster St.
-                        Barbara Köln</orgName>
-                    <orgName type="variant"  source="DNB">Kloster St. Barbara
-                        Köln</orgName>
-                    <orgName type="variant"  source="DNB">Kölner Kartause</orgName>
+                    <orgName type="display" source="LC">Köln, <affiliation>Carthusian</affiliation> abbey</orgName>
+                    <orgName type="crossref" source="DNB">Carthusia domus Sanctae Barbarae in Colonia</orgName>
+                    <orgName type="variant" source="DNB">Kartause Sankt Barbara Köln</orgName>
+                    <orgName type="variant" source="DNB">Kartause St. Barbara Köln</orgName>
+                    <orgName type="variant" source="DNB">Kartäuserkloster Sankt Barbara Köln</orgName>
+                    <orgName type="variant" source="DNB">Kartäuserkloster St. Barbara Köln</orgName>
+                    <orgName type="variant" source="DNB">Kloster St. Barbara Köln</orgName>
+                    <orgName type="variant" source="DNB">Kölner Kartause</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12807,12 +13241,9 @@
                 <!-- 2332 -->
                 <org xml:id="org_123184663">
                     <!-- record originally created from https://viaf.org/viaf/123184663/viaf.xml at 2017-05-09 12:24:30.561454 -->
-                    <orgName type="display"  source="LC bodl">London, Grocers'
-                        Company</orgName>
-                    <orgName type="variant" subtype="surnameFirst" source="LC">London., Grocers'
-                        Company</orgName>
-                    <orgName type="crossref"  source="LC">Worshipful Company of
-                        Grocers (London, England)</orgName>
+                    <orgName type="display" source="LC bodl">London, Grocers' Company</orgName>
+                    <orgName type="variant" subtype="surnameFirst" source="LC">London., Grocers' Company</orgName>
+                    <orgName type="crossref" source="LC">Worshipful Company of Grocers (London, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12836,12 +13267,9 @@
                 <!-- 2333 -->
                 <org xml:id="org_129111728">
                     <!-- record originally created from https://viaf.org/viaf/129111728/viaf.xml at 2017-05-09 12:24:33.057454 -->
-                    <orgName type="display"  source="LC bodl">Coventry and
-                        Lichfield, diocese</orgName>
-                    <orgName type="variant" subtype="surnameFirst" source="LC">Coventry (England :
-                        Diocese : Catholic Church)</orgName>
-                    <orgName type="crossref" subtype="surnameFirst" source="LC">Lichfield (England :
-                        Diocese : Catholic Church)</orgName>
+                    <orgName type="display" source="LC bodl">Coventry and Lichfield, diocese</orgName>
+                    <orgName type="variant" subtype="surnameFirst" source="LC">Coventry (England : Diocese : Catholic Church)</orgName>
+                    <orgName type="crossref" subtype="surnameFirst" source="LC">Lichfield (England : Diocese : Catholic Church)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12860,16 +13288,15 @@
                 <!-- 2501 -->
                 <org xml:id="org_135038090">
                     <!-- record originally created from https://viaf.org/viaf/135038090/viaf.xml at 2017-05-09 12:32:18.845794 -->
-                    <orgName type="display"  source="LC bodl">Medingen,
-                            <affiliation>Cistercian</affiliation> nunnery</orgName>
-                    <orgName type="crossref"  source="DNB">Kloster Medingen St. Mauritius</orgName>
-                    <orgName type="variant"  source="DNB">Kloster St. Mauritius Medingen</orgName>
-                    <orgName type="variant"  source="DNB"> Ev. Damenstift Medingen</orgName>
-                    <orgName type="variant"  source="DNB">Evangelisches Damenstift Medingen</orgName>
-                    <orgName type="variant"  source="DNB"> Ev. Damenstift Kloster Medingen</orgName>
-                    <orgName type="variant"  source="DNB">Evangelisches Damenstift Kloster Medingen</orgName>
-                    <orgName type="variant"  source="DNB">Kloster Medingen (Bad Bevensen)</orgName>
-                    <orgName type="variant"  source="DNB">Evangelisches Damenstift (Bad Bevensen)</orgName>
+                    <orgName type="display" source="LC bodl">Medingen, <affiliation>Cistercian</affiliation> nunnery</orgName>
+                    <orgName type="crossref" source="DNB">Kloster Medingen St. Mauritius</orgName>
+                    <orgName type="variant" source="DNB">Kloster St. Mauritius Medingen</orgName>
+                    <orgName type="variant" source="DNB"> Ev. Damenstift Medingen</orgName>
+                    <orgName type="variant" source="DNB">Evangelisches Damenstift Medingen</orgName>
+                    <orgName type="variant" source="DNB"> Ev. Damenstift Kloster Medingen</orgName>
+                    <orgName type="variant" source="DNB">Evangelisches Damenstift Kloster Medingen</orgName>
+                    <orgName type="variant" source="DNB">Kloster Medingen (Bad Bevensen)</orgName>
+                    <orgName type="variant" source="DNB">Evangelisches Damenstift (Bad Bevensen)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12910,9 +13337,10 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_158172799">
                     <!-- record originally created from https://viaf.org/viaf/151337156/viaf.xml at 2017-05-09 12:33:43.960986 -->
-                    <orgName type="display"  source="bodl">Oxford, Lincoln College</orgName>
+                    <orgName type="display" source="bodl">Oxford, Lincoln College</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -12940,38 +13368,31 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000121137485">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 <!-- 2536 -->
                 <org xml:id="org_140344389">
+<!-- ***** Old VIAF ID now redirects to 168107621 ***** -->
                     <!-- record originally created from https://viaf.org/viaf/140344389/viaf.xml at 2017-05-09 12:33:55.668865 -->
-                    <orgName type="display"  source="LC bodl">Oxford, Magdalen
-                        College</orgName>
-                    <orgName type="crossref"  source="DNB">Collegium Sanctae
-                        Mariae Magdalenae</orgName>
-                    <orgName type="variant"  source="DNB">Collegium Sanctae
-                        Mariae Magdalenae, Oxford</orgName>
-                    <orgName type="variant"  source="DNB">Magdalen College,
-                        Oxford</orgName>
-                    <orgName type="variant"  source="DNB">Magdalen College,
-                        University of Oxford</orgName>
-                    <orgName type="crossref"  source="DNB">Saint Mary Magdalen
-                        College</orgName>
-                    <orgName type="variant"  source="DNB">Saint Mary Magdalen
-                        College, Oxford</orgName>
-                    <orgName type="variant"  source="DNB">St. Mary Magdalen
-                        College</orgName>
-                    <orgName type="variant"  source="DNB">St. Mary Magdalen
-                        College, Oxford</orgName>
-                    <orgName type="crossref"  source="DNB">University of Oxford,
-                        Magdalen College</orgName>
-                    <orgName type="variant"  source="DNB">University of Oxford,
-                        Saint Mary Magdalen College</orgName>
-                    <orgName type="variant"  source="DNB">University of Oxford,
-                        St. Mary Magdalen College</orgName>
-                    <orgName type="variant"  source="DNB">University, Oxford,
-                        Magdalen College</orgName>
+                    <orgName type="display" source="LC bodl">Oxford, Magdalen College</orgName>
+                    <orgName type="crossref" source="DNB">Collegium Sanctae Mariae Magdalenae</orgName>
+                    <orgName type="variant" source="DNB">Collegium Sanctae Mariae Magdalenae, Oxford</orgName>
+                    <orgName type="variant" source="DNB">Magdalen College, Oxford</orgName>
+                    <orgName type="variant" source="DNB">Magdalen College, University of Oxford</orgName>
+                    <orgName type="crossref" source="DNB">Saint Mary Magdalen College</orgName>
+                    <orgName type="variant" source="DNB">Saint Mary Magdalen College, Oxford</orgName>
+                    <orgName type="variant" source="DNB">St. Mary Magdalen College</orgName>
+                    <orgName type="variant" source="DNB">St. Mary Magdalen College, Oxford</orgName>
+                    <orgName type="crossref" source="DNB">University of Oxford, Magdalen College</orgName>
+                    <orgName type="variant" source="DNB">University of Oxford, Saint Mary Magdalen College</orgName>
+                    <orgName type="variant" source="DNB">University of Oxford, St. Mary Magdalen College</orgName>
+                    <orgName type="variant" source="DNB">University, Oxford, Magdalen College</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -13004,18 +13425,25 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000123150747">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/168107621">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 <!-- 2625 -->
                 <org xml:id="org_153715381">
                     <!-- record originally created from https://viaf.org/viaf/153715381/viaf.xml at 2017-05-09 12:38:06.399076 -->
-                    <orgName type="display"  source="LC bodl">Lincoln,
-                        diocese</orgName>
-                    <orgName type="variant"  source="DNB">Catholic Church,
-                        Diocese of Lincoln, England</orgName>
-                    <orgName type="crossref"  source="DNB">Lincoln, England :
-                        Diocese : Catholic Church</orgName>
+                    <orgName type="display" source="LC bodl">Lincoln, diocese</orgName>
+                    <orgName type="variant" source="DNB">Catholic Church, Diocese of Lincoln, England</orgName>
+                    <orgName type="crossref" source="DNB">Lincoln, England : Diocese : Catholic Church</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -13044,14 +13472,10 @@
                 <!-- 2626 -->
                 <org xml:id="org_172374812">
                     <!-- record originally created from https://viaf.org/viaf/172374812/viaf.xml at 2017-05-09 12:38:08.887497 -->
-                    <orgName type="display"  source="DNB bodl">Admont,
-                        Stiftsbibliothek</orgName>
-                    <orgName type="crossref"  source="DNB">Kloster Admont,
-                        Bibliothek</orgName>
-                    <orgName type="variant"  source="DNB">Kloster Admont,
-                        Stiftsbibliothek</orgName>
-                    <orgName type="variant"  source="DNB">Klosterbibliothek
-                        Admont</orgName>
+                    <orgName type="display" source="DNB bodl">Admont, Stiftsbibliothek</orgName>
+                    <orgName type="crossref" source="DNB">Kloster Admont, Bibliothek</orgName>
+                    <orgName type="variant" source="DNB">Kloster Admont, Stiftsbibliothek</orgName>
+                    <orgName type="variant" source="DNB">Klosterbibliothek Admont</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -13064,6 +13488,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q304668">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -13071,9 +13500,8 @@
                 <org xml:id="org_232929480">
                     <!-- check: here? -->
                     <!-- record originally created from https://viaf.org/viaf/232929480/viaf.xml at 2017-05-09 12:38:31.179997 -->
-                    <orgName type="display"  source="LC bodl">Windsor, Military
-                        Knights</orgName>
-                    <orgName type="crossref"  source="LC">Poor Knights of Windsor</orgName>
+                    <orgName type="display" source="LC bodl">Windsor, Military Knights</orgName>
+                    <orgName type="crossref" source="LC">Poor Knights of Windsor</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -13092,11 +13520,9 @@
                 <!-- 2663 -->
                 <org xml:id="org_249304112">
                     <!-- record originally created from https://viaf.org/viaf/249304112/viaf.xml at 2017-05-09 12:39:52.689997 -->
-                    <orgName type="display"  source="DNB bodl">Schwäbisch Gmünd,
-                            <affiliation>Augustinian</affiliation> monastery</orgName>
-                    <orgName type="variant"  source="DNB"
-                        >Augustiner-Eremitenkloster Gmünd</orgName>
-                    <orgName type="variant"  source="DNB">Augustinerkloster Gmünd</orgName>
+                    <orgName type="display" source="DNB bodl">Schwäbisch Gmünd, <affiliation>Augustinian</affiliation> monastery</orgName>
+                    <orgName type="variant" source="DNB">Augustiner-Eremitenkloster Gmünd</orgName>
+                    <orgName type="variant" source="DNB">Augustinerkloster Gmünd</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -13114,6 +13540,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q28976823">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -13121,8 +13552,8 @@
                 <!-- check: here? -->
                 <org xml:id="org_131824444">
                     <!-- record originally created from https://viaf.org/viaf/131824444/viaf.xml at 2017-05-09 12:41:41.181197 -->
-                    <orgName type="display"  source="LC bodl">Canterbury, diocese, Court of Arches</orgName>
-                    <orgName type="variant"  source="LC">Catholic Church., Province of Canterbury (England)., Court of Arches </orgName>
+                    <orgName type="display" source="LC bodl">Canterbury, diocese, Court of Arches</orgName>
+                    <orgName type="variant" source="LC">Catholic Church., Province of Canterbury (England)., Court of Arches </orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -13151,9 +13582,8 @@
                 <!-- 2722 -->
                 <org xml:id="org_127830403">
                     <!-- record originally created from https://viaf.org/viaf/127830403/viaf.xml at 2017-05-09 12:42:33.004397 -->
-                    <orgName type="display"  source="LC">Lichfield
-                        Cathedral</orgName>
-                    <orgName type="crossref"  source="DNB">Cathedral, Lichfield</orgName>
+                    <orgName type="display" source="LC">Lichfield Cathedral</orgName>
+                    <orgName type="crossref" source="DNB">Cathedral, Lichfield</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -13174,6 +13604,11 @@
                             <item>
                                 <ref target="https://viaf.org/viaf/127830403">
                                     <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000106836093">
+                                    <title>ISNI</title>
                                 </ref>
                             </item>
                         </list>
@@ -13199,21 +13634,15 @@
                         </list>
                     </note>
                 </org>
-                
                 <!-- 2743 -->
                 <!-- 2750 -->
                 <org xml:id="org_169654564">
                     <!-- record originally created from https://viaf.org/viaf/169654564/viaf.xml at 2017-05-09 12:43:49.081397 -->
-                    <orgName type="display"  source="SUDOC bodl">Florence,
-                        Convento di San Marco</orgName>
-                    <orgName type="variant"  source="SUDOC">Convento San Marco
-                        (Florence, Italie)</orgName>
-                    <orgName type="variant"  source="SUDOC">Couvent Saint-Marc
-                        (Florence, Italie)</orgName>
-                    <orgName type="crossref" subtype="unknownOrder" source="SUDOC">Florence
-                        (Italie), Convento di San Marco</orgName>
-                    <orgName type="crossref"  source="SUDOC">Ordre des
-                        Prêcheurs., Convento di San Marco (Florence, Italie)</orgName>
+                    <orgName type="display" source="SUDOC bodl">Florence, Convento di San Marco</orgName>
+                    <orgName type="variant" source="SUDOC">Convento San Marco (Florence, Italie)</orgName>
+                    <orgName type="variant" source="SUDOC">Couvent Saint-Marc (Florence, Italie)</orgName>
+                    <orgName type="crossref" subtype="unknownOrder" source="SUDOC">Florence (Italie), Convento di San Marco</orgName>
+                    <orgName type="crossref" source="SUDOC">Ordre des Prêcheurs., Convento di San Marco (Florence, Italie)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -13237,10 +13666,8 @@
                 <!-- 2759 -->
                 <org xml:id="org_154915206">
                     <!-- record originally created from https://viaf.org/viaf/154915206/viaf.xml at 2017-05-09 12:44:14.341397 -->
-                    <orgName type="display"  source="LC bodl">Durham, bishopric
-                        of</orgName>
-                    <orgName type="crossref" subtype="surnameFirst" source="LC">Durham (England :
-                        Bishopric : Catholic Church)</orgName>
+                    <orgName type="display" source="LC bodl">Durham, bishopric of</orgName>
+                    <orgName type="crossref" subtype="surnameFirst" source="LC">Durham (England : Bishopric : Catholic Church)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -13259,10 +13686,8 @@
                 <!-- 2810 -->
                 <org xml:id="org_145941484">
                     <!-- record originally created from https://viaf.org/viaf/145941484/viaf.xml at 2017-05-09 12:46:35.459484 -->
-                    <orgName type="display"  source="LC bodl">Ely, diocese
-                        of</orgName>
-                    <orgName type="crossref"  source="DNB">Diocese of Ely, Church
-                        of England</orgName>
+                    <orgName type="display" source="LC bodl">Ely, diocese of</orgName>
+                    <orgName type="crossref" source="DNB">Diocese of Ely, Church of England</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -13291,10 +13716,8 @@
                 <!-- 2839 -->
                 <org xml:id="org_316390117">
                     <!-- record originally created from https://viaf.org/viaf/316390117/viaf.xml at 2017-05-09 12:47:56.363159 -->
-                    <orgName type="display"  source="DNB bodl">Neamţ,
-                        abbey</orgName>
-                    <orgName type="variant"  source="DNB">Kloster, Bistriţa-Neamţ</orgName>
-                   
+                    <orgName type="display" source="DNB bodl">Neamţ, abbey</orgName>
+                    <orgName type="variant" source="DNB">Kloster, Bistriţa-Neamţ</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -13313,16 +13736,11 @@
                 <!-- 2159 -->
                 <org xml:id="org_153848390">
                     <!-- record originally created from https://viaf.org/viaf/153848390/viaf.xml at 2017-05-09 12:16:22.716254 -->
-                    <orgName type="display" subtype="unknownOrder" source="BNF bodl">Avrillé,
-                        Prieuré de la Haie-aux-Bons-Hommes</orgName>
-                    <orgName type="crossref" subtype="unknownOrder" source="BNF">Prieuré de la
-                        Haie-aux-Bons Hommes lès-Angers, Avrillé, Maine-et-Loire</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Prieuré de la
-                        Haie-aux-Bonshommes, Avrillé, Maine-et-Loire</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Prieuré de la Haye
-                        lez Angers, Avrillé, Maine-et-Loire</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Prieuré de la
-                        Haye-aux-Bons Hommes les Angers, Avrillé, Maine-et-Loire</orgName>
+                    <orgName type="display" subtype="unknownOrder" source="BNF bodl">Avrillé, Prieuré de la Haie-aux-Bons-Hommes</orgName>
+                    <orgName type="crossref" subtype="unknownOrder" source="BNF">Prieuré de la Haie-aux-Bons Hommes lès-Angers, Avrillé, Maine-et-Loire</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Prieuré de la Haie-aux-Bonshommes, Avrillé, Maine-et-Loire</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Prieuré de la Haye lez Angers, Avrillé, Maine-et-Loire</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Prieuré de la Haye-aux-Bons Hommes les Angers, Avrillé, Maine-et-Loire</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -13341,8 +13759,7 @@
                 <!-- 2106 -->
                 <org xml:id="org_238824653">
                     <!-- record originally created from https://viaf.org/viaf/238824653/viaf.xml at 2017-05-09 12:13:56.198389 -->
-                    <orgName type="display" subtype="unknownOrder" source="WKP bodl">Venice, church
-                        of Santa Maria della Carità</orgName>
+                    <orgName type="display" subtype="unknownOrder" source="WKP bodl">Venice, church of Santa Maria della Carità</orgName>
                     <!-- no variants found in preferred sources -->
                     <note type="links">
                         <list type="links">
@@ -13360,50 +13777,57 @@
                     </note>
                 </org>
                 
-                
-               
-              
-                
                 <org xml:id="org_143202638">
                     <orgName type="display">Bressanone, cathedral</orgName>
                     <orgName type="variant" source="LC">Bressanone, duomo</orgName>
                     <note type="links">
                         <list type="links">
-                            <item><ref target="http://viaf.org/viaf/143202638"><title>VIAF</title></ref></item>
+                            <item>
+                                <ref target="http://viaf.org/viaf/143202638">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/n91041033">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
                         </list>
                         <list type="links">
-                            <item><ref target="http://id.loc.gov/authorities/names/n91041033"><title>LC</title></ref></item>
+                            <item>
+                                <ref target="http://id.loc.gov/authorities/names/n91041033">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/143202638">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
-                
-         
-              
-              
-               
-                
                 <!-- ************************************************************************************************************** -->
-                
                 <org xml:id="org_315687992">
                     <orgName type="display" source="bodl">Lismore, monastery and cathedral church of St Carthach (Carthage)</orgName>
                     <!--<place type="settlement" xml:id="place_7006733">
-                        <placeName type="index">Lismore</placeName>
-                        <placeName type="variant">Lios Mór</placeName>
-                        <!-\-  parent: id=1000003 -\->
-                        <!-\-  parent: id=7003505 -\->
-                        <country key="place_1000078">Ireland</country>
-                        <!-\-  parent: id=7029392 -\->
-                        <location>
-                            <geo>52.136667,-7.930833</geo>
-                        </location>
-                        <note type="source">Record based on information from the <ref
-                            target="http://www.getty.edu/research/tools/vocabularies/tgn/">Getty
-                            Thesaurus of Geographic Names</ref>, copyright 2017 the J. Paul Getty
-                            Trust, released under the <ref
-                                target="https://opendatacommons.org/licenses/by/1-0/">Open Data Commons
-                                Attribution License (ODC-By) 1.0 </ref>
-                        </note>
-                    </place>-->
+                            <placeName type="index">Lismore</placeName>
+                            <placeName type="variant">Lios Mór</placeName>
+                            <!-\-  parent: id=1000003 -\->
+                            <!-\-  parent: id=7003505 -\->
+                            <country key="place_1000078">Ireland</country>
+                            <!-\-  parent: id=7029392 -\->
+                            <location>
+                               <geo>52.136667,-7.930833</geo>
+                            </location>
+                            <note type="source">Record based on information from the <ref
+                               target="http://www.getty.edu/research/tools/vocabularies/tgn/">Getty
+                               Thesaurus of Geographic Names</ref>, copyright 2017 the J. Paul Getty
+                               Trust, released under the <ref
+                                   target="https://opendatacommons.org/licenses/by/1-0/">Open Data Commons
+                                   Attribution License (ODC-By) 1.0 </ref>
+                            </note>
+                       </place>-->
                     <location source="http://vocab.getty.edu/tgn/7006733">
                         <geo>52.136667,-7.930833</geo>
                     </location>
@@ -13506,10 +13930,8 @@
                 
                 <org xml:id="org_313533333">
                     <orgName type="display" source="bodl">Venice, convent of Santa Maria dei Servi</orgName>
-                    <orgName type="variant"  source="SUDOC">Convento dei Servi di Maria
-                        (Venise, Italie)</orgName>
-                    <orgName type="crossref" subtype="unknownOrder" source="SUDOC">Venise (Italie), Convento dei
-                        Servi di Maria</orgName>
+                    <orgName type="variant" source="SUDOC">Convento dei Servi di Maria (Venise, Italie)</orgName>
+                    <orgName type="crossref" subtype="unknownOrder" source="SUDOC">Venise (Italie), Convento dei Servi di Maria</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -13527,18 +13949,20 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q55157640">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
                 <org xml:id="org_150801356">
                     <orgName type="display" source="bodl">Rouen, fraternity (later puy or literary academy) of the Immaculate Conception</orgName>
-                    <orgName type="variant"  source="DNB">Académie Etablie à Rouen sous le
-                        Titre de l&#x27;Immaculée Conception</orgName>
-                    <orgName type="variant"  source="DNB">Académie de l&#x27;Immaculée
-                        Conception</orgName>
-                    <orgName type="variant"  source="DNB">Académie de
-                        l&#x27;Immaculée-Conception</orgName>
+                    <orgName type="variant" source="DNB">Académie Etablie à Rouen sous le Titre de l'Immaculée Conception</orgName>
+                    <orgName type="variant" source="DNB">Académie de l'Immaculée Conception</orgName>
+                    <orgName type="variant" source="DNB">Académie de l'Immaculée-Conception</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -13557,8 +13981,8 @@
                 
                 <org xml:id="org_310513586">
                     <orgName type="display" source="bodl">Esslingen (Baden-Württemberg), <affiliation>Dominican</affiliation> friary</orgName>
-                    <orgName type="variant"  source="DNB">Sankt Paul, Kloster</orgName>
-                    <orgName type="crossref"  source="DNB">Dominikanerkloster</orgName>
+                    <orgName type="variant" source="DNB">Sankt Paul, Kloster</orgName>
+                    <orgName type="crossref" source="DNB">Dominikanerkloster</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -13575,13 +13999,9 @@
                     </note>
                 </org>
                 
-                
-               
-                
                 <org xml:id="org_152531224">
                     <orgName type="display" source="bodl">Oxford, Canterbury College</orgName>
-                    <orgName type="variant"  source="LC">Canterbury College (University of
-                        Oxford)</orgName>
+                    <orgName type="variant" source="LC">Canterbury College (University of Oxford)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -13622,21 +14042,22 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q7594599">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
                 <org xml:id="org_130118418">
                     <orgName type="display" source="bodl">Oxford, New College</orgName>
-                    <orgName type="variant"  source="LC">New College (University of
-                        Oxford)</orgName>
-                    <orgName type="crossref"  source="DNB">College of St Mary,
-                        Oxford</orgName>
-                    <orgName type="variant"  source="DNB">New College of St Mary</orgName>
-                    <orgName type="variant"  source="DNB">New College, University of
-                        Oxford</orgName>
-                    <orgName type="crossref"  source="DNB">University of Oxford, New
-                        College</orgName>
+                    <orgName type="variant" source="LC">New College (University of Oxford)</orgName>
+                    <orgName type="crossref" source="DNB">College of St Mary, Oxford</orgName>
+                    <orgName type="variant" source="DNB">New College of St Mary</orgName>
+                    <orgName type="variant" source="DNB">New College, University of Oxford</orgName>
+                    <orgName type="crossref" source="DNB">University of Oxford, New College</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -13662,6 +14083,16 @@
                             <item>
                                 <ref target="https://viaf.org/viaf/130118418">
                                     <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000121569819">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q1376987">
+                                    <title>Wikidata</title>
                                 </ref>
                             </item>
                         </list>
@@ -13698,9 +14129,8 @@
                 
                 <org xml:id="org_140865145">
                     <orgName type="display" source="bodl">Hailes, <affiliation>Cistercian</affiliation> abbey</orgName>
-                    <orgName type="variant"  source="LC">Hailes Abbey</orgName>
-                    <orgName type="variant"  source="LC">Hailes (Monastery : Gloucestershire,
-                        England)</orgName>
+                    <orgName type="variant" source="LC">Hailes Abbey</orgName>
+                    <orgName type="variant" source="LC">Hailes (Monastery : Gloucestershire, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -13724,10 +14154,8 @@
                 
                 <org xml:id="org_136179651">
                     <orgName type="display" source="bodl">Oxford, <affiliation>Augustinian</affiliation> priory of St Frideswide</orgName>
-                    <orgName type="variant"  source="LC">St. Frideswide&#x27;s Monastery
-                        (Oxford, England)</orgName>
-                    <orgName type="variant"  source="LC">St. Frideswide&#x27;s Priory
-                        (Oxford, England)</orgName>
+                    <orgName type="variant" source="LC">St. Frideswide's Monastery (Oxford, England)</orgName>
+                    <orgName type="variant" source="LC">St. Frideswide's Priory (Oxford, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -13756,8 +14184,8 @@
                 
                 <org xml:id="org_135058831">
                     <orgName type="display" source="bodl">Margam, <affiliation>Cistercian</affiliation> abbey</orgName>
-                    <orgName type="variant"  source="LC">Margam Abbey</orgName>
-                    <orgName type="variant"  source="DNB">Margam Priory</orgName>
+                    <orgName type="variant" source="LC">Margam Abbey</orgName>
+                    <orgName type="variant" source="DNB">Margam Priory</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -13795,6 +14223,7 @@
                 </org>
                 
                 <org xml:id="org_155836576">
+<!-- ***** Old VIAF ID now redirects to 156148995743759750417 ***** -->
                     <orgName type="display" source="bodl">Osney, <affiliation>Augustinian</affiliation> priory and abbey</orgName>
                     <orgName type="variant" source="bodl">Oseney, <affiliation>Augustinian</affiliation> priory and abbey</orgName>
                     <note type="links">
@@ -13816,6 +14245,11 @@
                             </item>
                             <item>
                                 <ref target="https://viaf.org/viaf/155836576">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/156148995743759750417">
                                     <title>VIAF</title>
                                 </ref>
                             </item>
@@ -13876,14 +14310,10 @@
                 
                 <org xml:id="org_139688379">
                     <orgName type="display" source="bodl">Soignies (Belgium), abbey and collegiate church of St. Vincent</orgName>
-                    <orgName type="variant"  source="LC">Collégiale Saint-Vincent de
-                        Soignies</orgName>
-                    <orgName type="variant"  source="LC">Saint-Vincent de Soignies
-                        (Church)</orgName>
-                    <orgName type="variant" subtype="surnameFirst" source="LC">Soignies (Belgium)., Collégiale
-                        Saint-Vincent</orgName>
-                    <orgName type="variant" subtype="surnameFirst" source="LC">Soignies (Belgium).,
-                        Saint-Vincent (Church)</orgName>
+                    <orgName type="variant" source="LC">Collégiale Saint-Vincent de Soignies</orgName>
+                    <orgName type="variant" source="LC">Saint-Vincent de Soignies (Church)</orgName>
+                    <orgName type="variant" subtype="surnameFirst" source="LC">Soignies (Belgium)., Collégiale Saint-Vincent</orgName>
+                    <orgName type="variant" subtype="surnameFirst" source="LC">Soignies (Belgium)., Saint-Vincent (Church)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -13940,14 +14370,11 @@
                 
                 <org xml:id="org_134825322">
                     <orgName type="display" source="bodl">Oxford, Balliol College</orgName>
-                    <orgName type="variant"  source="LC">Balliol College (University of
-                        Oxford)</orgName>
-                    <orgName type="variant"  source="DNB">Balliol College, Oxford</orgName>
-                    <orgName type="variant"  source="DNB">Oxford, Balliol College</orgName>
-                    <orgName type="variant"  source="DNB">University of Oxford, Balliol
-                        College</orgName>
-                    <orgName type="variant"  source="DNB">University, Oxford, Balliol
-                        College</orgName>
+                    <orgName type="variant" source="LC">Balliol College (University of Oxford)</orgName>
+                    <orgName type="variant" source="DNB">Balliol College, Oxford</orgName>
+                    <orgName type="variant" source="DNB">Oxford, Balliol College</orgName>
+                    <orgName type="variant" source="DNB">University of Oxford, Balliol College</orgName>
+                    <orgName type="variant" source="DNB">University, Oxford, Balliol College</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -13980,14 +14407,18 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000122710773">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
                 <org xml:id="org_136008125">
                     <orgName type="display" source="bodl">Oxford, Corpus Christi College</orgName>
-                    <orgName type="variant"  source="DNB">University of Oxford, Corpus
-                        Christi College</orgName>
+                    <orgName type="variant" source="DNB">University of Oxford, Corpus Christi College</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -14020,6 +14451,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000106639073">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -14027,15 +14463,11 @@
                 <org xml:id="org_140757625">
                     <orgName type="display" source="bodl">Oxford, Christ Church (previously Cardinal College)</orgName>
                     <orgName type="variant">Cardinal College</orgName>
-                    <orgName type="variant"  source="DNB">Aedes Christi, g:Oxford</orgName>
-                    <orgName type="variant"  source="DNB">Christ Church College,
-                        g:Oxford</orgName>
-                    <orgName type="crossref"  source="DNB">University of Oxford, Aedes
-                        Christi</orgName>
-                    <orgName type="variant"  source="DNB">University of Oxford, Christ
-                        Church</orgName>
-                    <orgName type="variant"  source="DNB">University of Oxford, Christ Church
-                        College</orgName>
+                    <orgName type="variant" source="DNB">Aedes Christi, g:Oxford</orgName>
+                    <orgName type="variant" source="DNB">Christ Church College, g:Oxford</orgName>
+                    <orgName type="crossref" source="DNB">University of Oxford, Aedes Christi</orgName>
+                    <orgName type="variant" source="DNB">University of Oxford, Christ Church</orgName>
+                    <orgName type="variant" source="DNB">University of Oxford, Christ Church College</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -14058,12 +14490,23 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000123242350">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q86021443">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
                 <org xml:id="org_127102233">
-                    <orgName type="display" source="bodl">Lille, Chambre des comptes</orgName><!-- also http://viaf.org/viaf/142587845/-->
+                    <orgName type="display" source="bodl">Lille, Chambre des comptes</orgName>
+                    <!-- also http://viaf.org/viaf/142587845/-->
                     <note type="links">
                         <list type="links">
                             <item>
@@ -14086,6 +14529,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000121532274">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -14104,6 +14552,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q4976462">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -14111,14 +14564,10 @@
                 <org xml:id="org_128177579">
                     <orgName type="display" source="bodl">Beverley (Yorkshire), Collegiate Church of St. John</orgName>
                     <orgName type="variant" source="bodl">Beverley Minster</orgName>
-                    <orgName type="variant"  source="LC">Beverley Minster (Beverley,
-                        England)</orgName>
-                    <orgName type="crossref"  source="LC">Church of St. John (Beverley,
-                        England)</orgName>
-                    <orgName type="variant"  source="LC">Church of St. John and St. Martin
-                        (Beverley, England)</orgName>
-                    <orgName type="crossref"  source="LC">St. John&#x27;s (Church : Beverley,
-                        England)</orgName>
+                    <orgName type="variant" source="LC">Beverley Minster (Beverley, England)</orgName>
+                    <orgName type="crossref" source="LC">Church of St. John (Beverley, England)</orgName>
+                    <orgName type="variant" source="LC">Church of St. John and St. Martin (Beverley, England)</orgName>
+                    <orgName type="crossref" source="LC">St. John's (Church : Beverley, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -14165,6 +14614,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000404871030">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -14189,10 +14643,8 @@
                 
                 <org xml:id="org_154916527">
                     <orgName type="display" source="bodl">Winchester, Old Minster, afterwards cathedral priory</orgName>
-                    <orgName type="variant"  source="DNB">Cathedral Church of the Holy
-                        Trinity and of Saint Peter and Saint Paul and of Saint Swithun, g:Winchester</orgName>
-                    <orgName type="variant"  source="DNB">Cathedral Church of the Holy
-                        Trinity and of St. Peter and St. Paul and of St. Swithun, g:Winchester</orgName>
+                    <orgName type="variant" source="DNB">Cathedral Church of the Holy Trinity and of Saint Peter and Saint Paul and of Saint Swithun, g:Winchester</orgName>
+                    <orgName type="variant" source="DNB">Cathedral Church of the Holy Trinity and of St. Peter and St. Paul and of St. Swithun, g:Winchester</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -14220,15 +14672,20 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000107287460">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
                 <org xml:id="org_158596637">
                     <orgName type="display" source="bodl">Buildwas (Shropshire), <affiliation>Cistercian</affiliation> abbey of St. Mary and St. Chad</orgName>
-                    <orgName type="crossref"  source="LC">Buildewas Abbey (England)</orgName>
-                    <orgName type="variant"  source="LC">Buildwas Abbey (England)</orgName>
-                    <orgName type="variant"  source="LC">Buldwas Abbey (England)</orgName>
+                    <orgName type="crossref" source="LC">Buildewas Abbey (England)</orgName>
+                    <orgName type="variant" source="LC">Buildwas Abbey (England)</orgName>
+                    <orgName type="variant" source="LC">Buldwas Abbey (England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -14281,6 +14738,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000121885934">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -14288,12 +14750,9 @@
                 <org xml:id="org_168613438">
                     <orgName type="display" source="bodl">Olomouc, cathedral church</orgName>
                     <orgName type="variant" source="bodl">Olmütz cathedral</orgName>
-                    <orgName type="variant"  source="LC">Chrám sv. Mořice (Olomouc, Czech
-                        Republic)</orgName>
-                    <orgName type="variant"  source="LC">Chrám svatého Mořice (Olomouc, Czech
-                        Republic)</orgName>
-                    <orgName type="crossref"  source="LC">Sankt Mauritz in Olmütz
-                        (Cathedral)</orgName>
+                    <orgName type="variant" source="LC">Chrám sv. Mořice (Olomouc, Czech Republic)</orgName>
+                    <orgName type="variant" source="LC">Chrám svatého Mořice (Olomouc, Czech Republic)</orgName>
+                    <orgName type="crossref" source="LC">Sankt Mauritz in Olmütz (Cathedral)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -14308,13 +14767,11 @@
                             </item>
                         </list>
                     </note>
-                    
                 </org>
                 
                 <org xml:id="org_145707239">
                     <orgName type="display" source="bodl">Paris, church and hospital of Saint-Sépulcre </orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="BNF">Hôpital du
-                        Saint-Sépulcre, Paris</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="BNF">Hôpital du Saint-Sépulcre, Paris</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -14331,14 +14788,13 @@
                     </note>
                 </org>
                 
-                
                 <org xml:id="org_140811075">
                     <orgName type="display" source="bodl">Trois-Fontaines (dep. Marne), <affiliation>Cistercian</affiliation> abbey</orgName>
                     <orgName type="variant">Troisfontaines</orgName>
                     <location>
                         <geo>48.7177,4.9507</geo>
                     </location>
-                    <orgName type="variant"  source="DNB">Kloster Trois-Fontaines</orgName>
+                    <orgName type="variant" source="DNB">Kloster Trois-Fontaines</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -14359,8 +14815,8 @@
                         </list>
                     </note>
                     <note>Coordinates for the settlement of Trois-Fontaines, from the <ref
-                        target="http://www.getty.edu/research/tools/vocabularies/tgn/">Getty
-                        Thesaurus of Geographic Names</ref>, copyright 2017 the J. Paul Getty
+                            target="http://www.getty.edu/research/tools/vocabularies/tgn/">Getty
+                            Thesaurus of Geographic Names</ref>, copyright 2017 the J. Paul Getty
                         Trust, released under the <ref
                             target="https://opendatacommons.org/licenses/by/1-0/">Open Data Commons
                             Attribution License (ODC-By) 1.0</ref>.</note>
@@ -14451,31 +14907,33 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000122939906">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
                 <org xml:id="org_134422552">
-                    <orgName type="display" source="bodl">Nikolsburg (Czech Republic),  Dietrichstein library</orgName>
+                    <orgName type="display" source="bodl">Nikolsburg (Czech Republic), Dietrichstein library</orgName>
                     <orgName type="variant">Mikulov, Dietrichstein library</orgName>
-                    <orgName type="variant"  source="DNB">Fürstlich-Dietrichstein&#x27;sche
-                        Fideicommiss-Bibliothek</orgName>
-                    <orgName type="crossref"  source="DNB">Dietrichstein&#x27;sche
-                        Fideicommiss-Bibliothek</orgName>
-                    <orgName type="variant"  source="DNB">Dietrichsteinsche
-                        Bibliothek</orgName>
-                    <orgName type="variant"  source="DNB">Dietrichsteinská Knihovna</orgName>
-                    <orgName type="variant"  source="DNB">Dietrichstein’sche
-                        Fideicommiss-Bibliothek</orgName>
-                    <orgName type="variant"  source="DNB">Fürst Dietrichsteinsche
-                        Bibliothek</orgName>
-                    <orgName type="variant"  source="DNB">Fürstlich-Dietrichstein’sche
-                        Fideicommiss-Bibliothek</orgName>
-                    <orgName type="crossref"  source="DNB">Knížecí Dietrichsteinská
-                        Knihovna</orgName>
+                    <orgName type="variant" source="DNB">Fürstlich-Dietrichstein'sche Fideicommiss-Bibliothek</orgName>
+                    <orgName type="crossref" source="DNB">Dietrichstein'sche Fideicommiss-Bibliothek</orgName>
+                    <orgName type="variant" source="DNB">Dietrichsteinsche Bibliothek</orgName>
+                    <orgName type="variant" source="DNB">Dietrichsteinská Knihovna</orgName>
+                    <orgName type="variant" source="DNB">Dietrichstein’sche Fideicommiss-Bibliothek</orgName>
+                    <orgName type="variant" source="DNB">Fürst Dietrichsteinsche Bibliothek</orgName>
+                    <orgName type="variant" source="DNB">Fürstlich-Dietrichstein’sche Fideicommiss-Bibliothek</orgName>
+                    <orgName type="crossref" source="DNB">Knížecí Dietrichsteinská Knihovna</orgName>
                     <note type="links">
                         <list type="links">
-                            <item><ref target="http://data.cerl.org/owners/4488"><title>CERL</title></ref></item>
+                            <item>
+                                <ref target="http://data.cerl.org/owners/4488">
+                                    <title>CERL</title>
+                                </ref>
+                            </item>
                             <item>
                                 <ref target="http://d-nb.info/gnd/5086794-5">
                                     <title>GND</title>
@@ -14492,10 +14950,8 @@
                 
                 <org xml:id="org_2142145857037522921207">
                     <orgName type="display" source="bodl">Windsor, <affiliation>secular college</affiliation> of St. George's Chapel</orgName>
-                    <orgName type="variant"  source="DNB">College of St. George,
-                        Windsor</orgName>
-                    <orgName type="variant"  source="DNB">College of Saint George,
-                        Windsor</orgName>
+                    <orgName type="variant" source="DNB">College of St. George, Windsor</orgName>
+                    <orgName type="variant" source="DNB">College of Saint George, Windsor</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -14593,34 +15049,33 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000123537044">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q6820716">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
                 <org xml:id="org_159087661">
                     <orgName type="display" source="bodl">Oxford, St. John's College</orgName>
-                    <orgName type="variant"  source="DNB">Saint John Baptist College,
-                        Oxford</orgName>
-                    <orgName type="variant"  source="DNB">Saint John&#x27;s College Oxford,
-                        Ehemalige Vorzugsbenennung SWD</orgName>
-                    <orgName type="variant"  source="DNB">Saint John&#x27;s College,
-                        Oxford</orgName>
-                    <orgName type="variant"  source="DNB">Saint John&#x27;s College,
-                        University of Oxford</orgName>
-                    <orgName type="variant"  source="DNB">St. John&#x27;s College,
-                        Oxford</orgName>
-                    <orgName type="variant"  source="DNB">St. John&#x27;s College, University
-                        of Oxford</orgName>
-                    <orgName type="crossref"  source="DNB">University of Oxford, Saint John
-                        Baptist College</orgName>
-                    <orgName type="variant"  source="DNB">University of Oxford, Saint
-                        John&#x27;s College</orgName>
-                    <orgName type="variant"  source="DNB">University of Oxford, St
-                        John&#x27;s College</orgName>
-                    <orgName type="variant"  source="DNB">University of Oxford, St.
-                        John&#x27;s College, Oxford</orgName>
-                    <orgName type="variant"  source="DNB">University, Oxford, St. John&#x27;s
-                        College</orgName>
+                    <orgName type="variant" source="DNB">Saint John Baptist College, Oxford</orgName>
+                    <orgName type="variant" source="DNB">Saint John's College Oxford, Ehemalige Vorzugsbenennung SWD</orgName>
+                    <orgName type="variant" source="DNB">Saint John's College, Oxford</orgName>
+                    <orgName type="variant" source="DNB">Saint John's College, University of Oxford</orgName>
+                    <orgName type="variant" source="DNB">St. John's College, Oxford</orgName>
+                    <orgName type="variant" source="DNB">St. John's College, University of Oxford</orgName>
+                    <orgName type="crossref" source="DNB">University of Oxford, Saint John Baptist College</orgName>
+                    <orgName type="variant" source="DNB">University of Oxford, Saint John's College</orgName>
+                    <orgName type="variant" source="DNB">University of Oxford, St John's College</orgName>
+                    <orgName type="variant" source="DNB">University of Oxford, St. John's College, Oxford</orgName>
+                    <orgName type="variant" source="DNB">University, Oxford, St. John's College</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -14643,6 +15098,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000122966373">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -14650,14 +15110,10 @@
                 <org xml:id="org_148998848">
                     <orgName type="display" source="bodl">Würzburg, cathedral church of St. Kilian</orgName>
                     <orgName type="variant" source="bodl">Würzburg, cathedral church of St. Kylian</orgName>
-                    <orgName type="variant"  source="LC">St. Kiliansdom (Würzburg,
-                        Germany)</orgName>
-                    <orgName type="crossref" subtype="unknownOrder" source="DNB">Kiliansdom,
-                        g:Würzburg</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Sankt Kilian,
-                        g:Würzburg</orgName>
-                    <orgName type="crossref" subtype="unknownOrder" source="DNB">Würzburger Dom,
-                        g:Würzburg</orgName>
+                    <orgName type="variant" source="LC">St. Kiliansdom (Würzburg, Germany)</orgName>
+                    <orgName type="crossref" subtype="unknownOrder" source="DNB">Kiliansdom, g:Würzburg</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Sankt Kilian, g:Würzburg</orgName>
+                    <orgName type="crossref" subtype="unknownOrder" source="DNB">Würzburger Dom, g:Würzburg</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -14686,17 +15142,12 @@
                 
                 <org xml:id="org_139684558">
                     <orgName type="display" source="bodl">Peterborough, <affiliation>Benedictine</affiliation> abbey</orgName>
-                    <orgName type="variant"  source="DNB">Abbey of Saint Peter, Saint Paul,
-                        and Saint Andrew</orgName>
-                    <orgName type="variant"  source="DNB">Abbey of St. Peter, St. Paul, and
-                        St. Andrew</orgName>
-                    <orgName type="crossref"  source="DNB">Kloster Peterborough, Ehemalige
-                        Vorzugsbenennung SWD</orgName>
-                    <orgName type="crossref"  source="DNB">Monastery of
-                        Medehamstede</orgName>
-                    <orgName type="variant"  source="DNB">Peterborough Abbey</orgName>
-                    <orgName type="variant"  source="DNB">Peterborough Abbey, Peterborough,
-                        g:Cambrigde</orgName>
+                    <orgName type="variant" source="DNB">Abbey of Saint Peter, Saint Paul, and Saint Andrew</orgName>
+                    <orgName type="variant" source="DNB">Abbey of St. Peter, St. Paul, and St. Andrew</orgName>
+                    <orgName type="crossref" source="DNB">Kloster Peterborough, Ehemalige Vorzugsbenennung SWD</orgName>
+                    <orgName type="crossref" source="DNB">Monastery of Medehamstede</orgName>
+                    <orgName type="variant" source="DNB">Peterborough Abbey</orgName>
+                    <orgName type="variant" source="DNB">Peterborough Abbey, Peterborough, g:Cambrigde</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -14720,10 +15171,8 @@
                 
                 <org xml:id="org_158720589">
                     <orgName type="display" source="bodl">Dublin, cathedral priory (<affiliation>Augustinian</affiliation>)</orgName>
-                    <orgName type="variant"  source="LC">Christ Church Cathedral (Dublin,
-                        Ireland)</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Cathedral Church of the Holy
-                        Trinity, Dublin</orgName>
+                    <orgName type="variant" source="LC">Christ Church Cathedral (Dublin, Ireland)</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Cathedral Church of the Holy Trinity, Dublin</orgName>
                     <orgName type="variant" subtype="unknownOrder" source="DNB">Christ Church, Dublin</orgName>
                     <orgName type="crossref" subtype="unknownOrder" source="DNB">Holy Trinity, Dublin</orgName>
                     <note type="links">
@@ -14753,14 +15202,23 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/no2005086571">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q5108790">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
                 <org xml:id="org_136343236">
                     <orgName type="display" source="bodl">Dublin, <affiliation>Cistercian</affiliation> abbey of St Mary</orgName>
-                    <orgName type="variant"  source="LC">St. Mary&#x27;s Abbey (Dublin,
-                        Ireland)</orgName>
+                    <orgName type="variant" source="LC">St. Mary's Abbey (Dublin, Ireland)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -14781,6 +15239,11 @@
                             <item>
                                 <ref target="https://viaf.org/viaf/136343236">
                                     <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000404311199">
+                                    <title>ISNI</title>
                                 </ref>
                             </item>
                         </list>
@@ -14830,18 +15293,14 @@
                 
                 <org xml:id="org_139580416">
                     <orgName type="display" source="bodl">Tegernsee, <affiliation>Benedictine</affiliation> abbey</orgName>
-                    <orgName type="variant"  source="LC">Tegernsee (Abbey)</orgName>
-                    <orgName type="variant"  source="DNB">Abtei Tegernsee</orgName>
-                    <orgName type="variant"  source="DNB">Benediktinerabtei
-                        Tegernsee</orgName>
-                    <orgName type="variant"  source="DNB">Benediktinerabtei,
-                        Tegernsee</orgName>
-                    <orgName type="variant"  source="DNB">Benediktinerkloster,
-                        Tegernsee</orgName>
-                    <orgName type="variant"  source="DNB">Conventus Tegernseensis</orgName>
-                    <orgName type="variant"  source="DNB">Kloster, Tegernsee</orgName>
-                    <orgName type="variant"  source="DNB">Monasterium
-                        Tegernseensis</orgName>
+                    <orgName type="variant" source="LC">Tegernsee (Abbey)</orgName>
+                    <orgName type="variant" source="DNB">Abtei Tegernsee</orgName>
+                    <orgName type="variant" source="DNB">Benediktinerabtei Tegernsee</orgName>
+                    <orgName type="variant" source="DNB">Benediktinerabtei, Tegernsee</orgName>
+                    <orgName type="variant" source="DNB">Benediktinerkloster, Tegernsee</orgName>
+                    <orgName type="variant" source="DNB">Conventus Tegernseensis</orgName>
+                    <orgName type="variant" source="DNB">Kloster, Tegernsee</orgName>
+                    <orgName type="variant" source="DNB">Monasterium Tegernseensis</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -14867,8 +15326,6 @@
                         </list>
                     </note>
                 </org>
-                
-               
                 
                 <org xml:id="org_135437628">
                     <orgName type="display" source="bodl">Cambridge, King's College</orgName>
@@ -14904,6 +15361,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000121694257">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -14923,9 +15385,8 @@
                 
                 <org xml:id="org_269197839">
                     <orgName type="display" source="bodl">Freiburg im Breisgau, <affiliation>Capuchin</affiliation> convent</orgName>
-                    <orgName type="variant"  source="DNB">Kapuzinerkloster Freiburg</orgName>
-                    <orgName type="variant"  source="DNB">Kapuzinerkloster Freiburg im
-                        Breisgau</orgName>
+                    <orgName type="variant" source="DNB">Kapuzinerkloster Freiburg</orgName>
+                    <orgName type="variant" source="DNB">Kapuzinerkloster Freiburg im Breisgau</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -14941,6 +15402,11 @@
                             <item>
                                 <ref target="https://viaf.org/viaf/269197839">
                                     <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q16763074">
+                                    <title>Wikidata</title>
                                 </ref>
                             </item>
                         </list>
@@ -14972,8 +15438,7 @@
                 
                 <org xml:id="org_141158386">
                     <orgName type="display" source="bodl">Abingdon, <affiliation>Benedictine</affiliation> abbey</orgName>
-                    <orgName type="variant"  source="DNB">Monastery of Saint Mary,
-                        g:Abingdon</orgName>
+                    <orgName type="variant" source="DNB">Monastery of Saint Mary, g:Abingdon</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -15006,12 +15471,17 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000095717768">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
                 <org xml:id="org_143023731">
-                <orgName type="display" source="bodl">Oxford, All Souls College</orgName>
+                    <orgName type="display" source="bodl">Oxford, All Souls College</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -15044,9 +15514,13 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000121736314">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
-                    
                 </org>
                 
                 <org xml:id="org_157563783">
@@ -15143,9 +15617,8 @@
                 
                 <org xml:id="org_151936876">
                     <orgName type="display" source="bodl">Scheyern, <affiliation>Benedictine</affiliation> abbey</orgName>
-                    <orgName type="variant"  source="DNB">Benediktinerabtei,
-                        Scheyern</orgName>
-                    <orgName type="variant"  source="DNB">Abtei, Scheyern</orgName>
+                    <orgName type="variant" source="DNB">Benediktinerabtei, Scheyern</orgName>
+                    <orgName type="variant" source="DNB">Abtei, Scheyern</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -15177,12 +15650,10 @@
                     <location>
                         <geo>47.6833,9.0667</geo>
                     </location>
-                    <orgName type="variant"  source="DNB">Kloster Reichenau</orgName>
-                    <orgName type="variant"  source="DNB">Abtei Reichenau</orgName>
-                    <orgName type="variant"  source="DNB">Benediktinerabtei
-                        Reichenau</orgName>
-                    <orgName type="variant"  source="DNB">Monasterium Augiae
-                        Divitis</orgName>
+                    <orgName type="variant" source="DNB">Kloster Reichenau</orgName>
+                    <orgName type="variant" source="DNB">Abtei Reichenau</orgName>
+                    <orgName type="variant" source="DNB">Benediktinerabtei Reichenau</orgName>
+                    <orgName type="variant" source="DNB">Monasterium Augiae Divitis</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -15203,8 +15674,8 @@
                         </list>
                     </note>
                     <note type="source">Co-ordinates (for the island of Reichenau) from the <ref
-                        target="http://www.getty.edu/research/tools/vocabularies/tgn/">Getty
-                        Thesaurus of Geographic Names</ref>, copyright 2017 the J. Paul Getty
+                            target="http://www.getty.edu/research/tools/vocabularies/tgn/">Getty
+                            Thesaurus of Geographic Names</ref>, copyright 2017 the J. Paul Getty
                         Trust, released under the <ref
                             target="https://opendatacommons.org/licenses/by/1-0/">Open Data Commons
                             Attribution License (ODC-By) 1.0</ref>.</note>
@@ -15244,18 +15715,20 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000106750214">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
                 <org xml:id="org_131247511">
                     <orgName type="display" source="bodl">Chelles, <affiliation>Benedictine</affiliation> nunnery</orgName>
-                    <orgName type="variant"  source="LC">Abbaye de Chelles (Chelles,
-                        Seine-et-Marne, France)</orgName>
-                    <orgName type="variant"  source="LC">Abbey of Notre-Dame-de-Chelles
-                        (Chelles, Seine-et-Marne, France)</orgName>
-                    <orgName type="variant"  source="LC">Notre-Dame-de-Chelles (Abbey :
-                        Chelles, Seine-et-Marne, France)</orgName>
+                    <orgName type="variant" source="LC">Abbaye de Chelles (Chelles, Seine-et-Marne, France)</orgName>
+                    <orgName type="variant" source="LC">Abbey of Notre-Dame-de-Chelles (Chelles, Seine-et-Marne, France)</orgName>
+                    <orgName type="variant" source="LC">Notre-Dame-de-Chelles (Abbey : Chelles, Seine-et-Marne, France)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -15283,6 +15756,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/000000012158607X">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -15307,22 +15785,14 @@
                 
                 <org xml:id="org_152458362">
                     <orgName type="display" source="bodl">Mariënwater (in Rosmalen, 's-Hertogenbosch), Bridgettine nunnery </orgName>
-                    <orgName type="variant"  source="LC">Marienwater (Monastery : Rosmalen,
-                        Netherlands)</orgName>
-                    <orgName type="variant"  source="LC">Ad Aquas Frigidas (Monastery :
-                        Rosmalen, Netherlands)</orgName>
-                    <orgName type="variant"  source="LC">Ad Aquas Marie prope Buscum Ducis
-                        (Monastery)</orgName>
-                    <orgName type="variant"  source="LC">Coudewater (Monastery : Rosmalen,
-                        Netherlands)</orgName>
-                    <orgName type="variant"  source="LC">Klooster Coudewater (Rosmalen,
-                        Netherlands)</orgName>
-                    <orgName type="variant"  source="LC">Klooster Mariënwater (Rosmalen,
-                        Netherlands)</orgName>
-                    <orgName type="variant"  source="LC">Koudewater (Monastery : Rosmalen,
-                        Netherlands)</orgName>
-                    <orgName type="variant"  source="LC">O.L. Vrouw van de Koude Wateren
-                        (Monastery : Rosmalen, Netherlands)</orgName>
+                    <orgName type="variant" source="LC">Marienwater (Monastery : Rosmalen, Netherlands)</orgName>
+                    <orgName type="variant" source="LC">Ad Aquas Frigidas (Monastery : Rosmalen, Netherlands)</orgName>
+                    <orgName type="variant" source="LC">Ad Aquas Marie prope Buscum Ducis (Monastery)</orgName>
+                    <orgName type="variant" source="LC">Coudewater (Monastery : Rosmalen, Netherlands)</orgName>
+                    <orgName type="variant" source="LC">Klooster Coudewater (Rosmalen, Netherlands)</orgName>
+                    <orgName type="variant" source="LC">Klooster Mariënwater (Rosmalen, Netherlands)</orgName>
+                    <orgName type="variant" source="LC">Koudewater (Monastery : Rosmalen, Netherlands)</orgName>
+                    <orgName type="variant" source="LC">O.L. Vrouw van de Koude Wateren (Monastery : Rosmalen, Netherlands)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -15333,6 +15803,11 @@
                             <item>
                                 <ref target="https://viaf.org/viaf/152458362">
                                     <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q17603380">
+                                    <title>Wikidata</title>
                                 </ref>
                             </item>
                         </list>
@@ -15359,8 +15834,7 @@
                 
                 <org xml:id="org_313222993">
                     <orgName type="display" source="bodl">Aubazines, <affiliation>Cistercian</affiliation> abbey of St Mary</orgName>
-                    <orgName type="variant"  source="SUDOC">Religieuses du Sacré-Coeur de
-                        Marie (Aubazine, Corrèze)</orgName>
+                    <orgName type="variant" source="SUDOC">Religieuses du Sacré-Coeur de Marie (Aubazine, Corrèze)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -15379,10 +15853,8 @@
                 
                 <org xml:id="org_168675251">
                     <orgName type="display" source="bodl">Florence, <affiliation>Camaldolese</affiliation> convent of S. Maria degli Angeli</orgName>
-                    <orgName type="variant"  source="LC">Convento di S. Maria degli Angeli
-                        (Florence, Italy)</orgName>
-                    <orgName type="variant"  source="DNB">Convento di Santa Maria degli
-                        Angeli, Florenz</orgName>
+                    <orgName type="variant" source="LC">Convento di S. Maria degli Angeli (Florence, Italy)</orgName>
+                    <orgName type="variant" source="DNB">Convento di Santa Maria degli Angeli, Florenz</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -15403,6 +15875,16 @@
                             <item>
                                 <ref target="https://viaf.org/viaf/168675251">
                                     <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000122048177">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q24933742">
+                                    <title>Wikidata</title>
                                 </ref>
                             </item>
                         </list>
@@ -15443,12 +15925,35 @@
                     <!-- check the date? -->
                 </org>
                 
-                
-               
-                 <org xml:id="org_141123009">
-                <orgName type="display" source="bodl">Florence (Ferrara), Council of (1438-45)</orgName>
-               <!-- check: add variants -->
-                     <note type="links"><list type="links"><item><ref target="https://viaf.org/viaf/141123009"><title>VIAF</title></ref></item></list></note>
+                <org xml:id="org_141123009">
+                    <orgName type="display" source="bodl">Florence (Ferrara), Council of (1438-45)</orgName>
+                    <!-- check: add variants -->
+                    <note type="links">
+                        <list type="links">
+                            <item>
+                                <ref target="https://viaf.org/viaf/141123009">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000121706780">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/n50001247">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://catalogue.bnf.fr/ark:/12148/cb12148045b">
+                                    <title>BNF</title>
+                                </ref>
+                            </item>
+                            
+                            
+                        </list>
+                    </note>
                 </org>
                 
                 <org xml:id="org_146685036">
@@ -15481,14 +15986,10 @@
                 
                 <org xml:id="org_132688628">
                     <orgName type="display" source="bodl">Vincennes, Council of (1329)</orgName>
-                    <orgName type="variant"  source="LC">Assemblée de Vincennes,
-                        (1329)</orgName>
-                    <orgName type="variant"  source="LC">Conférences de Vincennes,
-                        (1329)</orgName>
-                    <orgName type="variant" subtype="surnameFirst" source="LC">France., Assemblée de Vincennes,
-                        (1329)</orgName>
-                    <orgName type="variant"  source="LC">Vincennes, Assembly of,
-                        1329</orgName>
+                    <orgName type="variant" source="LC">Assemblée de Vincennes, (1329)</orgName>
+                    <orgName type="variant" source="LC">Conférences de Vincennes, (1329)</orgName>
+                    <orgName type="variant" subtype="surnameFirst" source="LC">France., Assemblée de Vincennes, (1329)</orgName>
+                    <orgName type="variant" source="LC">Vincennes, Assembly of, 1329</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -15517,11 +16018,9 @@
                 
                 <org xml:id="org_311465280">
                     <orgName type="display" source="bodl">Coventry, <affiliation>Benedictine</affiliation> cathedral priory of St Mary</orgName>
-                    <orgName type="variant"  source="LC">St Mary&#x27;s Priory and Cathedral
-                        (Coventry, England)</orgName>
-                    <orgName type="variant"  source="LC">Coventry Priory Cathedral</orgName>
-                    <orgName type="variant"  source="LC">Saint Mary&#x27;s Priory and
-                        Cathedral (Coventry, England)</orgName>
+                    <orgName type="variant" source="LC">St Mary's Priory and Cathedral (Coventry, England)</orgName>
+                    <orgName type="variant" source="LC">Coventry Priory Cathedral</orgName>
+                    <orgName type="variant" source="LC">Saint Mary's Priory and Cathedral (Coventry, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -15545,16 +16044,11 @@
                 
                 <org xml:id="org_144471224">
                     <orgName type="display" source="bodl">Crowland, <affiliation>Benedictine</affiliation> abbey</orgName>
-                    <orgName type="variant"  source="LC">Croyland Abbey (Crowland,
-                        England)</orgName>
-                    <orgName type="variant"  source="LC">Abbatia Croylandesis (Crowland,
-                        England)</orgName>
-                    <orgName type="variant"  source="LC">Abbey of Croyland (Crowland,
-                        England)</orgName>
-                    <orgName type="variant"  source="LC">Church of the Blessed Virgin Mary,
-                        Saint Bartholomew, and Saint Guthlac (Crowland, England)</orgName>
-                    <orgName type="variant"  source="LC">Crowland Abbey (Crowland,
-                        England)</orgName>
+                    <orgName type="variant" source="LC">Croyland Abbey (Crowland, England)</orgName>
+                    <orgName type="variant" source="LC">Abbatia Croylandesis (Crowland, England)</orgName>
+                    <orgName type="variant" source="LC">Abbey of Croyland (Crowland, England)</orgName>
+                    <orgName type="variant" source="LC">Church of the Blessed Virgin Mary, Saint Bartholomew, and Saint Guthlac (Crowland, England)</orgName>
+                    <orgName type="variant" source="LC">Crowland Abbey (Crowland, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -15617,7 +16111,8 @@
                     </note>
                 </org>
                 
-                <org xml:id="org_305126922"><orgName type="display" source="bodl">Liège, diocese</orgName>
+                <org xml:id="org_305126922">
+                    <orgName type="display" source="bodl">Liège, diocese</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -15640,15 +16135,21 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q871606">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
-                    </note></org>
+                    </note>
+                </org>
                 
                 <org xml:id="org_152509582">
                     <orgName type="display" source="bodl">Lisbon, English College</orgName>
-                    <orgName type="variant"  source="LC">English College of Lisbon</orgName>
-                    <orgName type="variant"  source="DNB">English College, Lissabon</orgName>
-                    <orgName type="variant"  source="DNB">Lisbo College</orgName>
-                    <orgName type="variant"  source="DNB">Lisbon College</orgName>
+                    <orgName type="variant" source="LC">English College of Lisbon</orgName>
+                    <orgName type="variant" source="DNB">English College, Lissabon</orgName>
+                    <orgName type="variant" source="DNB">Lisbo College</orgName>
+                    <orgName type="variant" source="DNB">Lisbon College</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -15709,6 +16210,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/000000012112764X">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -15747,16 +16253,21 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000122547101">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
                 <org xml:id="org_145549427">
                     <orgName type="display" source="bodl">Godstow, <affiliation>Benedictine</affiliation> nunnery</orgName>
-                    <orgName type="variant"  source="LC">Godstow Nunnery</orgName>
-                    <orgName type="variant"  source="LC">Abbey of Godstow</orgName>
-                    <orgName type="variant"  source="LC">Godstow Abbey</orgName>
-                    <orgName type="variant"  source="LC">Godstow Priory</orgName>
+                    <orgName type="variant" source="LC">Godstow Nunnery</orgName>
+                    <orgName type="variant" source="LC">Abbey of Godstow</orgName>
+                    <orgName type="variant" source="LC">Godstow Abbey</orgName>
+                    <orgName type="variant" source="LC">Godstow Priory</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -15798,10 +16309,9 @@
                 
                 <org xml:id="org_234338663">
                     <orgName type="display" source="bodl">Guisborough, <affiliation>Augustinian</affiliation> priory</orgName>
-                    <orgName type="variant"  source="DNB">Kloster Guisborough</orgName>
-                    <orgName type="variant"  source="DNB">Augustinerkloster,
-                        Guisborough</orgName>
-                    <orgName type="variant"  source="DNB">Gisborough Priory</orgName>
+                    <orgName type="variant" source="DNB">Kloster Guisborough</orgName>
+                    <orgName type="variant" source="DNB">Augustinerkloster, Guisborough</orgName>
+                    <orgName type="variant" source="DNB">Gisborough Priory</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -15853,14 +16363,11 @@
                 
                 <org xml:id="org_142485651">
                     <orgName type="display" source="bodl">Himmerod, <affiliation>Cistercian</affiliation> abbey</orgName>
-                    <orgName type="variant"  source="DNB">Kloster Himmerod</orgName>
-                    <orgName type="variant"  source="DNB">Abtei Himmerod</orgName>
-                    <orgName type="variant"  source="DNB">Kloster Unserer Lieben Frau
-                        Himmerod</orgName>
-                    <orgName type="variant"  source="DNB">Zisterzienserabtei
-                        Himmerod</orgName>
-                    <orgName type="variant"  source="DNB">Zisterzienserkloster
-                        Himmerod</orgName>
+                    <orgName type="variant" source="DNB">Kloster Himmerod</orgName>
+                    <orgName type="variant" source="DNB">Abtei Himmerod</orgName>
+                    <orgName type="variant" source="DNB">Kloster Unserer Lieben Frau Himmerod</orgName>
+                    <orgName type="variant" source="DNB">Zisterzienserabtei Himmerod</orgName>
+                    <orgName type="variant" source="DNB">Zisterzienserkloster Himmerod</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -15906,10 +16413,9 @@
                 </org>
                 
                 <org xml:id="org_151723892">
-                    <orgName type="display" source="bodl">Kirkham (Yorkshire), <affiliation>Augustinian</affiliation> priory</orgName>  <orgName type="variant"  source="LC">Kirkham Priory (Yorkshire,
-                        England)</orgName>
-                    <orgName type="variant"  source="LC">Kirkham Abbey (Yorkshire,
-                        England)</orgName>
+                    <orgName type="display" source="bodl">Kirkham (Yorkshire), <affiliation>Augustinian</affiliation> priory</orgName>
+                    <orgName type="variant" source="LC">Kirkham Priory (Yorkshire, England)</orgName>
+                    <orgName type="variant" source="LC">Kirkham Abbey (Yorkshire, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -15956,15 +16462,11 @@
                 
                 <org xml:id="org_158948225">
                     <orgName type="display" source="bodl">Klosterneuburg, <affiliation>Augustinian</affiliation> abbey</orgName>
-                    <orgName type="variant"  source="LC">Stift Klosterneuburg</orgName>
-                    <orgName type="variant"  source="DNB">Augustiner-Chorherrenstift
-                        Klosterneuburg</orgName>
-                    <orgName type="variant"  source="DNB">Chorherrenstift
-                        Klosterneuburg</orgName>
-                    <orgName type="variant"  source="DNB">Chorherrenstift Klosterneuburg
-                        Verlag</orgName>
-                    <orgName type="variant"  source="DNB">Klosterneuburg,
-                        Chorherrenstift</orgName>
+                    <orgName type="variant" source="LC">Stift Klosterneuburg</orgName>
+                    <orgName type="variant" source="DNB">Augustiner-Chorherrenstift Klosterneuburg</orgName>
+                    <orgName type="variant" source="DNB">Chorherrenstift Klosterneuburg</orgName>
+                    <orgName type="variant" source="DNB">Chorherrenstift Klosterneuburg Verlag</orgName>
+                    <orgName type="variant" source="DNB">Klosterneuburg, Chorherrenstift</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -15985,6 +16487,16 @@
                             <item>
                                 <ref target="https://viaf.org/viaf/158948225">
                                     <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://catalogue.bnf.fr/ark:/12148/cb12063607g">
+                                    <title>BNF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q697145">
+                                    <title>Wikidata</title>
                                 </ref>
                             </item>
                         </list>
@@ -16043,6 +16555,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000404278528">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                     <!-- viaf ref = 'London corporation' -->
@@ -16050,14 +16567,10 @@
                 
                 <org xml:id="org_239220402">
                     <orgName type="display" source="bodl">Luxeuil, <affiliation>Benedictine</affiliation> abbey</orgName>
-                    <orgName type="variant"  source="LC">Monastère de Luxeuil
-                        (Luxeuil-les-Bains, France)</orgName>
-                    <orgName type="variant"  source="LC">Abbaye Saint-Colomban de Luxeuil
-                        (Luxeuil-les-Bains, France)</orgName>
-                    <orgName type="variant"  source="LC">Kloster von Luxeuil
-                        (Luxeuil-les-Bains, France)</orgName>
-                    <orgName type="variant"  source="LC">Kloster zu Luxeuil
-                        (Luxeuil-les-Bains, France)</orgName>
+                    <orgName type="variant" source="LC">Monastère de Luxeuil (Luxeuil-les-Bains, France)</orgName>
+                    <orgName type="variant" source="LC">Abbaye Saint-Colomban de Luxeuil (Luxeuil-les-Bains, France)</orgName>
+                    <orgName type="variant" source="LC">Kloster von Luxeuil (Luxeuil-les-Bains, France)</orgName>
+                    <orgName type="variant" source="LC">Kloster zu Luxeuil (Luxeuil-les-Bains, France)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -16091,18 +16604,21 @@
                 
                 <org xml:id="org_132406363">
                     <orgName type="display" source="bodl">Mainz, <affiliation>Carthusian</affiliation> abbey of St Michael</orgName>
-                    <orgName type="variant"  source="DNB">Kartause, Mainz</orgName>
-                    <orgName type="variant"  source="DNB">Cartusia Moguntina</orgName>
-                    <orgName type="variant"  source="DNB">Kartäuser, Kartause,
-                        Mainz</orgName>
-                    <orgName type="variant"  source="DNB">Kartäuser, Mainz</orgName>
+                    <orgName type="variant" source="DNB">Kartause, Mainz</orgName>
+                    <orgName type="variant" source="DNB">Cartusia Moguntina</orgName>
+                    <orgName type="variant" source="DNB">Kartäuser, Kartause, Mainz</orgName>
+                    <orgName type="variant" source="DNB">Kartäuser, Mainz</orgName>
                     <location source="http://klosterdatenbank.germania-sacra.de/gsn/40176">
                         <geo>49.989614874514,8.2876825332642</geo>
                     </location>
                     <note>Co-ordinates from Germania Sacra</note>
                     <note type="links">
                         <list type="links">
-                            <item><ref target="http://klosterdatenbank.germania-sacra.de/gsn/40176"><title>Germania Sacra</title></ref></item>
+                            <item>
+                                <ref target="http://klosterdatenbank.germania-sacra.de/gsn/40176">
+                                    <title>Germania Sacra</title>
+                                </ref>
+                            </item>
                             <item>
                                 <ref target="http://d-nb.info/gnd/3072620-7">
                                     <title>GND</title>
@@ -16111,6 +16627,11 @@
                             <item>
                                 <ref target="https://viaf.org/viaf/132406363">
                                     <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/nb2019007432">
+                                    <title>LC</title>
                                 </ref>
                             </item>
                         </list>
@@ -16177,20 +16698,23 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000121835128">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
                 <org xml:id="org_242823650">
                     <orgName type="display" source="bodl">Zevenborren, <affiliation>Augustinian</affiliation> priory</orgName>
-                    <orgName type="variant"  source="DNB">Priorij Zevenborren</orgName>
-                    <orgName type="variant"  source="DNB">Augustiner-Chorherrenstift
-                        Zevenborren</orgName>
-                    <orgName type="variant"  source="DNB">Augustinerpriorij
-                        Zevenborren</orgName>
-                    <orgName type="variant"  source="DNB">Conventus Septem Fontium</orgName>
-                    <orgName type="variant"  source="DNB">Klooster Zevenborren</orgName>
-                    <orgName type="variant"  source="DNB">Prieuré de Sept Fontaines</orgName>
+                    <orgName type="variant" source="DNB">Priorij Zevenborren</orgName>
+                    <orgName type="variant" source="DNB">Augustiner-Chorherrenstift Zevenborren</orgName>
+                    <orgName type="variant" source="DNB">Augustinerpriorij Zevenborren</orgName>
+                    <orgName type="variant" source="DNB">Conventus Septem Fontium</orgName>
+                    <orgName type="variant" source="DNB">Klooster Zevenborren</orgName>
+                    <orgName type="variant" source="DNB">Prieuré de Sept Fontaines</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -16311,6 +16835,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000123081657">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -16327,6 +16856,11 @@
                             <item>
                                 <ref target="https://viaf.org/viaf/132788727">
                                     <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q62032346">
+                                    <title>Wikidata</title>
                                 </ref>
                             </item>
                         </list>
@@ -16371,23 +16905,15 @@
                 
                 <org xml:id="org_138041763">
                     <orgName type="display" source="bodl">Würzburg, Stift Haug</orgName>
-                    <orgName type="variant"  source="LC">Stift Haug (Würzburg,
-                        Germany)</orgName>
-                    <orgName type="variant"  source="DNB">Kath. Pfarramt Stift Haug
-                        Würzburg</orgName>
-                    <orgName type="variant"  source="DNB">Katholisches Pfarramt Stift Haug
-                        Würzburg</orgName>
-                    <orgName type="variant"  source="DNB">Katholisches Pfarramt, Pfarrei
-                        Stift Haug, Würzburg</orgName>
-                    <orgName type="variant"  source="DNB">Pfarrei St. Johannes in Stift
-                        Haug</orgName>
-                    <orgName type="variant"  source="DNB">Pfarrei Stift Haug St. Johannes der
-                        Täufer und St. Johannes Evangelist Würzburg</orgName>
-                    <orgName type="variant"  source="DNB">Pfarrei Stift Haug
-                        Würzburg</orgName>
-                    <orgName type="variant"  source="DNB">Pfarrgemeinde St. Johannes in Stift
-                        Haug mit St. Gertraud in Würzburg</orgName>
-                    <orgName type="variant"  source="DNB">Stift Haug, Würzburg</orgName>
+                    <orgName type="variant" source="LC">Stift Haug (Würzburg, Germany)</orgName>
+                    <orgName type="variant" source="DNB">Kath. Pfarramt Stift Haug Würzburg</orgName>
+                    <orgName type="variant" source="DNB">Katholisches Pfarramt Stift Haug Würzburg</orgName>
+                    <orgName type="variant" source="DNB">Katholisches Pfarramt, Pfarrei Stift Haug, Würzburg</orgName>
+                    <orgName type="variant" source="DNB">Pfarrei St. Johannes in Stift Haug</orgName>
+                    <orgName type="variant" source="DNB">Pfarrei Stift Haug St. Johannes der Täufer und St. Johannes Evangelist Würzburg</orgName>
+                    <orgName type="variant" source="DNB">Pfarrei Stift Haug Würzburg</orgName>
+                    <orgName type="variant" source="DNB">Pfarrgemeinde St. Johannes in Stift Haug mit St. Gertraud in Würzburg</orgName>
+                    <orgName type="variant" source="DNB">Stift Haug, Würzburg</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -16410,16 +16936,13 @@
                 </org>
                 
                 <org xml:id="org_168512946">
+<!-- ***** Old VIAF ID now redirects to 150895894 ***** -->
                     <orgName type="display" source="bodl">London, cathedral church of St Paul</orgName>
-                    <orgName type="variant"  source="LC">St. Paul&#x27;s Cathedral (London,
-                        England)</orgName>
-                    <orgName type="variant"  source="DNB">SPCS, Abkuerzung</orgName>
-                    <orgName type="variant"  source="DNB">Saint Paul&#x27;s Cathedral School,
-                        London</orgName>
-                    <orgName type="variant"  source="DNB">St. Paul&#x27;s Cathedral,
-                        London</orgName>
-                    <orgName type="variant"  source="bodl">St. Pauls Cathedral,
-                        London</orgName>
+                    <orgName type="variant" source="LC">St. Paul's Cathedral (London, England)</orgName>
+                    <orgName type="variant" source="DNB">SPCS, Abkuerzung</orgName>
+                    <orgName type="variant" source="DNB">Saint Paul's Cathedral School, London</orgName>
+                    <orgName type="variant" source="DNB">St. Paul's Cathedral, London</orgName>
+                    <orgName type="variant" source="bodl">St. Pauls Cathedral, London</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -16447,19 +16970,26 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000115407522">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/150895894">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
                 <org xml:id="org_266324378">
                     <orgName type="display" source="bodl">Padua, <affiliation>Benedictine</affiliation> abbey of Santa Guistina</orgName>
-                    <orgName type="variant"  source="LC">Abbazia di Santa Giustina (Padua,
-                        Italy)</orgName>
-                    <orgName type="variant"  source="DNB">Abbaye de Sainte Justine,
-                        Padua</orgName>
-                    <orgName type="variant"  source="DNB">Abbazia di S. Giustina,
-                        Padua</orgName>
-                    <orgName type="variant"  source="DNB">Benediktinerabtei, Padua</orgName>
+                    <orgName type="variant" source="LC">Abbazia di Santa Giustina (Padua, Italy)</orgName>
+                    <orgName type="variant" source="DNB">Abbaye de Sainte Justine, Padua</orgName>
+                    <orgName type="variant" source="DNB">Abbazia di S. Giustina, Padua</orgName>
+                    <orgName type="variant" source="DNB">Benediktinerabtei, Padua</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -16487,18 +17017,25 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/000000012187889X">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q56258125">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
                 <org xml:id="org_156265118">
                     <orgName type="display" source="bodl">Perugia, <affiliation>Cistercian</affiliation> nunnery of Santa Giuliana</orgName>
-                    <orgName type="variant"  source="LC">Monastero di S. Giuliana (Perugia,
-                        Italy)</orgName>
-                    <orgName type="variant"  source="LC">Monastero di Santa Giuliana
-                        (Perugia, Italy)</orgName>
-                    <orgName type="variant"  source="LC">S. Giuliana (Monastery : Perugia,
-                        Italy)</orgName>
+                    <orgName type="variant" source="LC">Monastero di S. Giuliana (Perugia, Italy)</orgName>
+                    <orgName type="variant" source="LC">Monastero di Santa Giuliana (Perugia, Italy)</orgName>
+                    <orgName type="variant" source="LC">S. Giuliana (Monastery : Perugia, Italy)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -16519,8 +17056,6 @@
                         </list>
                     </note>
                 </org>
-                
-               
                 
                 <org xml:id="org_159826695">
                     <orgName type="display" source="bodl">Belmont (Herefordshire), abbey of St Michael</orgName>
@@ -16543,14 +17078,11 @@
                 <org xml:id="org_141608775">
                     <orgName type="display" source="bodl">Venice, basilica of San Marco</orgName>
                     <!-- record originally created from https://viaf.org/viaf/141608775/viaf.xml at 2018-10-08 14:42:40.469383 -->
-                    <orgName type="variant"  source="LC">Basilica di San Marco (Venice,
-                        Italy)</orgName>
-                    <orgName type="variant"  source="DNB">Basilica di San Marco,
-                        Venedig</orgName>
-                    <orgName type="variant"  source="DNB">Basilika di San Marco,
-                        Venedig</orgName>
-                    <orgName type="crossref"  source="DNB">Markusdom, Venedig</orgName>
-                    <orgName type="variant"  source="DNB">Markuskirche, Venedig</orgName>
+                    <orgName type="variant" source="LC">Basilica di San Marco (Venice, Italy)</orgName>
+                    <orgName type="variant" source="DNB">Basilica di San Marco, Venedig</orgName>
+                    <orgName type="variant" source="DNB">Basilika di San Marco, Venedig</orgName>
+                    <orgName type="crossref" source="DNB">Markusdom, Venedig</orgName>
+                    <orgName type="variant" source="DNB">Markuskirche, Venedig</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -16578,6 +17110,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000122226906">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -16585,18 +17122,13 @@
                 <org xml:id="org_244228863">
                     <orgName type="display" source="bodl">Regensburg, <affiliation>Augustinian</affiliation> abbey of St Mang (Magnus), Stadtamhof </orgName>
                     <!-- record originally created from https://viaf.org/viaf/244228863/viaf.xml at 2018-10-08 14:42:43.012199 -->
-                    <orgName type="variant"  source="DNB">Sankt Mang, Regensburg</orgName>
-                    <orgName type="variant"  source="DNB">Sankt Andreas,
-                        Regensburg</orgName>
-                    <orgName type="variant"  source="DNB">Sankt Magn, Regensburg</orgName>
-                    <orgName type="variant"  source="DNB">Sankt Mang,
-                        Regensburg-Stadtamhof</orgName>
-                    <orgName type="variant"  source="DNB">St. Mangkirche,
-                        Regensburg</orgName>
-                    <orgName type="variant"  source="DNB">Stiftskirche Sankt Mang,
-                        Regensburg-Stadtamhof</orgName>
-                    <orgName type="variant"  source="DNB">Stiftskirche Sankt Mang,
-                        Stadtamhof</orgName>
+                    <orgName type="variant" source="DNB">Sankt Mang, Regensburg</orgName>
+                    <orgName type="variant" source="DNB">Sankt Andreas, Regensburg</orgName>
+                    <orgName type="variant" source="DNB">Sankt Magn, Regensburg</orgName>
+                    <orgName type="variant" source="DNB">Sankt Mang, Regensburg-Stadtamhof</orgName>
+                    <orgName type="variant" source="DNB">St. Mangkirche, Regensburg</orgName>
+                    <orgName type="variant" source="DNB">Stiftskirche Sankt Mang, Regensburg-Stadtamhof</orgName>
+                    <orgName type="variant" source="DNB">Stiftskirche Sankt Mang, Stadtamhof</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -16616,24 +17148,15 @@
                 <org xml:id="org_141420298">
                     <orgName type="display" source="bodl">Poissy, <affiliation>Dominican</affiliation> nunnery of St Louis</orgName>
                     <!-- record originally created from https://viaf.org/viaf/141420298/viaf.xml at 2018-10-08 14:42:45.462415 -->
-                    <orgName type="variant"  source="BNF">Prieuré
-                        Saint-Louis, Poissy, Yvelines</orgName>
-                    <orgName type="crossref"  source="BNF">Couvent S. Louys de
-                        Poissy</orgName>
-                    <orgName type="crossref"  source="BNF">Monastère de Saint-Louis de
-                        Poissy</orgName>
-                    <orgName type="variant"  source="BNF">Monastère royal de
-                        Poissy</orgName>
-                    <orgName type="variant"  source="BNF">Monastère royal de S. Louis de
-                        Poissy</orgName>
-                    <orgName type="variant"  source="BNF">Monastère royal de St-Louis de
-                        Poissy</orgName>
-                    <orgName type="crossref"  source="BNF">Prieuré de Dominicaines,
-                        Poissy, Yvelines ; Saint-Louis), 1304-1792</orgName>
-                    <orgName type="variant"  source="BNF">Prieuré royal de S. Louis de
-                        Poissy</orgName>
-                    <orgName type="variant"  source="BNF">Prieuré royal de Saint-Louis de
-                        Poissy</orgName>
+                    <orgName type="variant" source="BNF">Prieuré Saint-Louis, Poissy, Yvelines</orgName>
+                    <orgName type="crossref" source="BNF">Couvent S. Louys de Poissy</orgName>
+                    <orgName type="crossref" source="BNF">Monastère de Saint-Louis de Poissy</orgName>
+                    <orgName type="variant" source="BNF">Monastère royal de Poissy</orgName>
+                    <orgName type="variant" source="BNF">Monastère royal de S. Louis de Poissy</orgName>
+                    <orgName type="variant" source="BNF">Monastère royal de St-Louis de Poissy</orgName>
+                    <orgName type="crossref" source="BNF">Prieuré de Dominicaines, Poissy, Yvelines ; Saint-Louis), 1304-1792</orgName>
+                    <orgName type="variant" source="BNF">Prieuré royal de S. Louis de Poissy</orgName>
+                    <orgName type="variant" source="BNF">Prieuré royal de Saint-Louis de Poissy</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -16653,30 +17176,18 @@
                 <org xml:id="org_126179587">
                     <orgName type="display" source="bodl">Paris, <affiliation>Benedictine</affiliation> abbey of St Denis</orgName>
                     <!-- record originally created from https://viaf.org/viaf/126179587/viaf.xml at 2018-10-08 14:42:48.171635 -->
-                    <orgName type="variant"  source="LC">Église abbatiale de Saint-Denis
-                        (Saint-Denis, France)</orgName>
-                    <orgName type="crossref"  source="LC">Abbey Church of Saint-Denis
-                        (Saint-Denis, France)</orgName>
-                    <orgName type="crossref"  source="LC">Basilique de Saint-Denis
-                        (Saint-Denis, France)</orgName>
-                    <orgName type="variant"  source="LC">Basilique royale de Saint-Denis
-                        (Saint-Denis, France)</orgName>
-                    <orgName type="crossref"  source="LC">Cathédrale Saint-Denis
-                        (Saint-Denis, France)</orgName>
-                    <orgName type="variant"  source="LC">Église S. Denys (Saint-Denis,
-                        France)</orgName>
-                    <orgName type="variant"  source="LC">Église de S. Denys (Saint-Denis,
-                        France)</orgName>
-                    <orgName type="crossref"  source="LC">Saint-Denis (Abbey church :
-                        Saint-Denis, France)</orgName>
-                    <orgName type="variant"  source="LC">Saint-Denis (Basilica : Saint-Denis,
-                        France)</orgName>
-                    <orgName type="variant"  source="LC">Saint-Denis (Cathedral :
-                        Saint-Denis, France)</orgName>
-                    <orgName type="variant"  source="LC">St-Denis (Abbey church :
-                        Saint-Denis, France)</orgName>
-                    <orgName type="variant"  source="LC">St. Denys (Abbey church :
-                        Saint-Denis, France)</orgName>
+                    <orgName type="variant" source="LC">Église abbatiale de Saint-Denis (Saint-Denis, France)</orgName>
+                    <orgName type="crossref" source="LC">Abbey Church of Saint-Denis (Saint-Denis, France)</orgName>
+                    <orgName type="crossref" source="LC">Basilique de Saint-Denis (Saint-Denis, France)</orgName>
+                    <orgName type="variant" source="LC">Basilique royale de Saint-Denis (Saint-Denis, France)</orgName>
+                    <orgName type="crossref" source="LC">Cathédrale Saint-Denis (Saint-Denis, France)</orgName>
+                    <orgName type="variant" source="LC">Église S. Denys (Saint-Denis, France)</orgName>
+                    <orgName type="variant" source="LC">Église de S. Denys (Saint-Denis, France)</orgName>
+                    <orgName type="crossref" source="LC">Saint-Denis (Abbey church : Saint-Denis, France)</orgName>
+                    <orgName type="variant" source="LC">Saint-Denis (Basilica : Saint-Denis, France)</orgName>
+                    <orgName type="variant" source="LC">Saint-Denis (Cathedral : Saint-Denis, France)</orgName>
+                    <orgName type="variant" source="LC">St-Denis (Abbey church : Saint-Denis, France)</orgName>
+                    <orgName type="variant" source="LC">St. Denys (Abbey church : Saint-Denis, France)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -16704,6 +17215,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000121081709">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -16711,14 +17227,13 @@
                 <org xml:id="org_133706555">
                     <orgName type="display" source="bodl">Trier, <affiliation>Carthusian</affiliation> abbey of St Alban</orgName>
                     <!-- record originally created from https://viaf.org/viaf/133706555/viaf.xml at 2018-10-08 14:42:50.624654 -->
-                    <orgName type="variant"  source="LC">Kartause St. Alban (Trier,
-                        Germany)</orgName>
-                    <orgName type="variant"  source="DNB">Kartause St. Alban Trier</orgName>
-                    <orgName type="variant"  source="DNB">Kartause Trier</orgName>
-                    <orgName type="variant"  source="DNB">Kartäuser Trier</orgName>
-                    <orgName type="variant"  source="DNB">Kartäuserkloster Trier</orgName>
-                    <orgName type="variant"  source="DNB">Karthause St. Alban Trier</orgName>
-                    <orgName type="variant"  source="DNB">Kloster Sankt Alban Trier</orgName>
+                    <orgName type="variant" source="LC">Kartause St. Alban (Trier, Germany)</orgName>
+                    <orgName type="variant" source="DNB">Kartause St. Alban Trier</orgName>
+                    <orgName type="variant" source="DNB">Kartause Trier</orgName>
+                    <orgName type="variant" source="DNB">Kartäuser Trier</orgName>
+                    <orgName type="variant" source="DNB">Kartäuserkloster Trier</orgName>
+                    <orgName type="variant" source="DNB">Karthause St. Alban Trier</orgName>
+                    <orgName type="variant" source="DNB">Kloster Sankt Alban Trier</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -16753,12 +17268,9 @@
                 <org xml:id="org_139999868">
                     <orgName type="display" source="bodl">Thetford, <affiliation>Cluniac</affiliation> priory of SS Mary and Andrew</orgName>
                     <!-- record originally created from https://viaf.org/viaf/139999868/viaf.xml at 2018-10-08 14:42:53.155870 -->
-                    <orgName type="variant"  source="LC">Thetford Priory (Thetford,
-                        England)</orgName>
-                    <orgName type="crossref"  source="LC">Priory of St. Mary at Thetford
-                        (Thetford, England)</orgName>
-                    <orgName type="crossref"  source="LC">St. Mary at Thetford (Priory :
-                        Thetford, England)</orgName>
+                    <orgName type="variant" source="LC">Thetford Priory (Thetford, England)</orgName>
+                    <orgName type="crossref" source="LC">Priory of St. Mary at Thetford (Thetford, England)</orgName>
+                    <orgName type="crossref" source="LC">St. Mary at Thetford (Priory : Thetford, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -16778,8 +17290,8 @@
                 <org xml:id="org_267407979">
                     <orgName type="display" source="bodl">London, Sion College</orgName>
                     <!-- record originally created from https://viaf.org/viaf/267407979/viaf.xml at 2018-10-08 14:42:55.607488 -->
-                    <orgName type="variant"  source="LC">Sion College</orgName>
-                    <orgName type="crossref"  source="DNB">Collegium Sionense</orgName>
+                    <orgName type="variant" source="LC">Sion College</orgName>
+                    <orgName type="crossref" source="DNB">Collegium Sionense</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -16809,7 +17321,7 @@
                 <org xml:id="org_268456246">
                     <orgName type="display" source="bodl">Sibton (Suffolk), <affiliation>Cistercian</affiliation> abbey</orgName>
                     <!-- record originally created from https://viaf.org/viaf/150071244/viaf.xml at 2018-10-08 14:42:58.481906 -->
-                    <orgName type="variant"  source="LC">Sibton Abbey</orgName>
+                    <orgName type="variant" source="LC">Sibton Abbey</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -16839,9 +17351,8 @@
                 <org xml:id="org_157558711">
                     <orgName type="display" source="bodl">Burton upon Trent, <affiliation>Benedictine</affiliation> abbey</orgName>
                     <!-- record originally created from https://viaf.org/viaf/157558711/viaf.xml at 2018-10-08 14:43:01.014123 -->
-                    <orgName type="variant"  source="LC">Burton Abbey (Burton upon Trent,
-                        England)</orgName>
-                    <orgName type="variant"  source="LC">Burton-on-Trent, Abbey</orgName>
+                    <orgName type="variant" source="LC">Burton Abbey (Burton upon Trent, England)</orgName>
+                    <orgName type="variant" source="LC">Burton-on-Trent, Abbey</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -16864,6 +17375,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q17641694">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -16871,18 +17387,13 @@
                 <org xml:id="org_126083163">
                     <orgName type="display" source="bodl">Seitenstetten, <affiliation>Benedictine</affiliation> abbey</orgName>
                     <!-- record originally created from https://viaf.org/viaf/126083163/viaf.xml at 2018-10-08 14:43:03.588140 -->
-                    <orgName type="variant"  source="LC">Benediktinerstift
-                        Seitenstetten</orgName>
-                    <orgName type="variant"  source="LC">Benediktiner-Abtei
-                        Seitenstetten</orgName>
-                    <orgName type="variant"  source="LC">Benediktinerkloster
-                        Seitenstetten</orgName>
-                    <orgName type="crossref"  source="LC">Kloster Seitenstetten</orgName>
-                    <orgName type="crossref" subtype="surnameFirst" source="LC">Seitenstetten (Austria).,
-                        Benediktinerstift</orgName>
-                    <orgName type="variant"  source="LC">Seitenstetten, Austria (Benedictine
-                        abbey)</orgName>
-                    <orgName type="variant"  source="LC">Stift Seitenstetten</orgName>
+                    <orgName type="variant" source="LC">Benediktinerstift Seitenstetten</orgName>
+                    <orgName type="variant" source="LC">Benediktiner-Abtei Seitenstetten</orgName>
+                    <orgName type="variant" source="LC">Benediktinerkloster Seitenstetten</orgName>
+                    <orgName type="crossref" source="LC">Kloster Seitenstetten</orgName>
+                    <orgName type="crossref" subtype="surnameFirst" source="LC">Seitenstetten (Austria)., Benediktinerstift</orgName>
+                    <orgName type="variant" source="LC">Seitenstetten, Austria (Benedictine abbey)</orgName>
+                    <orgName type="variant" source="LC">Stift Seitenstetten</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -16905,6 +17416,16 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000106576260">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q385745">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -16912,10 +17433,8 @@
                 <org xml:id="org_308185589">
                     <orgName type="display" source="bodl">Auderghem (Soignes), Abbaye du Rouge-Cloître (<affiliation>Augustinian</affiliation>)</orgName>
                     <!-- record originally created from https://viaf.org/viaf/308185589/viaf.xml at 2018-10-08 14:43:06.130956 -->
-                    <orgName type="variant"  source="DNB">Rood Klooster,
-                        Auderghem</orgName>
-                    <orgName type="variant"  source="bodl">Rood Klooster,
-                        Ouderghem</orgName>
+                    <orgName type="variant" source="DNB">Rood Klooster, Auderghem</orgName>
+                    <orgName type="variant" source="bodl">Rood Klooster, Ouderghem</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -16968,13 +17487,11 @@
                                     <title>GND</title>
                                 </ref>
                             </item>
-                            
                             <item>
                                 <ref target="https://id.loc.gov/authorities/names/nr93035920">
                                     <title>LC</title>
                                 </ref>
                             </item>
-                            
                             <item>
                                 <ref target="https://viaf.org/viaf/248254900">
                                     <title>VIAF</title>
@@ -16990,8 +17507,6 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            
-                            
                         </list>
                     </note>
                 </org>
@@ -16999,8 +17514,7 @@
                 <org xml:id="org_167950876">
                     <orgName type="display" source="bodl">Norwich, <affiliation>Benedictine</affiliation> cathedral priory</orgName>
                     <!-- record originally created from https://viaf.org/viaf/167950876/viaf.xml at 2018-10-08 14:43:11.142588 -->
-                    <orgName type="variant" source="LC">Norwich Priory (Norwich,
-                        England)</orgName>
+                    <orgName type="variant" source="LC">Norwich Priory (Norwich, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -17028,6 +17542,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000122008685">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -17035,12 +17554,9 @@
                 <org xml:id="org_134239581">
                     <orgName type="display" source="bodl">Norwich, diocese</orgName>
                     <!-- record originally created from https://viaf.org/viaf/134239581/viaf.xml at 2018-10-08 14:43:13.872606 -->
-                    <orgName type="variant" source="LC">Church of England., Diocese of
-                        Norwich</orgName>
-                    <orgName type="variant" source="LC">Church of England., Province of
-                        Canterbury., Diocese of Norwich</orgName>
-                    <orgName type="crossref" subtype="surnameFirst" source="LC">Norwich (England : Diocese :
-                        Church of England)</orgName>
+                    <orgName type="variant" source="LC">Church of England., Diocese of Norwich</orgName>
+                    <orgName type="variant" source="LC">Church of England., Province of Canterbury., Diocese of Norwich</orgName>
+                    <orgName type="crossref" subtype="surnameFirst" source="LC">Norwich (England : Diocese : Church of England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -17058,7 +17574,7 @@
                 </org>
                 
                 <org xml:id="org_240554317">
-                    <orgName type="display" source="bodl">Marcoussis, <affiliation>Célestins</affiliation></orgName>
+                    <orgName type="display" source="bodl">Marcoussis, <affiliation>Célestins</affiliation> </orgName>
                     <!-- record originally created from https://viaf.org/viaf/240554317/viaf.xml at 2018-10-08 14:43:16.432022 -->
                     <orgName type="variant" source="DNB">Kloster Marcoussis</orgName>
                     <note type="links">
@@ -17080,31 +17596,20 @@
                 <org xml:id="org_146464421">
                     <orgName type="display" source="bodl">Hildesheim, <affiliation>Benedictine</affiliation> abbey of St Godehard</orgName>
                     <!-- record originally created from https://viaf.org/viaf/146464421/viaf.xml at 2018-10-08 14:43:18.990439 -->
-                    <orgName type="variant" source="LC">St. Godehard zu Hildesheim (Church :
-                        Germany)</orgName>
+                    <orgName type="variant" source="LC">St. Godehard zu Hildesheim (Church : Germany)</orgName>
                     <orgName type="crossref" source="DNB">Benediktiner, Hildesheim</orgName>
-                    <orgName type="crossref" source="DNB">Cenobium Beati Patri Godehardi,
-                        Hildesheim</orgName>
+                    <orgName type="crossref" source="DNB">Cenobium Beati Patri Godehardi, Hildesheim</orgName>
                     <orgName type="crossref" source="DNB">Hildesheimensis Ecclesia</orgName>
-                    <orgName type="crossref" source="DNB">Monasterium S. Godehardi Ord. S.
-                        Benedicti, Hildesheim</orgName>
-                    <orgName type="variant" source="DNB">Monasterium Sancti Godehardi
-                        Hildeneshemmensis</orgName>
-                    <orgName type="variant" source="DNB">Monasterium Sancti Godehardi
-                        Hildensemensis Ordinis Beati Benedicti</orgName>
-                    <orgName type="variant" source="DNB">Monasterium Sancti Godehardi,
-                        Hildesheim</orgName>
-                    <orgName type="crossref" source="DNB">Ordo Sancti Benedicti,
-                        Benediktinerkloster St. Godehard, Hildesheim</orgName>
-                    <orgName type="variant" source="DNB">Sanct Godehard,
-                        Hildesheim</orgName>
-                    <orgName type="variant" source="DNB">Sankt Godehard,
-                        Hildesheim</orgName>
-                    <orgName type="variant" source="DNB">Sente Godderde,
-                        Hildesheim</orgName>
+                    <orgName type="crossref" source="DNB">Monasterium S. Godehardi Ord. S. Benedicti, Hildesheim</orgName>
+                    <orgName type="variant" source="DNB">Monasterium Sancti Godehardi Hildeneshemmensis</orgName>
+                    <orgName type="variant" source="DNB">Monasterium Sancti Godehardi Hildensemensis Ordinis Beati Benedicti</orgName>
+                    <orgName type="variant" source="DNB">Monasterium Sancti Godehardi, Hildesheim</orgName>
+                    <orgName type="crossref" source="DNB">Ordo Sancti Benedicti, Benediktinerkloster St. Godehard, Hildesheim</orgName>
+                    <orgName type="variant" source="DNB">Sanct Godehard, Hildesheim</orgName>
+                    <orgName type="variant" source="DNB">Sankt Godehard, Hildesheim</orgName>
+                    <orgName type="variant" source="DNB">Sente Godderde, Hildesheim</orgName>
                     <orgName type="variant" source="DNB">St. Godehard, Hildesheim</orgName>
-                    <orgName type="variant" source="DNB">Stichte to Sunte Godehards,
-                        Hildesheim</orgName>
+                    <orgName type="variant" source="DNB">Stichte to Sunte Godehards, Hildesheim</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -17134,10 +17639,8 @@
                 <org xml:id="org_150110428">
                     <orgName type="display" source="LC">Wiltshire Archaeological and Natural History Society</orgName>
                     <!-- record originally created from https://viaf.org/viaf/150110428/viaf.xml at 2018-10-08 14:43:21.566456 -->
-                    <orgName type="variant" source="LC">Wiltshire Archaeological and Natural
-                        History Society</orgName>
-                    <orgName type="variant" source="DNB">Wiltshire Archaeological &amp;
-                        Natural History Society</orgName>
+                    <orgName type="variant" source="LC">Wiltshire Archaeological and Natural History Society</orgName>
+                    <orgName type="variant" source="DNB">Wiltshire Archaeological &amp; Natural History Society</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -17155,16 +17658,26 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000106719591">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q8023421">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
                 <org xml:id="org_159340687">
-                    <orgName type="display" source="bodl">Arezzo, cathedral</orgName> <!-- record originally created from https://viaf.org/viaf/159340687/viaf.xml at 2018-10-08 14:43:24.046871 -->
+                    <orgName type="display" source="bodl">Arezzo, cathedral</orgName>
+                    <!-- record originally created from https://viaf.org/viaf/159340687/viaf.xml at 2018-10-08 14:43:24.046871 -->
                     <orgName type="variant" source="LC">Duomo di Arezzo</orgName>
-                    <orgName type="crossref" source="LC">Cattedrale (Arezzo,
-                        Italy)</orgName>
-                    <orgName type="variant" source="LC">Duomo d&#x27;Arezzo</orgName>
+                    <orgName type="crossref" source="LC">Cattedrale (Arezzo, Italy)</orgName>
+                    <orgName type="variant" source="LC">Duomo d'Arezzo</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -17190,10 +17703,8 @@
                     <orgName type="display" source="bodl">Wells, cathedral</orgName>
                     <!-- record originally created from https://viaf.org/viaf/136008586/viaf.xml at 2018-10-08 14:43:26.636488 -->
                     <orgName type="variant" source="LC">Wells Cathedral</orgName>
-                    <orgName type="crossref" source="LC">Saint Andrew&#x27;s Cathedral
-                        (Wells, England)</orgName>
-                    <orgName type="variant" source="LC">St. Andrew&#x27;s Cathedral (Wells,
-                        England)</orgName>
+                    <orgName type="crossref" source="LC">Saint Andrew's Cathedral (Wells, England)</orgName>
+                    <orgName type="variant" source="LC">St. Andrew's Cathedral (Wells, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -17211,6 +17722,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000092689482">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -17218,8 +17734,7 @@
                 <org xml:id="org_140943552">
                     <orgName type="display" source="bodl">Zamora, Cisterican monastery of Nuestra Señora, Valparaíso </orgName>
                     <!-- record originally created from https://viaf.org/viaf/140943552/viaf.xml at 2018-10-08 14:43:29.168106 -->
-                    <orgName type="variant" source="LC">Nuestra Señora de Valparaíso
-                        (Monastery : Spain)</orgName>
+                    <orgName type="variant" source="LC">Nuestra Señora de Valparaíso (Monastery : Spain)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -17239,16 +17754,11 @@
                 <org xml:id="org_126334887">
                     <orgName type="display" source="bodl">Zadar, <affiliation>Benedictine</affiliation> abbey of St Chrysogonus</orgName>
                     <!-- record originally created from https://viaf.org/viaf/126334887/viaf.xml at 2018-10-08 14:43:31.696322 -->
-                    <orgName type="variant" source="DNB">Samostan Svetog Krševana,
-                        Zadar</orgName>
-                    <orgName type="crossref" source="DNB">Abbaye Saint Chrysogone,
-                        Zadar</orgName>
-                    <orgName type="variant" source="DNB">Abbaye de Saint Chrysogone,
-                        Zadar</orgName>
-                    <orgName type="crossref" source="DNB">Muški Bendikstinski Samostan Sv.
-                        Krševana, Zadar</orgName>
-                    <orgName type="variant" source="DNB">Sanostan Sv. Krsevana,
-                        Zadar</orgName>
+                    <orgName type="variant" source="DNB">Samostan Svetog Krševana, Zadar</orgName>
+                    <orgName type="crossref" source="DNB">Abbaye Saint Chrysogone, Zadar</orgName>
+                    <orgName type="variant" source="DNB">Abbaye de Saint Chrysogone, Zadar</orgName>
+                    <orgName type="crossref" source="DNB">Muški Bendikstinski Samostan Sv. Krševana, Zadar</orgName>
+                    <orgName type="variant" source="DNB">Sanostan Sv. Krsevana, Zadar</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -17268,16 +17778,11 @@
                 <org xml:id="org_146323850">
                     <orgName type="display" source="bodl">Venice, Scuola Grande della Misericordia</orgName>
                     <!-- record originally created from https://viaf.org/viaf/146323850/viaf.xml at 2018-10-08 14:43:34.145538 -->
-                    <orgName type="variant" source="DNB">Scuola Grande della Misericordia,
-                        Venedig</orgName>
-                    <orgName type="variant" source="DNB">Scuola Grande della Misericordia di
-                        Venezia</orgName>
-                    <orgName type="variant" source="DNB">Scuola Grande della Misericordia,
-                        Venezia</orgName>
-                    <orgName type="variant" source="DNB">Scuola Grande di Santa Maria della
-                        Misericordia, Venezia</orgName>
-                    <orgName type="variant" source="DNB">Scuola Grande di Santa Maria di
-                        Valverde</orgName>
+                    <orgName type="variant" source="DNB">Scuola Grande della Misericordia, Venedig</orgName>
+                    <orgName type="variant" source="DNB">Scuola Grande della Misericordia di Venezia</orgName>
+                    <orgName type="variant" source="DNB">Scuola Grande della Misericordia, Venezia</orgName>
+                    <orgName type="variant" source="DNB">Scuola Grande di Santa Maria della Misericordia, Venezia</orgName>
+                    <orgName type="variant" source="DNB">Scuola Grande di Santa Maria di Valverde</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -17290,6 +17795,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/n00005749">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -17297,10 +17807,8 @@
                 <org xml:id="org_152797746">
                     <orgName type="display" source="bodl">Vicenza, <affiliation>Benedictine</affiliation> abbey of SS. Felice e Fortunato</orgName>
                     <!-- record originally created from https://viaf.org/viaf/152797746/viaf.xml at 2018-10-08 14:43:36.892156 -->
-                    <orgName type="variant" source="LC">Basilica dei S.S. Felice e Fortunato
-                        (Vicenza, Italy)</orgName>
-                    <orgName type="variant" source="LC">Basilica dei Santi Felice e
-                        Fortunato (Vicenza, Italy)</orgName>
+                    <orgName type="variant" source="LC">Basilica dei S.S. Felice e Fortunato (Vicenza, Italy)</orgName>
+                    <orgName type="variant" source="LC">Basilica dei Santi Felice e Fortunato (Vicenza, Italy)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -17322,16 +17830,13 @@
                     </note>
                 </org>
                 
-                
                 <org xml:id="org_235700069">
                     <orgName type="display" source="bodl">Siena, Benedictine nunnery of Santa Bonda (SS. AAbbondio e Abbondanzio)</orgName>
                     <orgName type="variant" source="bodl">Santo Abundio e Abundanzio</orgName>
                     <orgName type="variant" source="bodl">SS. Abundius and Abundantius (S. Bonda)</orgName>
                     <!-- record originally created from https://viaf.org/viaf/235700069/viaf.xml at 2018-10-08 14:43:39.548173 -->
-                    <orgName type="variant" source="DNB">Sant&#x27;Abbondio,
-                        Kloster</orgName>
-                    <orgName type="crossref" source="DNB">Monastero dei SS. Abbondio e
-                        Abbondanzio</orgName>
+                    <orgName type="variant" source="DNB">Sant'Abbondio, Kloster</orgName>
+                    <orgName type="crossref" source="DNB">Monastero dei SS. Abbondio e Abbondanzio</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -17351,8 +17856,7 @@
                 <org xml:id="org_156374852">
                     <orgName type="display" source="bodl">Priverno, <affiliation>Cisterican</affiliation> abbey of San Stefano, Fossanova</orgName>
                     <!-- record originally created from https://viaf.org/viaf/156374852/viaf.xml at 2018-10-08 14:43:42.153390 -->
-                    <orgName type="variant" source="LC">Abbazia di Fossanova (Priverno,
-                        Italy)</orgName>
+                    <orgName type="variant" source="LC">Abbazia di Fossanova (Priverno, Italy)</orgName>
                     <orgName type="variant" source="DNB">Abbazia di Fossanova</orgName>
                     <note type="links">
                         <list type="links">
@@ -17393,14 +17897,10 @@
                 <org xml:id="org_144600874">
                     <orgName type="display" source="bodl">Mistrás, metropolitan church of St Demetrios</orgName>
                     <!-- record originally created from https://viaf.org/viaf/144600874/viaf.xml at 2018-10-08 14:43:44.883407 -->
-                    <orgName type="variant" source="LC">Hagios Dēmētrios (Church : Mistra,
-                        Greece)</orgName>
-                    <orgName type="crossref" source="LC">Metropolis of Mystras (Church :
-                        Mistra, Greece)</orgName>
-                    <orgName type="variant" source="LC">Mētropolē tou Mystra (Church :
-                        Mistra, Greece)</orgName>
-                    <orgName type="crossref" source="LC">St. Demetrios (Church : Mistra,
-                        Greece)</orgName>
+                    <orgName type="variant" source="LC">Hagios Dēmētrios (Church : Mistra, Greece)</orgName>
+                    <orgName type="crossref" source="LC">Metropolis of Mystras (Church : Mistra, Greece)</orgName>
+                    <orgName type="variant" source="LC">Mētropolē tou Mystra (Church : Mistra, Greece)</orgName>
+                    <orgName type="crossref" source="LC">St. Demetrios (Church : Mistra, Greece)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -17458,28 +17958,18 @@
                 <org xml:id="org_127140314">
                     <orgName type="display" source="bodl">Niederalteich, <affiliation>Benedictine</affiliation> abbey</orgName>
                     <!-- record originally created from https://viaf.org/viaf/123647601/viaf.xml at 2018-10-08 14:43:50.658445 -->
-                    <orgName type="variant" source="LC">Kloster Niederaltaich
-                        (Niederalteich, Germany)</orgName>
+                    <orgName type="variant" source="LC">Kloster Niederaltaich (Niederalteich, Germany)</orgName>
                     <orgName type="crossref" source="DNB">Abtei Niederaltaich</orgName>
-                    <orgName type="variant" source="DNB">Abtei Niederalteich,
-                        Niederalteich</orgName>
-                    <orgName type="crossref" source="DNB">Benediktinerabtei
-                        Niederaltaich</orgName>
-                    <orgName type="variant" source="DNB">Benediktinerabtei Sankt
-                        Mauritius</orgName>
-                    <orgName type="variant" source="DNB">Benediktinerabtei Sankt Mauritius,
-                        Niederalteich</orgName>
-                    <orgName type="variant" source="DNB">Benediktinerabtei der Heiligen
-                        Mauritius und Nikolaus, Niederalteich</orgName>
-                    <orgName type="variant" source="DNB">Benediktinerabtei,
-                        Niederalteich</orgName>
+                    <orgName type="variant" source="DNB">Abtei Niederalteich, Niederalteich</orgName>
+                    <orgName type="crossref" source="DNB">Benediktinerabtei Niederaltaich</orgName>
+                    <orgName type="variant" source="DNB">Benediktinerabtei Sankt Mauritius</orgName>
+                    <orgName type="variant" source="DNB">Benediktinerabtei Sankt Mauritius, Niederalteich</orgName>
+                    <orgName type="variant" source="DNB">Benediktinerabtei der Heiligen Mauritius und Nikolaus, Niederalteich</orgName>
+                    <orgName type="variant" source="DNB">Benediktinerabtei, Niederalteich</orgName>
                     <orgName type="variant" source="DNB">Kloster Niederaltaich</orgName>
                     <orgName type="variant" source="DNB">Kloster, Niederalteich</orgName>
-                    <orgName type="crossref" source="DNB">Ordo Sancti Benedicti, Abtei,
-                        Niederalteich</orgName>
-                    <orgName type="crossref" source="DNB">Sankt Mauritius, Kloster, nswd,
-                        http://d-nb.info/standards/elementset/gnd#variantName, Ehemalige Vorzugsbenennung
-                        SWD</orgName>
+                    <orgName type="crossref" source="DNB">Ordo Sancti Benedicti, Abtei, Niederalteich</orgName>
+                    <orgName type="crossref" source="DNB">Sankt Mauritius, Kloster, nswd, http://d-nb.info/standards/elementset/gnd#variantName, Ehemalige Vorzugsbenennung SWD</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -17507,6 +17997,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000106569247">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -17514,12 +18009,9 @@
                 <org xml:id="org_148489681">
                     <orgName type="display" source="bodl">Jouarre, <affiliation>Benedictine</affiliation> nunnery</orgName>
                     <!-- record originally created from https://viaf.org/viaf/148489681/viaf.xml at 2018-10-08 14:43:53.341662 -->
-                    <orgName type="variant" source="LC">Abbaye Notre-Dame de Jouarre
-                        (Seine-et-Marne, France)</orgName>
-                    <orgName type="variant" source="LC">Abbaye de Jouarre (Seine-et-Marne,
-                        France)</orgName>
-                    <orgName type="crossref" source="LC">Jouarre (Abbey : Seine-et-Marne,
-                        France)</orgName>
+                    <orgName type="variant" source="LC">Abbaye Notre-Dame de Jouarre (Seine-et-Marne, France)</orgName>
+                    <orgName type="variant" source="LC">Abbaye de Jouarre (Seine-et-Marne, France)</orgName>
+                    <orgName type="crossref" source="LC">Jouarre (Abbey : Seine-et-Marne, France)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -17547,6 +18039,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000121809712">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -17554,8 +18051,7 @@
                 <org xml:id="org_160939265">
                     <orgName type="display" source="bodl">Lod (Lydda), church of St George</orgName>
                     <!-- record originally created from https://viaf.org/viaf/160939265/viaf.xml at 2018-10-08 14:43:55.776278 -->
-                    <orgName type="variant" source="NLI">St. George&#x27;s Burial Church
-                        (Lod), lat</orgName>
+                    <orgName type="variant" source="NLI">St. George's Burial Church (Lod), lat</orgName>
                     <!-- no variants found in preferred sources -->
                     <note type="links">
                         <list type="links">
@@ -17571,12 +18067,9 @@
                 <org xml:id="org_125752208">
                     <orgName type="display" source="bodl">Canterbury, parish church of St Dunstan's Without the West Gate</orgName>
                     <!-- record originally created from https://viaf.org/viaf/125752208/viaf.xml at 2018-10-08 14:43:58.225493 -->
-                    <orgName type="variant" source="LC">St. Dunstan&#x27;s Church
-                        (Canterbury, England)</orgName>
-                    <orgName type="crossref" source="LC">Parish Church of St. Dunstan
-                        (Canterbury, England)</orgName>
-                    <orgName type="variant" source="LC">Saint Dunstan&#x27;s Church
-                        (Canterbury, England)</orgName>
+                    <orgName type="variant" source="LC">St. Dunstan's Church (Canterbury, England)</orgName>
+                    <orgName type="crossref" source="LC">Parish Church of St. Dunstan (Canterbury, England)</orgName>
+                    <orgName type="variant" source="LC">Saint Dunstan's Church (Canterbury, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -17596,20 +18089,14 @@
                 <org xml:id="org_150190778">
                     <orgName type="display" source="bodl">Fécamp, <affiliation>Benedictine</affiliation> abbey</orgName>
                     <!-- record originally created from https://viaf.org/viaf/150190778/viaf.xml at 2018-10-08 14:44:00.690309 -->
-                    <orgName type="variant" source="SUDOC">Abbaye de la Sainte-Trinité de
-                        Fécamp</orgName>
-                    <orgName type="variant" source="SUDOC">Abbaye de Bénédictines (Fécamp,
-                        Seine-Maritime) (Sainte-Trinité)</orgName>
-                    <orgName type="variant" source="SUDOC">Abbaye de Bénédictins (Fécamp,
-                        Seine-Maritime) (Sainte-Trinité)</orgName>
-                    <orgName type="variant" source="SUDOC">Abbaye de Bénédictins
-                        (Saint-Maur) (Fécamp, Seine-Maritime) (Sainte-Trinité)</orgName>
+                    <orgName type="variant" source="SUDOC">Abbaye de la Sainte-Trinité de Fécamp</orgName>
+                    <orgName type="variant" source="SUDOC">Abbaye de Bénédictines (Fécamp, Seine-Maritime) (Sainte-Trinité)</orgName>
+                    <orgName type="variant" source="SUDOC">Abbaye de Bénédictins (Fécamp, Seine-Maritime) (Sainte-Trinité)</orgName>
+                    <orgName type="variant" source="SUDOC">Abbaye de Bénédictins (Saint-Maur) (Fécamp, Seine-Maritime) (Sainte-Trinité)</orgName>
                     <orgName type="variant" source="SUDOC">Abbaye de Fescamps</orgName>
                     <orgName type="variant" source="SUDOC">Abbaye de Fécamp</orgName>
-                    <orgName type="variant" source="SUDOC">Abbaye de Fécamp
-                        (Seine-Maritime)</orgName>
-                    <orgName type="crossref"  source="SUDOC">Fécamp (Seine-Maritime),
-                        Abbaye de la Trinité</orgName>
+                    <orgName type="variant" source="SUDOC">Abbaye de Fécamp (Seine-Maritime)</orgName>
+                    <orgName type="crossref" source="SUDOC">Fécamp (Seine-Maritime), Abbaye de la Trinité</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -17639,9 +18126,7 @@
                 <org xml:id="org_123169804">
                     <orgName type="display" source="bodl">Mont-Saint-Michel, <affiliation>Benedictine</affiliation> abbey</orgName>
                     <!-- record originally created from https://viaf.org/viaf/123169804/viaf.xml at 2018-10-08 14:44:03.389126 -->
-                    <orgName type="variant" source="LC">Mont-Saint-Michel (Abbey :
-                        France)</orgName>
-                    
+                    <orgName type="variant" source="LC">Mont-Saint-Michel (Abbey : France)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -17674,10 +18159,14 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000120972913">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
-                
                 <!-- 16.10.17 -->
                 <org xml:id="org_266765811">
                     <orgName type="display" source="bodl">St Gall, <affiliation>Benedictine</affiliation> abbey</orgName>
@@ -17718,15 +18207,25 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000121103496">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q155699">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
                 <org xml:id="org_175619750">
+<!-- ***** Old VIAF ID now redirects to 125561252 ***** -->
                     <orgName type="display" source="bodl">Bermondsey, Zaehnsdorf, bookbinders </orgName>
                     <!-- record originally created from https://viaf.org/viaf/175619750/viaf.xml at 2018-10-08 14:44:08.521559 -->
-                    <orgName type="variant" source="DNB">Zaehnsdorf Company,
-                        London</orgName>
+                    <orgName type="variant" source="DNB">Zaehnsdorf Company, London</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -17739,6 +18238,16 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/n85274074">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/125561252">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -17746,10 +18255,8 @@
                 <org xml:id="org_295377124">
                     <orgName type="display" source="bodl">London, W. H. Smith &amp; Son, booksellers &amp; binders</orgName>
                     <!-- record originally created from https://viaf.org/viaf/295377124/viaf.xml at 2018-10-08 14:44:11.064376 -->
-                    <orgName type="variant" source="DNB">W. H. Smith &amp; Son,
-                        London</orgName>
-                    <orgName type="variant" source="DNB">W. H. Smith &amp; Son, Booksellers
-                        and Stationers</orgName>
+                    <orgName type="variant" source="DNB">W. H. Smith &amp; Son, London</orgName>
+                    <orgName type="variant" source="DNB">W. H. Smith &amp; Son, Booksellers and Stationers</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -17769,12 +18276,9 @@
                 <org xml:id="org_147818232">
                     <orgName type="display" source="bodl">London, Council of (1268)</orgName>
                     <!-- record originally created from https://viaf.org/viaf/147818232/viaf.xml at 2018-10-08 14:44:13.514591 -->
-                    <orgName type="variant" source="LC">Catholic Church., Legatine Council,
-                        (1268 :, London, England)</orgName>
-                    <orgName type="variant" source="LC">Catholic Church., Legatine Council,
-                        London, 1268</orgName>
-                    <orgName type="crossref" source="LC">Legatine Council, (1268 :, London,
-                        England)</orgName>
+                    <orgName type="variant" source="LC">Catholic Church., Legatine Council, (1268 :, London, England)</orgName>
+                    <orgName type="variant" source="LC">Catholic Church., Legatine Council, London, 1268</orgName>
+                    <orgName type="crossref" source="LC">Legatine Council, (1268 :, London, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -17797,8 +18301,7 @@
                     <orgName type="variant" source="LC">J. &amp; J. Leighton</orgName>
                     <orgName type="variant" source="DNB">J. &amp; J. Leighton</orgName>
                     <orgName type="variant" source="DNB">J. and J. Leighton</orgName>
-                    <orgName type="variant" source="DNB">J. and J. Leighton,
-                        London</orgName>
+                    <orgName type="variant" source="DNB">J. and J. Leighton, London</orgName>
                     <orgName type="crossref" source="DNB">Leighton, London</orgName>
                     <note type="links">
                         <list type="links">
@@ -17824,16 +18327,11 @@
                 <org xml:id="org_135655377">
                     <orgName type="display" source="bodl">Paris, <affiliation>Benedictine</affiliation> abbey of Saint-Germain-des-Prés</orgName>
                     <!-- record originally created from https://viaf.org/viaf/135655377/viaf.xml at 2018-10-08 14:44:18.964027 -->
-                    <orgName type="variant" source="LC">Saint-Germain-des-Prés (Abbey :
-                        Paris, France)</orgName>
-                    <orgName type="crossref" source="DNB">Église Saint-Germain-des-Prés,
-                        Paris</orgName>
-                    <orgName type="crossref" source="DNB">Monasterium S. Germani a Pratis,
-                        Paris</orgName>
-                    <orgName type="variant" source="DNB">Monasterium Sancti Germani a
-                        Pratis, Paris</orgName>
-                    <orgName type="variant" source="DNB">Saint-Germain-des-Prés,
-                        Paris</orgName>
+                    <orgName type="variant" source="LC">Saint-Germain-des-Prés (Abbey : Paris, France)</orgName>
+                    <orgName type="crossref" source="DNB">Église Saint-Germain-des-Prés, Paris</orgName>
+                    <orgName type="crossref" source="DNB">Monasterium S. Germani a Pratis, Paris</orgName>
+                    <orgName type="variant" source="DNB">Monasterium Sancti Germani a Pratis, Paris</orgName>
+                    <orgName type="variant" source="DNB">Saint-Germain-des-Prés, Paris</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -17866,6 +18364,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000119401152">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -17873,8 +18376,7 @@
                 <org xml:id="org_295820821">
                     <orgName type="display" source="bodl">Stanley (Wiltshire), <affiliation>Cistercian</affiliation> abbey</orgName>
                     <!-- record originally created from https://viaf.org/viaf/295820821/viaf.xml at 2018-10-08 14:44:21.725245 -->
-                    <orgName type="variant" source="LC">Stanley Abbey (Wiltshire,
-                        England)</orgName>
+                    <orgName type="variant" source="LC">Stanley Abbey (Wiltshire, England)</orgName>
                     <orgName type="crossref" source="DNB">Kloster Stanley</orgName>
                     <note type="links">
                         <list type="links">
@@ -17909,13 +18411,10 @@
                 
                 <org xml:id="org_317069910">
                     <orgName type="display" source="bodl">Sora (near Naples), <affiliation>Benedictine</affiliation> (later <affiliation>Cistercian</affiliation>) abbey of St. Dominic (later of the Virgin Mary)</orgName>
-                   
                     <!-- record originally created from https://viaf.org/viaf/317069910/viaf.xml at 2018-10-08 14:44:24.190060 -->
                     <orgName type="variant" source="DNB">Kloster San Domenico Sora</orgName>
-                    <orgName type="crossref" source="DNB">Abbazia di S. Domenico di
-                        Sora</orgName>
-                    <orgName type="variant" source="DNB">Abbazia di San Domenico Abbate di
-                        Sora</orgName>
+                    <orgName type="crossref" source="DNB">Abbazia di S. Domenico di Sora</orgName>
+                    <orgName type="variant" source="DNB">Abbazia di San Domenico Abbate di Sora</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -17939,7 +18438,8 @@
                                 </ref>
                             </item>
                         </list>
-                    </note> <bibl>Cottineau II, col. 3062</bibl>
+                    </note>
+                    <bibl>Cottineau II, col. 3062</bibl>
                 </org>
                 
                 <org xml:id="org_133002293">
@@ -17949,10 +18449,8 @@
                     <orgName type="variant" source="DNB">S &amp; S</orgName>
                     <orgName type="variant" source="DNB">S and S</orgName>
                     <orgName type="variant" source="DNB">Sangorski and Sutcliffe</orgName>
-                    <orgName type="variant" source="DNB">Sangorski, Francis Longinus,
-                        Firma</orgName>
-                    <orgName type="variant" source="DNB">Sutcliffe, George Herbert,
-                        Firma</orgName>
+                    <orgName type="variant" source="DNB">Sangorski, Francis Longinus, Firma</orgName>
+                    <orgName type="variant" source="DNB">Sutcliffe, George Herbert, Firma</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -17980,22 +18478,23 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000091003784">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
                 <org xml:id="org_145597689">
-                  <orgName type="display" source="bodl">Mainz, <affiliation>Benedictine</affiliation> abbey of St Alban</orgName>
+                    <orgName type="display" source="bodl">Mainz, <affiliation>Benedictine</affiliation> abbey of St Alban</orgName>
                     <!-- record originally created from https://viaf.org/viaf/145597689/viaf.xml at 2018-10-08 14:44:29.243282 -->
-                    <orgName type="variant" source="LC">Abtei St. Alban (Mainz,
-                        Germany)</orgName>
-                    <orgName type="crossref" source="DNB">Benediktinerabtei St. Alban
-                        Mainz</orgName>
+                    <orgName type="variant" source="LC">Abtei St. Alban (Mainz, Germany)</orgName>
+                    <orgName type="crossref" source="DNB">Benediktinerabtei St. Alban Mainz</orgName>
                     <orgName type="variant" source="DNB">Benediktinerkloster Mainz</orgName>
-                    <orgName type="crossref" source="DNB">Kloster Sankt Alban
-                        Mainz</orgName>
-                    <orgName type="crossref" source="DNB">Stift St. Alban vor
-                        Mainz</orgName>
+                    <orgName type="crossref" source="DNB">Kloster Sankt Alban Mainz</orgName>
+                    <orgName type="crossref" source="DNB">Stift St. Alban vor Mainz</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -18020,17 +18519,14 @@
                             </item>
                         </list>
                     </note>
-              </org>
+                </org>
                 
                 <org xml:id="org_150912735">
                     <orgName type="display" source="bodl">Regensburg, <affiliation>Benedictine</affiliation> abbey of St Emmeram</orgName>
                     <!-- record originally created from https://viaf.org/viaf/150912735/viaf.xml at 2018-10-08 14:44:31.832882 -->
-                    <orgName type="variant" source="LC">St. Emmeram (Monastery : Regensburg,
-                        Germany)</orgName>
-                    <orgName type="crossref" source="DNB">Pfarrei Sankt Emmeram,
-                        Regensburg</orgName>
-                    <orgName type="variant" source="DNB">Sankt Emmeram R&lt;egensburg&gt;,
-                        Pfarrei, Ehemalige Vorzugsbenennung SWD</orgName>
+                    <orgName type="variant" source="LC">St. Emmeram (Monastery : Regensburg, Germany)</orgName>
+                    <orgName type="crossref" source="DNB">Pfarrei Sankt Emmeram, Regensburg</orgName>
+                    <orgName type="variant" source="DNB">Sankt Emmeram R&lt;egensburg&gt;, Pfarrei, Ehemalige Vorzugsbenennung SWD</orgName>
                     <orgName type="variant" source="DNB">Sankt Emmeram, Regensburg</orgName>
                     <orgName type="variant" source="DNB">St. Emmeram, Regensburg</orgName>
                     <note type="links">
@@ -18060,6 +18556,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q19309358">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -18067,12 +18568,9 @@
                 <org xml:id="org_150552322">
                     <orgName type="display" source="bodl">Como, <affiliation>Benedictine</affiliation> monastery of Sant'Abbondio</orgName>
                     <!-- record originally created from https://viaf.org/viaf/150552322/viaf.xml at 2018-10-08 14:44:34.313282 -->
-                    <orgName type="variant" source="LC">Basilica di Sant&#x27;Abbondio
-                        (Como, Italy)</orgName>
-                    <orgName type="variant" source="LC">Basilica di S. Abbondio (Como,
-                        Italy)</orgName>
-                    <orgName type="crossref" source="LC">Sant&#x27;Abbondio (Church : Como,
-                        Italy)</orgName>
+                    <orgName type="variant" source="LC">Basilica di Sant'Abbondio (Como, Italy)</orgName>
+                    <orgName type="variant" source="LC">Basilica di S. Abbondio (Como, Italy)</orgName>
+                    <orgName type="crossref" source="LC">Sant'Abbondio (Church : Como, Italy)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -18102,7 +18600,6 @@
                 <org xml:id="org_152022496">
                     <orgName type="display" source="bodl">Landévennec, <affiliation>Benedictine</affiliation> abbey of Saint-Guénolé</orgName>
                     <orgName type="variant" source="LC">Abbaye de Landévennec</orgName>
-                    
                     <note type="links">
                         <list type="links">
                             <item>
@@ -18135,6 +18632,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000119578329">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -18142,14 +18644,11 @@
                 <org xml:id="org_131442366">
                     <orgName type="display" source="bodl">Saint-Omer, <affiliation>Benedictine</affiliation> abbey of Saint-Bertin</orgName>
                     <!-- record originally created from https://viaf.org/viaf/131442366/viaf.xml at 2018-10-08 14:44:39.633882 -->
-                    <orgName type="variant" source="LC">Saint-Bertin (Monastery :
-                        Saint-Omer, Pas-de-Calais, France)</orgName>
+                    <orgName type="variant" source="LC">Saint-Bertin (Monastery : Saint-Omer, Pas-de-Calais, France)</orgName>
                     <orgName type="crossref" source="DNB">Abbaye, Saint-Omer</orgName>
-                    <orgName type="crossref" source="DNB">Monasterium Sancti Bertini,
-                        Saint-Omer</orgName>
+                    <orgName type="crossref" source="DNB">Monasterium Sancti Bertini, Saint-Omer</orgName>
                     <orgName type="variant" source="DNB">Monasterium, Saint-Omer</orgName>
-                    <orgName type="variant" source="DNB">Saint-Bertin, Saint-Omer ;
-                        Stift</orgName>
+                    <orgName type="variant" source="DNB">Saint-Bertin, Saint-Omer ; Stift</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -18182,6 +18681,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000106873847">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -18189,7 +18693,7 @@
                 <org xml:id="org_125070864">
                     <orgName type="display" source="bodl">Aulne, <affiliation>Benedictine</affiliation> abbey</orgName>
                     <!-- record originally created from https://viaf.org/viaf/125070864/viaf.xml at 2018-10-08 14:44:42.184082 -->
-                    <orgName type="variant" source="LC">Abbaye d&#x27;Aulne</orgName>
+                    <orgName type="variant" source="LC">Abbaye d'Aulne</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -18216,11 +18720,8 @@
                     </note>
                 </org>
                 
-           
-                
                 <org xml:id="org_172482280">
                     <orgName type="display" source="bodl">Corvey, <affiliation>Benedictine</affiliation> abbey</orgName>
-                    
                     <country key="place_7000084">Germany</country>
                     <location source="JPG">
                         <geo>51.7833,9.4</geo>
@@ -18259,6 +18760,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000122630255">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -18268,17 +18774,12 @@
                     <orgName type="variant" source="bodl">Acqua Fredda, <affiliation>Cisterican</affiliation> abbey of St Mary</orgName>
                     <!-- record originally created from https://viaf.org/viaf/240561051/viaf.xml at 2018-10-08 14:44:47.534882 -->
                     <orgName type="variant" source="DNB">Santa Maria, Kloster</orgName>
-                    <orgName type="crossref" source="DNB">Abbazia
-                        dell&#x27;Acquafredda</orgName>
-                    <orgName type="variant" source="DNB">Abbazia dell&#x27;Acquafredda,
-                        Lenno</orgName>
-                    <orgName type="variant" source="DNB">Abbazia di Santa Maria
-                        dell&#x27;Acquafredda</orgName>
+                    <orgName type="crossref" source="DNB">Abbazia dell'Acquafredda</orgName>
+                    <orgName type="variant" source="DNB">Abbazia dell'Acquafredda, Lenno</orgName>
+                    <orgName type="variant" source="DNB">Abbazia di Santa Maria dell'Acquafredda</orgName>
                     <orgName type="crossref" source="DNB">Badia di Acquafredda</orgName>
-                    <orgName type="crossref" source="DNB">Monastero
-                        dell&#x27;Acquafredda</orgName>
-                    <orgName type="variant" source="DNB">Monastero dell&#x27;Acquafredda,
-                        Lenno</orgName>
+                    <orgName type="crossref" source="DNB">Monastero dell'Acquafredda</orgName>
+                    <orgName type="variant" source="DNB">Monastero dell'Acquafredda, Lenno</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -18298,20 +18799,13 @@
                 <org xml:id="org_123233264">
                     <orgName type="display" source="bodl">Bologna, <affiliation>Franciscan</affiliation> convent of San Francesco</orgName>
                     <!-- record originally created from https://viaf.org/viaf/123233264/viaf.xml at 2018-10-08 14:44:49.985082 -->
-                    <orgName type="variant" source="LC">Convento di S. Francesco di Bologna
-                        (Bologna, Italy)</orgName>
-                    <orgName type="crossref" source="DNB">Bologna, Convento di S.
-                        Francesco</orgName>
-                    <orgName type="variant" source="DNB">Convento di S. Francesco
-                        Bologna</orgName>
-                    <orgName type="variant" source="DNB">Convento di S. Francesco di
-                        Bologna</orgName>
-                    <orgName type="variant" source="DNB">Convento di San Francesco
-                        Bologna</orgName>
-                    <orgName type="variant" source="DNB">Convento di San Francesco di
-                        Bologna</orgName>
-                    <orgName type="crossref" source="DNB">Franziskanerkloster
-                        Bologna</orgName>
+                    <orgName type="variant" source="LC">Convento di S. Francesco di Bologna (Bologna, Italy)</orgName>
+                    <orgName type="crossref" source="DNB">Bologna, Convento di S. Francesco</orgName>
+                    <orgName type="variant" source="DNB">Convento di S. Francesco Bologna</orgName>
+                    <orgName type="variant" source="DNB">Convento di S. Francesco di Bologna</orgName>
+                    <orgName type="variant" source="DNB">Convento di San Francesco Bologna</orgName>
+                    <orgName type="variant" source="DNB">Convento di San Francesco di Bologna</orgName>
+                    <orgName type="crossref" source="DNB">Franziskanerkloster Bologna</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -18336,8 +18830,7 @@
                 <org xml:id="org_212968081">
                     <orgName type="display" source="bodl">Chiaravalle de Bagnolo, <affiliation>Cistercian</affiliation> abbey (Milan)</orgName>
                     <!-- record originally created from https://viaf.org/viaf/212968081/viaf.xml at 2018-10-08 14:44:52.855482 -->
-                    <orgName type="variant" source="LC">Santa Maria di Chiaravalle (Abbey :
-                        Milan, Italy)</orgName>
+                    <orgName type="variant" source="LC">Santa Maria di Chiaravalle (Abbey : Milan, Italy)</orgName>
                     <orgName type="crossref" source="DNB">Abbazia di Chiaravalle</orgName>
                     <note type="links">
                         <list type="links">
@@ -18378,14 +18871,10 @@
                 <org xml:id="org_141000452">
                     <orgName type="display" source="bodl">Meaux, <affiliation>Benedictine</affiliation> abbey of St Faron</orgName>
                     <!-- record originally created from https://viaf.org/viaf/141000452/viaf.xml at 2018-10-08 14:44:55.621682 -->
-                    <orgName type="variant" source="SUDOC">Abbaye Saint-Faron (Meaux,
-                        Seine-et-Marne)</orgName>
-                    <orgName type="variant" source="SUDOC">Abbaye Saint-Pharon (Meaux,
-                        Seine-et-Marne)</orgName>
-                    <orgName type="variant" source="SUDOC">Abbaye Sainte-Croix et
-                        Saint-Jean-Baptiste (Meaux, Seine-et-Marne)</orgName>
-                    <orgName type="variant" source="SUDOC">Abbaye de Bénédictins (Meaux,
-                        Seine-et-Marne ; Saint-Faron) (0628-179.)</orgName>
+                    <orgName type="variant" source="SUDOC">Abbaye Saint-Faron (Meaux, Seine-et-Marne)</orgName>
+                    <orgName type="variant" source="SUDOC">Abbaye Saint-Pharon (Meaux, Seine-et-Marne)</orgName>
+                    <orgName type="variant" source="SUDOC">Abbaye Sainte-Croix et Saint-Jean-Baptiste (Meaux, Seine-et-Marne)</orgName>
+                    <orgName type="variant" source="SUDOC">Abbaye de Bénédictins (Meaux, Seine-et-Marne ; Saint-Faron) (0628-179.)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -18410,8 +18899,7 @@
                 <org xml:id="org_254121248">
                     <orgName type="display" source="bodl">Zadar, <affiliation>Benedictine</affiliation> abbey of St Chrysogonus (Sveti Krševan)</orgName>
                     <!-- record originally created from https://viaf.org/viaf/254121248/viaf.xml at 2018-10-08 14:44:58.182082 -->
-                    <orgName type="variant" source="BAV">Sveti Krševan (abbazia benedettina
-                        : Zadar)</orgName>
+                    <orgName type="variant" source="BAV">Sveti Krševan (abbazia benedettina : Zadar)</orgName>
                     <!-- no variants found in preferred sources -->
                     <note type="links">
                         <list type="links">
@@ -18423,11 +18911,11 @@
                         </list>
                     </note>
                 </org>
+                
                 <org xml:id="org_254633607">
                     <orgName type="display" source="bodl">Zadar, <affiliation>Benedictine</affiliation> nunnery of the Virgin Mary (Sveti Marija)</orgName>
                     <!-- record originally created from https://viaf.org/viaf/254633607/viaf.xml at 2018-10-08 14:45:00.631282 -->
-                    <orgName type="variant" source="BAV">Sveti Marija (monastero benedettino
-                        : Zadar)</orgName>
+                    <orgName type="variant" source="BAV">Sveti Marija (monastero benedettino : Zadar)</orgName>
                     <!-- no variants found in preferred sources -->
                     <note type="links">
                         <list type="links">
@@ -18444,7 +18932,7 @@
                     <orgName type="display" source="bodl">Pavia, <affiliation>Charterhouse</affiliation> (Certosa di Pavia)</orgName>
                     <!-- record originally created from https://viaf.org/viaf/132622625/viaf.xml at 2018-10-08 14:45:03.330082 -->
                     <orgName type="variant" source="LC">Certosa di Pavia</orgName>
-                    <orgName type="variant"  source="DNB">Certosa, Pavia</orgName>
+                    <orgName type="variant" source="DNB">Certosa, Pavia</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -18484,10 +18972,8 @@
                 <org xml:id="org_266189883">
                     <orgName type="display" source="bodl">Brive-la-Gaillarde, Corrèze, <affiliation>Franciscan</affiliation> friary</orgName>
                     <!-- record originally created from https://viaf.org/viaf/266189883/viaf.xml at 2018-10-08 14:45:06.076682 -->
-                    <orgName type="variant" source="SUDOC">Couvent franciscain
-                        (Brive-la-Gaillarde, Corrèze)</orgName>
-                    <orgName type="crossref" source="SUDOC">Ordre des frères mineurs.,
-                        Province Les Franciscains France-Ouest (Brive-la-Gaillarde, Corrèze)</orgName>
+                    <orgName type="variant" source="SUDOC">Couvent franciscain (Brive-la-Gaillarde, Corrèze)</orgName>
+                    <orgName type="crossref" source="SUDOC">Ordre des frères mineurs., Province Les Franciscains France-Ouest (Brive-la-Gaillarde, Corrèze)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -18512,15 +18998,10 @@
                 <org xml:id="org_157389164">
                     <orgName type="display" source="bodl">Saint-Jean-de-Thouars, <affiliation>Benedictine nunnery</affiliation> of Saint-Jean de Bonneval-les-Thouars </orgName>
                     <!-- record originally created from https://viaf.org/viaf/157389164/viaf.xml at 2018-10-08 14:45:08.807682 -->
-                    <orgName type="variant" source="SUDOC">Abbaye de Saint-Jean de
-                        Bonneval-les-Thouars (Saint-Jean-de-Thouars, Deux-Sèvres)</orgName>
-                    <orgName type="variant" source="SUDOC">Abbaye de Bénédictines
-                        (Saint-Jean-de-Thouars, Deux-Sèvres ; Saint-Jean de Bonneval-les-Thouars)
-                        (0966-1791)</orgName>
-                    <orgName type="variant" source="SUDOC">Abbaye de Saint-Jean de
-                        Bonneval-lez-Thouars</orgName>
-                    <orgName type="variant" source="SUDOC">Abbaye royale de Saint-Jean de
-                        Bonneval-lez-Touars</orgName>
+                    <orgName type="variant" source="SUDOC">Abbaye de Saint-Jean de Bonneval-les-Thouars (Saint-Jean-de-Thouars, Deux-Sèvres)</orgName>
+                    <orgName type="variant" source="SUDOC">Abbaye de Bénédictines (Saint-Jean-de-Thouars, Deux-Sèvres ; Saint-Jean de Bonneval-les-Thouars) (0966-1791)</orgName>
+                    <orgName type="variant" source="SUDOC">Abbaye de Saint-Jean de Bonneval-lez-Thouars</orgName>
+                    <orgName type="variant" source="SUDOC">Abbaye royale de Saint-Jean de Bonneval-lez-Touars</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -18538,6 +19019,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q62084795">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -18545,8 +19031,7 @@
                 <org xml:id="org_250806462">
                     <orgName type="display" source="bodl">Piacenza, <affiliation>Benedictine</affiliation> abbey of St Sixtus</orgName>
                     <!-- record originally created from https://viaf.org/viaf/250806462/viaf.xml at 2018-10-08 14:45:11.350482 -->
-                    <orgName type="variant" source="DNB">Kloster San Sisto
-                        Piacenza</orgName>
+                    <orgName type="variant" source="DNB">Kloster San Sisto Piacenza</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -18563,14 +19048,11 @@
                     </note>
                 </org>
                 
-                
                 <org xml:id="org_223669083">
                     <orgName type="display" source="bodl">Downpatrick, <affiliation>Benedictine</affiliation> cathedral priory of Down</orgName>
                     <!-- record originally created from https://viaf.org/viaf/223669083/viaf.xml at 2018-10-08 14:45:13.784082 -->
-                    <orgName type="variant" source="LC">Down Cathedral (Downpatrick,
-                        Northern Ireland)</orgName>
-                    <orgName type="crossref" source="LC">Cathedral of the Holy Trinity
-                        (Downpatrick, Northern Ireland)</orgName>
+                    <orgName type="variant" source="LC">Down Cathedral (Downpatrick, Northern Ireland)</orgName>
+                    <orgName type="crossref" source="LC">Cathedral of the Holy Trinity (Downpatrick, Northern Ireland)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -18590,8 +19072,7 @@
                 <org xml:id="org_254016085">
                     <orgName type="display" source="bodl">Moggio Udinese, <affiliation>Benedictine</affiliation> abbey of St Gall</orgName>
                     <!-- record originally created from https://viaf.org/viaf/254016085/viaf.xml at 2018-10-08 14:45:16.529682 -->
-                    <orgName type="variant" source="SUDOC">Abbazia di San Gallo (Moggio
-                        Udinese, Italie)</orgName>
+                    <orgName type="variant" source="SUDOC">Abbazia di San Gallo (Moggio Udinese, Italie)</orgName>
                     <orgName type="variant" source="SUDOC">Abbazia di Moggio</orgName>
                     <orgName type="crossref" source="SUDOC">Kloster Moggio</orgName>
                     <note type="links">
@@ -18619,16 +19100,12 @@
                 <org xml:id="org_208896312">
                     <orgName type="display" source="bodl">Hauterive, <affiliation>Cisterican</affiliation> abbey of St Mary</orgName>
                     <!-- record originally created from https://viaf.org/viaf/208896312/viaf.xml at 2018-10-08 14:45:19.132682 -->
-                    <orgName type="variant" source="LC">Hauterive (Cistercian
-                        abbey)</orgName>
-                    <orgName type="crossref" source="DNB">Abbaye cistercienne
-                        d&#x27;Hauterive</orgName>
+                    <orgName type="variant" source="LC">Hauterive (Cistercian abbey)</orgName>
+                    <orgName type="crossref" source="DNB">Abbaye cistercienne d'Hauterive</orgName>
                     <orgName type="variant" source="DNB">Abtei Hauterive</orgName>
-                    <orgName type="variant" source="DNB">Abtei Notre-Dame von
-                        Hauterive</orgName>
+                    <orgName type="variant" source="DNB">Abtei Notre-Dame von Hauterive</orgName>
                     <orgName type="crossref" source="DNB">Kloster Hauterive</orgName>
-                    <orgName type="crossref" source="DNB">Zisterzienserabtei
-                        Hauterive</orgName>
+                    <orgName type="crossref" source="DNB">Zisterzienserabtei Hauterive</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -18656,6 +19133,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q444740">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -18664,8 +19146,7 @@
                     <orgName type="display" source="bodl">Brescia, cathedral church</orgName>
                     <!-- record originally created from https://viaf.org/viaf/157173843/viaf.xml at 2018-10-08 14:45:21.706682 -->
                     <orgName type="variant" source="LC">Duomo di Brescia</orgName>
-                    <orgName type="crossref" source="DNB">Cattedrale di Brescia,
-                        Brescia</orgName>
+                    <orgName type="crossref" source="DNB">Cattedrale di Brescia, Brescia</orgName>
                     <orgName type="variant" source="DNB">Duomo nuovo di Brescia</orgName>
                     <orgName type="variant" source="DNB">Duomo nuovo, Brescia</orgName>
                     <note type="links">
@@ -18690,6 +19171,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000104955515">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -18698,10 +19184,8 @@
                     <orgName type="display" source="bodl">Breme-Novalesa, <affiliation>Benedictine</affiliation> abbey</orgName>
                     <!-- record originally created from https://viaf.org/viaf/158357258/viaf.xml at 2018-10-08 14:45:24.155882 -->
                     <orgName type="variant" source="LC">Abbazia della Novalesa</orgName>
-                    <orgName type="variant" source="DNB">Abbazia Benedettina dei SS. Pietro
-                        e Andrea</orgName>
-                    <orgName type="crossref" source="DNB">Novalesa - Abbazia Benedettina dei
-                        SS. Pietro e Andrea, Unveraenderte Form</orgName>
+                    <orgName type="variant" source="DNB">Abbazia Benedettina dei SS. Pietro e Andrea</orgName>
+                    <orgName type="crossref" source="DNB">Novalesa - Abbazia Benedettina dei SS. Pietro e Andrea, Unveraenderte Form</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -18735,15 +19219,11 @@
                 
                 <org xml:id="org_305788823">
                     <orgName type="display" source="bodl">Salzburg, diocese</orgName>
-                    <orgName type="variant" source="LC">Catholic Church., Archdiocese of
-                        Salzburg (Austria)</orgName>
-                    <orgName type="crossref" source="DNB">Diözesansynode, Katholische
-                        Kirche, Erzdiözese Salzburg</orgName>
+                    <orgName type="variant" source="LC">Catholic Church., Archdiocese of Salzburg (Austria)</orgName>
+                    <orgName type="crossref" source="DNB">Diözesansynode, Katholische Kirche, Erzdiözese Salzburg</orgName>
                     <orgName type="variant" source="DNB">Diözese Salzburg</orgName>
-                    <orgName type="variant" source="DNB">Domkustodie, Katholische Kirche,
-                        Erzdiözese Salzburg</orgName>
-                    <orgName type="crossref" source="DNB">Erzbischöfliches Ordinariat,
-                        Katholische Kirche, Erzdiözese Salzburg</orgName>
+                    <orgName type="variant" source="DNB">Domkustodie, Katholische Kirche, Erzdiözese Salzburg</orgName>
+                    <orgName type="crossref" source="DNB">Erzbischöfliches Ordinariat, Katholische Kirche, Erzdiözese Salzburg</orgName>
                     <orgName type="variant" source="DNB">Erzbistum Salzburg</orgName>
                     <orgName type="variant" source="DNB">Erzdiözese Salzburg</orgName>
                     <note type="links">
@@ -18768,6 +19248,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000096506823">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -18775,22 +19260,16 @@
                 <org xml:id="org_310746171">
                     <orgName type="display" source="bodl">Saint-Amarin (afterwards Thann), <affiliation>Benedictine</affiliation> abbey (afterwards <affiliation>collegiate church</affiliation>)</orgName>
                     <orgName type="variant" source="bodl">St Amarin</orgName>
-                 
                     <!-- record originally created from https://viaf.org/viaf/310746171/viaf.xml at 2018-10-08 14:45:29.756282 -->
-                    <orgName type="variant" source="SUDOC">Chapitre de la collégiale
-                        Saint-Thiébaut (Thann, Haut-Rhin)</orgName>
+                    <orgName type="variant" source="SUDOC">Chapitre de la collégiale Saint-Thiébaut (Thann, Haut-Rhin)</orgName>
                     <orgName type="crossref" source="SUDOC">Abbaye de Saint-Amarin</orgName>
-                    <orgName type="variant" source="SUDOC">Chapitre collégial de
-                        Thann</orgName>
-                    <orgName type="variant" source="SUDOC">Chapitre de
-                        Saint-Amarin</orgName>
+                    <orgName type="variant" source="SUDOC">Chapitre collégial de Thann</orgName>
+                    <orgName type="variant" source="SUDOC">Chapitre de Saint-Amarin</orgName>
                     <orgName type="variant" source="SUDOC">Chapitre de Thann</orgName>
-                    <orgName type="crossref"  source="SUDOC">Saint-Amarin (Haut-Rhin),
-                        Abbaye</orgName>
-                    <orgName type="variant"  source="SUDOC">Saint-Amarin (Haut-Rhin),
-                        Chapitre de la collégiale</orgName>
-                    <orgName type="crossref"  source="SUDOC">Thann (Haut-Rhin), Chapitre
-                        de la collégiale Saint-Thiébaut</orgName>   <bibl>Cottineau II col. 2584</bibl>
+                    <orgName type="crossref" source="SUDOC">Saint-Amarin (Haut-Rhin), Abbaye</orgName>
+                    <orgName type="variant" source="SUDOC">Saint-Amarin (Haut-Rhin), Chapitre de la collégiale</orgName>
+                    <orgName type="crossref" source="SUDOC">Thann (Haut-Rhin), Chapitre de la collégiale Saint-Thiébaut</orgName>
+                    <bibl>Cottineau II col. 2584</bibl>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -18815,8 +19294,7 @@
                 <org xml:id="org_138522977">
                     <orgName type="display" source="bodl">Murbach, Benedictine abbey</orgName>
                     <!-- record originally created from https://viaf.org/viaf/138522977/viaf.xml at 2018-10-08 14:45:32.380082 -->
-                    <orgName type="variant" source="LC">Abbaye de Murbach (Murbach,
-                        France)</orgName>
+                    <orgName type="variant" source="LC">Abbaye de Murbach (Murbach, France)</orgName>
                     <orgName type="variant" source="DNB">Abtei Murbach</orgName>
                     <orgName type="crossref" source="DNB">Kloster Murbach</orgName>
                     <orgName type="crossref" source="DNB">Reichsabtei Murbach</orgName>
@@ -18852,6 +19330,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000121681552">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -18859,8 +19342,7 @@
                 <org xml:id="org_128317513">
                     <orgName type="display">Eddington Bindery</orgName>
                     <!-- record originally created from https://viaf.org/viaf/128317513/viaf.xml at 2018-10-08 14:45:34.923882 -->
-                    <orgName type="variant" source="NKC">Eddington Bindery (Hungerford,
-                        Anglie), kn20050427043</orgName>
+                    <orgName type="variant" source="NKC">Eddington Bindery (Hungerford, Anglie), kn20050427043</orgName>
                     <!-- no variants found in preferred sources -->
                     <note type="links">
                         <list type="links">
@@ -18897,8 +19379,7 @@
                     <orgName type="display" source="bodl">Burgos, Convento de San Agustín</orgName>
                     <!-- not found in Cottineau -->
                     <!-- record originally created from https://viaf.org/viaf/145653569/viaf.xml at 2018-10-08 14:45:39.994882 -->
-                    <orgName type="variant" source="LC">Convento de San Agustín (Burgos,
-                        Spain)</orgName>
+                    <orgName type="variant" source="LC">Convento de San Agustín (Burgos, Spain)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -18940,11 +19421,9 @@
                     <orgName type="display" source="bodl">Chartres, cathedral</orgName>
                     <!-- record originally created from https://viaf.org/viaf/138342928/viaf.xml at 2018-10-08 14:45:45.349682 -->
                     <orgName type="variant" source="LC">Cathédrale de Chartres</orgName>
-                    <orgName type="crossref"  source="DNB">Kathedrale Notre-Dame de
-                        Chartres, Chartres</orgName>
-                    <orgName type="variant"  source="DNB">Kathedrale von Chartres,
-                        Chartres</orgName>
-                    <orgName type="crossref"  source="DNB">Notre-Dame, Chartres</orgName>
+                    <orgName type="crossref" source="DNB">Kathedrale Notre-Dame de Chartres, Chartres</orgName>
+                    <orgName type="variant" source="DNB">Kathedrale von Chartres, Chartres</orgName>
+                    <orgName type="crossref" source="DNB">Notre-Dame, Chartres</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -18970,6 +19449,16 @@
                             <item>
                                 <ref target="https://viaf.org/viaf/138342928">
                                     <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://catalogue.bnf.fr/ark:/12148/cb10753389j">
+                                    <title>BNF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q3152815">
+                                    <title>Wikidata</title>
                                 </ref>
                             </item>
                         </list>
@@ -19001,8 +19490,7 @@
                 <org xml:id="org_1115145857069622921436">
                     <orgName type="display" source="bodl">London, Harmsworth Trust library</orgName>
                     <!-- record originally created from https://viaf.org/viaf/1115145857069622921436/viaf.xml at 2018-10-08 14:45:50.451882 -->
-                    <orgName type="variant" source="DNB">Harmsworth Trust Library,
-                        London</orgName>
+                    <orgName type="variant" source="DNB">Harmsworth Trust Library, London</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -19027,10 +19515,8 @@
                     <orgName type="variant" source="LC">Panteon (Rome, Italy)</orgName>
                     <orgName type="crossref" subtype="surnameFirst" source="LC">Rome (City)., Pantheon</orgName>
                     <orgName type="variant" subtype="surnameFirst" source="LC">Rome (Italy)., Pantheon</orgName>
-                    <orgName type="crossref" subtype="surnameFirst" source="LC">Santa Maria Rotonda (Church :
-                        Rome, Italy)</orgName>
-                    <orgName type="variant" source="LC">Santa Maria ad Martyres (Church :
-                        Rome, Italy)</orgName>
+                    <orgName type="crossref" subtype="surnameFirst" source="LC">Santa Maria Rotonda (Church : Rome, Italy)</orgName>
+                    <orgName type="variant" source="LC">Santa Maria ad Martyres (Church : Rome, Italy)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -19056,13 +19542,10 @@
                     <orgName type="display" source="bodl">Saint-Malo, cathedral church of St Vincent</orgName>
                     <!-- record originally created from https://viaf.org/viaf/266852074/viaf.xml at 2018-10-08 14:45:55.585282 -->
                     <orgName type="variant" source="LC">Cathédrale de Saint-Malo</orgName>
-                    <orgName type="variant"  source="DNB">Cathédrale Saint-Malo</orgName>
-                    <orgName type="crossref"  source="DNB">Ehemalige Kathedrale
-                        Saint-Vincent, Saint-Malo</orgName>
-                    <orgName type="crossref"  source="DNB">Saint Vincent,
-                        Saint-Malo</orgName>
-                    <orgName type="variant"  source="DNB">Saint-Vincent-de-Saragosse
-                        Saint-Malo</orgName>
+                    <orgName type="variant" source="DNB">Cathédrale Saint-Malo</orgName>
+                    <orgName type="crossref" source="DNB">Ehemalige Kathedrale Saint-Vincent, Saint-Malo</orgName>
+                    <orgName type="crossref" source="DNB">Saint Vincent, Saint-Malo</orgName>
+                    <orgName type="variant" source="DNB">Saint-Vincent-de-Saragosse Saint-Malo</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -19085,20 +19568,14 @@
                 </org>
                 
                 <org xml:id="org_173376610">
-                    <orgName type="display" source="bodl">Bois-Seigneur-Isaac (Braine-l'Alleud), priory of <affiliation>Augustinian canons (Windesheim congregation)</affiliation></orgName>
+                    <orgName type="display" source="bodl">Bois-Seigneur-Isaac (Braine-l'Alleud), priory of <affiliation>Augustinian canons (Windesheim congregation)</affiliation> </orgName>
                     <!-- record originally created from https://viaf.org/viaf/173376610/viaf.xml at 2018-10-08 14:45:58.174882 -->
-                    <orgName type="variant" source="LC">Chapelle de
-                        Bois-Seigneur-Isaac</orgName>
-                    <orgName type="crossref" source="LC">Abbaye de Bois-Seigneur-Isaac
-                        (Braine-l&#x27;Alleud, Belgium)</orgName>
-                    <orgName type="variant" source="LC">Chapelle du Saint-Sang
-                        (Braine-l&#x27;Alleud, Belgium)</orgName>
-                    <orgName type="crossref" source="LC">Monastère Saint-Charbel
-                        (Braine-l&#x27;Alleud, Belgium)</orgName>
-                    <orgName type="crossref" source="LC">Prieuré de Bois-Seigneur-Isaac
-                        (Braine-l&#x27;Alleud, Belgium)</orgName>
-                    <orgName type="variant" source="LC">Prieuré des Prémontrés de
-                        Bois-Seigneur-Isaac (Braine-l&#x27;Alleud, Belgium)</orgName>
+                    <orgName type="variant" source="LC">Chapelle de Bois-Seigneur-Isaac</orgName>
+                    <orgName type="crossref" source="LC">Abbaye de Bois-Seigneur-Isaac (Braine-l'Alleud, Belgium)</orgName>
+                    <orgName type="variant" source="LC">Chapelle du Saint-Sang (Braine-l'Alleud, Belgium)</orgName>
+                    <orgName type="crossref" source="LC">Monastère Saint-Charbel (Braine-l'Alleud, Belgium)</orgName>
+                    <orgName type="crossref" source="LC">Prieuré de Bois-Seigneur-Isaac (Braine-l'Alleud, Belgium)</orgName>
+                    <orgName type="variant" source="LC">Prieuré des Prémontrés de Bois-Seigneur-Isaac (Braine-l'Alleud, Belgium)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -19133,13 +19610,11 @@
                 <org xml:id="org_240145542525596640761">
                     <orgName type="display" source="bodl">Villeneuve-lès-Avignon, <affiliation>Charterhouse</affiliation> of Val de Bénédiction</orgName>
                     <!-- record originally created from https://viaf.org/viaf/240145542525596640761/viaf.xml at 2018-10-08 14:46:00.920482 -->
-                    <orgName type="variant" source="DNB">Kartäuserkloster
-                        Villeneuve-lès-Avignon</orgName>
+                    <orgName type="variant" source="DNB">Kartäuserkloster Villeneuve-lès-Avignon</orgName>
                     <orgName type="crossref" source="DNB">Cartusia Villenova</orgName>
                     <orgName type="variant" source="DNB">Charterhouse</orgName>
                     <orgName type="variant" source="DNB">Chartreuse</orgName>
-                    <orgName type="variant" source="DNB">Chartreuse du
-                        Val-de-Bénédiction</orgName>
+                    <orgName type="variant" source="DNB">Chartreuse du Val-de-Bénédiction</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -19159,12 +19634,9 @@
                 <org xml:id="org_124103277">
                     <orgName type="display" source="bodl">Paris, <affiliation>Jesuit college</affiliation> of Clermont</orgName>
                     <!-- record originally created from https://viaf.org/viaf/124103277/viaf.xml at 2018-10-08 14:46:03.479882 -->
-                    <orgName type="variant" source="LC">Collège de Clermont (Paris,
-                        France)</orgName>
-                    <orgName type="variant" source="DNB">Claromontanum Collegium
-                        Paris</orgName>
-                    <orgName type="variant" source="DNB">Collegium Claromontanum
-                        Paris</orgName>
+                    <orgName type="variant" source="LC">Collège de Clermont (Paris, France)</orgName>
+                    <orgName type="variant" source="DNB">Claromontanum Collegium Paris</orgName>
+                    <orgName type="variant" source="DNB">Collegium Claromontanum Paris</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -19182,6 +19654,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000085816754">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -19189,8 +19666,7 @@
                 <org xml:id="org_138512183">
                     <orgName type="display" source="bodl">Northampton, <affiliation>parish church</affiliation> of St Peter</orgName>
                     <!-- record originally created from https://viaf.org/viaf/138512183/viaf.xml at 2018-10-08 14:46:06.007082 -->
-                    <orgName type="variant" source="LC">Church of St. Peter (Northampton,
-                        England)</orgName>
+                    <orgName type="variant" source="LC">Church of St. Peter (Northampton, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -19206,16 +19682,11 @@
                         </list>
                     </note>
                 </org>
-                
-                
-              
-                
                 <!-- 19.3.18 -->
                 <org xml:id="org_246948936">
                     <orgName type="display" source="bodl">Deerhurst, <affiliation>priory</affiliation> and <affiliation>parish church</affiliation> of St Mary</orgName>
                     <!-- record originally created from https://viaf.org/viaf/246948936/viaf.xml at 2018-10-08 14:46:10.923082 -->
-                    <orgName type="variant" source="LC">St. Mary&#x27;s Church (Deerhurst,
-                        England)</orgName>
+                    <orgName type="variant" source="LC">St. Mary's Church (Deerhurst, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -19245,10 +19716,8 @@
                 <org xml:id="org_157113813">
                     <orgName type="display" source="bodl">Worcester, diocese</orgName>
                     <!-- record originally created from https://viaf.org/viaf/157113813/viaf.xml at 2018-10-08 14:46:13.459682 -->
-                    <orgName type="variant" source="LC">Catholic Church., Diocese of
-                        Worcester (England)</orgName>
-                    <orgName type="crossref" subtype="surnameFirst" source="LC">Worcester (England : Diocese :
-                        Catholic Church)</orgName>
+                    <orgName type="variant" source="LC">Catholic Church., Diocese of Worcester (England)</orgName>
+                    <orgName type="crossref" subtype="surnameFirst" source="LC">Worcester (England : Diocese : Catholic Church)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -19266,11 +19735,10 @@
                 </org>
                 
                 <org xml:id="org_144217511">
-                    <orgName type="display" source="bodl">Salisbury, <affiliation>cathedral church</affiliation></orgName>
+                    <orgName type="display" source="bodl">Salisbury, <affiliation>cathedral church</affiliation> </orgName>
                     <!-- record originally created from https://viaf.org/viaf/144217511/viaf.xml at 2018-10-08 14:46:16.365882 -->
                     <orgName type="variant" source="LC">Salisbury Cathedral</orgName>
-                    <orgName type="crossref" source="LC">Cathedral Church of the Blessed
-                        Virgin Mary (Salisbury, England)</orgName>
+                    <orgName type="crossref" source="LC">Cathedral Church of the Blessed Virgin Mary (Salisbury, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -19288,6 +19756,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000097442200">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -19295,12 +19768,9 @@
                 <org xml:id="org_125940881">
                     <orgName type="display" source="bodl">Burton Lazars, hospital of St Lazarus</orgName>
                     <!-- record originally created from https://viaf.org/viaf/125940881/viaf.xml at 2018-10-08 14:46:19.111482 -->
-                    <orgName type="variant" source="LC">Hospital of St. Lazarus (Burton
-                        Lazars, England)</orgName>
-                    <orgName type="crossref" subtype="surnameFirst" source="LC">Burton Lazars (England).,
-                        Hospital of St. Lazarus</orgName>
-                    <orgName type="variant" source="LC">Hospital of Saint Lazarus (Burton
-                        Lazars, England)</orgName>
+                    <orgName type="variant" source="LC">Hospital of St. Lazarus (Burton Lazars, England)</orgName>
+                    <orgName type="crossref" subtype="surnameFirst" source="LC">Burton Lazars (England)., Hospital of St. Lazarus</orgName>
+                    <orgName type="variant" source="LC">Hospital of Saint Lazarus (Burton Lazars, England)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -19320,8 +19790,7 @@
                 <org xml:id="org_123598658">
                     <orgName type="display" source="bodl">Florence, <affiliation>Benedictine</affiliation> monastery of S. Felicita</orgName>
                     <!-- record originally created from https://viaf.org/viaf/123598658/viaf.xml at 2018-10-08 14:46:21.872682 -->
-                    <orgName type="variant" source="LC">Chiesa di Santa Felicita (Florence,
-                        Italy)</orgName>
+                    <orgName type="variant" source="LC">Chiesa di Santa Felicita (Florence, Italy)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -19347,32 +19816,23 @@
                         </list>
                     </note>
                 </org>
-            
+                
                 <org xml:id="org_252240186">
                     <orgName type="display" source="bodl">Paris, <affiliation>Augustinian</affiliation> abbey of St.-Victor</orgName>
                     <!-- record originally created from https://viaf.org/viaf/252240186/viaf.xml at 2018-10-08 14:46:24.556882 -->
-                    <orgName type="variant" source="LC">Saint-Victor (Abbey : Paris,
-                        France)</orgName>
-                    <orgName type="crossref" source="DNB">Abbaye Saint-Victor
-                        Paris</orgName>
-                    <orgName type="variant" source="DNB">Abbaye de Saint-Victor
-                        Paris</orgName>
+                    <orgName type="variant" source="LC">Saint-Victor (Abbey : Paris, France)</orgName>
+                    <orgName type="crossref" source="DNB">Abbaye Saint-Victor Paris</orgName>
+                    <orgName type="variant" source="DNB">Abbaye de Saint-Victor Paris</orgName>
                     <orgName type="variant" source="DNB">Abtei Saint-Victor Paris</orgName>
                     <orgName type="variant" source="DNB">Abtei Sankt Viktor Paris</orgName>
                     <orgName type="variant" source="DNB">Abtei St-Victor Paris</orgName>
                     <orgName type="variant" source="DNB">Abtei St. Viktor Paris</orgName>
-                    <orgName type="crossref" source="DNB">Chapelle de Saint-Victor
-                        Paris</orgName>
-                    <orgName type="variant" source="DNB">Chorherrenstift Sankt Viktor
-                        Paris</orgName>
-                    <orgName type="variant" source="DNB">Chorherrenstift St. Viktor
-                        Paris</orgName>
-                    <orgName type="crossref" source="DNB">Regalis Abbatia Sancti Victoris
-                        Parisiensis</orgName>
-                    <orgName type="variant" source="DNB">Saint-Victor, Abbaye,
-                        Paris</orgName>
-                    <orgName type="variant" source="DNB">Saint-Victor, Kloster,
-                        Paris</orgName>
+                    <orgName type="crossref" source="DNB">Chapelle de Saint-Victor Paris</orgName>
+                    <orgName type="variant" source="DNB">Chorherrenstift Sankt Viktor Paris</orgName>
+                    <orgName type="variant" source="DNB">Chorherrenstift St. Viktor Paris</orgName>
+                    <orgName type="crossref" source="DNB">Regalis Abbatia Sancti Victoris Parisiensis</orgName>
+                    <orgName type="variant" source="DNB">Saint-Victor, Abbaye, Paris</orgName>
+                    <orgName type="variant" source="DNB">Saint-Victor, Kloster, Paris</orgName>
                     <orgName type="variant" source="DNB">Stift Sankt Viktor Paris</orgName>
                     <orgName type="variant" source="DNB">Stift St. Viktor Paris</orgName>
                     <note type="links">
@@ -19407,6 +19867,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000120972024">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -19414,8 +19879,7 @@
                 <org xml:id="org_312805416">
                     <orgName type="display" source="bodl">Sens-sur-Yonne, <affiliation>Benedictine</affiliation> abbey of Saint-Pierre-le-Vif</orgName>
                     <!-- record originally created from https://viaf.org/viaf/312805416/viaf.xml at 2018-10-08 14:46:27.021682 -->
-                    <orgName type="variant" source="LC">Saint-Pierre-le-Vif (Monastery :
-                        Sens-sur-Yonne, France)</orgName>
+                    <orgName type="variant" source="LC">Saint-Pierre-le-Vif (Monastery : Sens-sur-Yonne, France)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -19435,9 +19899,9 @@
                 <org xml:id="org_148097195">
                     <orgName type="display" source="bodl">Verona, Benedictine monastery of San Zeno Maggiore</orgName>
                     <!-- record originally created from https://viaf.org/viaf/148097195/viaf.xml at 2018-10-08 14:46:29.470282 -->
-                    <orgName type="variant" source="LC">Monastero di San Zeno (Verona,
-                        Italy)</orgName>
-                    <orgName type="variant" source="DNB">Monastero di San Zeno</orgName>  <location source="https://en.wikipedia.org/wiki/Basilica_of_San_Zeno,_Verona">
+                    <orgName type="variant" source="LC">Monastero di San Zeno (Verona, Italy)</orgName>
+                    <orgName type="variant" source="DNB">Monastero di San Zeno</orgName>
+                    <location source="https://en.wikipedia.org/wiki/Basilica_of_San_Zeno,_Verona">
                         <geo>45.4425,10.979167</geo>
                     </location>
                     <note type="links">
@@ -19459,7 +19923,6 @@
                             </item>
                         </list>
                     </note>
-                  
                     <note>Co-ordinates from Wikipedia.</note>
                 </org>
                 
@@ -19467,16 +19930,18 @@
                     <orgName type="display" source="bodl">Neuzelle, <affiliation>Cistercian</affiliation> abbey</orgName>
                     <!-- record originally created from https://viaf.org/viaf/245815193/viaf.xml at 2018-10-08 14:46:31.935082 -->
                     <orgName type="variant" source="LC">Stift Neuzelle</orgName>
-                    <orgName type="crossref" source="DNB">Zisterzienserkloster
-                        Neuzelle</orgName>
+                    <orgName type="crossref" source="DNB">Zisterzienserkloster Neuzelle</orgName>
                     <location source="http://klosterdatenbank.germania-sacra.de/gsn/757">
                         <geo>52.090556,14.652222</geo>
                     </location>
                     <note>Co-ordinates from Germania Sacra</note>
                     <note type="links">
                         <list type="links">
-                            <item><ref target="http://klosterdatenbank.germania-sacra.de/gsn/757"><title>Germania Sacra</title></ref></item>
-                        
+                            <item>
+                                <ref target="http://klosterdatenbank.germania-sacra.de/gsn/757">
+                                    <title>Germania Sacra</title>
+                                </ref>
+                            </item>
                             <item>
                                 <ref target="http://d-nb.info/gnd/4390178-5">
                                     <title>GND</title>
@@ -19503,25 +19968,23 @@
                 
                 <org xml:id="org_126802421">
                     <orgName type="display" source="bodl">Würzburg, <affiliation>Benedictine</affiliation> abbey of St Stephen (St Stephan)</orgName>
-                    <orgName type="variant" source="LC">Benediktinerkloster St. Stephan
-                        (Würzburg, Germany)</orgName>
-                    <orgName type="variant" source="DNB">Benediktinerabtei Sankt Stephan,
-                        Würzburg</orgName>
-                    <orgName type="variant" source="DNB">Benediktinerabtei St. Stephan,
-                        Würzburg</orgName>
-                    <orgName type="variant" source="DNB">Benediktinerkloster Sankt
-                        Stephan</orgName>
-                    <orgName type="variant" source="DNB">Benediktinerkloster St.
-                        Stephan</orgName>
-                    <orgName type="crossref" source="DNB">Kloster St. Stephan
-                        Würzburg</orgName>
+                    <orgName type="variant" source="LC">Benediktinerkloster St. Stephan (Würzburg, Germany)</orgName>
+                    <orgName type="variant" source="DNB">Benediktinerabtei Sankt Stephan, Würzburg</orgName>
+                    <orgName type="variant" source="DNB">Benediktinerabtei St. Stephan, Würzburg</orgName>
+                    <orgName type="variant" source="DNB">Benediktinerkloster Sankt Stephan</orgName>
+                    <orgName type="variant" source="DNB">Benediktinerkloster St. Stephan</orgName>
+                    <orgName type="crossref" source="DNB">Kloster St. Stephan Würzburg</orgName>
                     <location source="http://klosterdatenbank.germania-sacra.de/gsn/60435">
                         <geo>49.7895,9.9348</geo>
                     </location>
                     <note>Co-ordinates from Germania Sacra</note>
                     <note type="links">
                         <list type="links">
-                            <item><ref target="http://klosterdatenbank.germania-sacra.de/gsn/60435"><title>Germania Sacra</title></ref></item>
+                            <item>
+                                <ref target="http://klosterdatenbank.germania-sacra.de/gsn/60435">
+                                    <title>Germania Sacra</title>
+                                </ref>
+                            </item>
                             <item>
                                 <ref target="http://id.loc.gov/authorities/names/n91024909">
                                     <title>LC</title>
@@ -19547,16 +20010,19 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q28978865">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
                 <org xml:id="org_139637930">
                     <orgName type="display" source="bodl">Reading, <affiliation>Benedictine</affiliation> abbey</orgName>
-                    <orgName type="variant" source="LC">Reading Abbey (Reading,
-                        England)</orgName>
-                    <orgName type="variant" subtype="surnameFirst" source="LC">Reading (England).,
-                        Abbey</orgName>
+                    <orgName type="variant" source="LC">Reading Abbey (Reading, England)</orgName>
+                    <orgName type="variant" subtype="surnameFirst" source="LC">Reading (England)., Abbey</orgName>
                     <location source="https://en.wikipedia.org/wiki/Reading_Abbey">
                         <geo>51.456347, -0.965086</geo>
                     </location>
@@ -19576,25 +20042,25 @@
                         </list>
                     </note>
                 </org>
-               
+                
                 <org xml:id="org_139922418">
                     <orgName type="display" source="bodl">Heidenheim, St Wunibald's (<affiliation>Benedictine</affiliation> and <affiliation>secular canons</affiliation>)</orgName>
                     <!-- record originally created from https://viaf.org/viaf/139922418/viaf.xml at 2018-10-08 14:46:39.339482 -->
-                    <orgName type="variant" source="LC">Benediktinerkloster Heidenheim
-                        (Heidenheim, Bavaria, Germany)</orgName>
-                    <orgName type="variant" source="LC">Benediktinerabtei Heidenheim
-                        (Heidenheim, Bavaria, Germany)</orgName>
-                    <orgName type="crossref" source="LC">Heidenheim (Monastery : Heidenheim,
-                        Bavaria, Germany)</orgName>
-                    <orgName type="crossref" source="LC">Kloster Heidenheim (Heidenheim,
-                        Bavaria, Germany)</orgName>
+                    <orgName type="variant" source="LC">Benediktinerkloster Heidenheim (Heidenheim, Bavaria, Germany)</orgName>
+                    <orgName type="variant" source="LC">Benediktinerabtei Heidenheim (Heidenheim, Bavaria, Germany)</orgName>
+                    <orgName type="crossref" source="LC">Heidenheim (Monastery : Heidenheim, Bavaria, Germany)</orgName>
+                    <orgName type="crossref" source="LC">Kloster Heidenheim (Heidenheim, Bavaria, Germany)</orgName>
                     <location source="http://klosterdatenbank.germania-sacra.de/gsn/60127">
                         <geo>49.0177,10.7427</geo>
                     </location>
                     <note>Co-ordinates from Germania Sacra.</note>
                     <note type="links">
                         <list type="links">
-                            <item><ref target="http://klosterdatenbank.germania-sacra.de/gsn/60127"><title>Germania Sacra</title></ref></item>
+                            <item>
+                                <ref target="http://klosterdatenbank.germania-sacra.de/gsn/60127">
+                                    <title>Germania Sacra</title>
+                                </ref>
+                            </item>
                             <item>
                                 <ref target="http://id.loc.gov/authorities/names/no2006064291">
                                     <title>LC</title>
@@ -19616,8 +20082,7 @@
                 
                 <org xml:id="org_159896141">
                     <orgName type="display" source="bodl">Fleury, <affiliation>Benedictine</affiliation> abbey of Saint-Benoît-sur-Loire</orgName>
-                    <orgName type="variant" source="DNB">Abbaye de Fleury,
-                        Saint-Benoît-sur-Loire</orgName>
+                    <orgName type="variant" source="DNB">Abbaye de Fleury, Saint-Benoît-sur-Loire</orgName>
                     <location source="https://en.wikipedia.org/wiki/Fleury_Abbey">
                         <geo>47.809797, 2.305519</geo>
                     </location>
@@ -19686,29 +20151,25 @@
                         </list>
                     </note>
                 </org>
-               
-               
-               <!-- new, 2.19 : -->
-              
-               
-               
+                <!-- new, 2.19 : -->
                 <org xml:id="org_136144523">
                     <orgName type="display" source="bodl">Würzburg, Kollegiatstift Neumünster, <affiliation>collegiate church</affiliation> of St John Evangelist</orgName>
                     <!-- record originally created from https://viaf.org/viaf/136144523/viaf.xml at 2019-03-13 14:59:45.052761 -->
-                    <orgName type="variant" subtype="corporate" source="LC">Neumünsterkirche (Würzburg,
-                        Germany)</orgName>
+                    <orgName type="variant" subtype="corporate" source="LC">Neumünsterkirche (Würzburg, Germany)</orgName>
                     <orgName type="variant" subtype="corporate" source="DNB">Neumünster, Würzburg</orgName>
-                    <orgName type="variant" subtype="corporate" source="DNB">Pfarrei Neumünster (St. Johannes
-                        Evangelist) Würzburg</orgName>
-                    <orgName type="variant" subtype="corporate" source="DNB">Pfarrei Neumünster
-                        Würzburg</orgName>
+                    <orgName type="variant" subtype="corporate" source="DNB">Pfarrei Neumünster (St. Johannes Evangelist) Würzburg</orgName>
+                    <orgName type="variant" subtype="corporate" source="DNB">Pfarrei Neumünster Würzburg</orgName>
                     <location source="http://klosterdatenbank.germania-sacra.de/gsn/1058">
                         <geo>49.793831,9.931578</geo>
                     </location>
                     <note>Co-ordinates from Germania Sacra</note>
                     <note type="links">
                         <list type="links">
-                            <item><ref target="http://klosterdatenbank.germania-sacra.de/gsn/1058"><title>Germania Sacra</title></ref></item>
+                            <item>
+                                <ref target="http://klosterdatenbank.germania-sacra.de/gsn/1058">
+                                    <title>Germania Sacra</title>
+                                </ref>
+                            </item>
                             <item>
                                 <ref target="http://id.loc.gov/authorities/names/n88037200">
                                     <title>LC</title>
@@ -19724,18 +20185,21 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <item><ref target="https://viaf.org/viaf/136144523"><title>VIAF</title></ref></item>
-                    </list>
+                            <item>
+                                <ref target="https://viaf.org/viaf/136144523">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                        </list>
                     </note>
                 </org>
                 
                 <org xml:id="org_211935376">
+<!-- ***** Old VIAF ID now redirects to 158676805 ***** -->
                     <orgName type="display" source="bodl">Metz, <affiliation>Benedictine</affiliation> abbey of St Vincent</orgName>
                     <!-- record originally created from https://viaf.org/viaf/211935376/viaf.xml at 2019-03-13 14:59:47.954379 -->
-                    <orgName type="variant" subtype="corporate" source="SUDOC">Abbaye Saint-Vincent
-                        (Metz)</orgName>
-                    <orgName type="crossref" subtype="unknownOrder" source="SUDOC">Metz (Moselle), Abbaye
-                        Saint-Vincent</orgName>
+                    <orgName type="variant" subtype="corporate" source="SUDOC">Abbaye Saint-Vincent (Metz)</orgName>
+                    <orgName type="crossref" subtype="unknownOrder" source="SUDOC">Metz (Moselle), Abbaye Saint-Vincent</orgName>
                     <location source="https://fr.wikipedia.org/wiki/Abbaye_Saint-Vincent_de_Metz">
                         <geo>49.1121, 6.2574</geo>
                     </location>
@@ -19757,15 +20221,29 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/no2009095155">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/158676805">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q2820451">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
-               
+                
                 <org xml:id="org_122051762">
-                   <orgName type="display" source="bodl">Constantinople, monastery of Theotokos Evergetis</orgName>
+                    <orgName type="display" source="bodl">Constantinople, monastery of Theotokos Evergetis</orgName>
                     <!-- record originally created from https://viaf.org/viaf/122051762/viaf.xml at 2019-03-13 14:59:50.902798 -->
-                    <orgName type="variant" subtype="corporate" source="LC">Theotokos Evergetis (Monastery :
-                        Istanbul, Turkey)</orgName>
+                    <orgName type="variant" subtype="corporate" source="LC">Theotokos Evergetis (Monastery : Istanbul, Turkey)</orgName>
                     <note type="links">
                         <list type="links">
                             <item>
@@ -19788,81 +20266,95 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                        </list></note>
+                        </list>
+                    </note>
                 </org>
                 
                 <org xml:id="org_237710601">
                     <orgName type="display" source="bodl">Fulda, <affiliation>Benedictine</affiliation> abbey of St Salvator</orgName>
                     <!-- record originally created from https://viaf.org/viaf/237710601/viaf.xml at 2019-03-13 14:59:53.929218 -->
-                    <orgName type="variant" subtype="corporate" source="DNB">Kloster Sankt Salvator und
-                        Bonifatius Fulda</orgName>
-                    <orgName type="crossref" subtype="corporate" source="DNB">Benediktinerkloster
-                        Fulda</orgName>
-                    <orgName type="variant" subtype="corporate" source="DNB">Benediktinerkloster Sankt Salvator
-                        und Bonifatius Fulda</orgName>
-                    <orgName type="crossref" subtype="corporate" source="DNB">Fulda,
-                        Benediktinerkloster</orgName>
-                    <orgName type="variant" subtype="corporate" source="DNB">Kloster des Bonifatius
-                        Fulda</orgName>
+                    <orgName type="variant" subtype="corporate" source="DNB">Kloster Sankt Salvator und Bonifatius Fulda</orgName>
+                    <orgName type="crossref" subtype="corporate" source="DNB">Benediktinerkloster Fulda</orgName>
+                    <orgName type="variant" subtype="corporate" source="DNB">Benediktinerkloster Sankt Salvator und Bonifatius Fulda</orgName>
+                    <orgName type="crossref" subtype="corporate" source="DNB">Fulda, Benediktinerkloster</orgName>
+                    <orgName type="variant" subtype="corporate" source="DNB">Kloster des Bonifatius Fulda</orgName>
                     <orgName type="crossref" subtype="corporate" source="DNB">Reichsabtei Fulda</orgName>
                     <orgName type="variant" subtype="corporate" source="DNB">Reichskloster Fulda</orgName>
                     <orgName type="crossref" subtype="corporate" source="DNB">Sanctus Bonifacius Fulda</orgName>
-                    <orgName type="variant" subtype="corporate" source="DNB">Stift Sankt Salvator und Bonifatius
-                        Fulda</orgName>
+                    <orgName type="variant" subtype="corporate" source="DNB">Stift Sankt Salvator und Bonifatius Fulda</orgName>
                     <location source="http://klosterdatenbank.germania-sacra.de/gsn/30121">
                         <geo>50.55413185,9.672582597</geo>
                     </location>
                     <note>Co-ordinates from Germania Sacra</note>
                     <note type="links">
                         <list type="links">
-                            <item><ref target="http://klosterdatenbank.germania-sacra.de/gsn/30121"><title>Germania Sacra</title></ref></item>
+                            <item>
+                                <ref target="http://klosterdatenbank.germania-sacra.de/gsn/30121">
+                                    <title>Germania Sacra</title>
+                                </ref>
+                            </item>
                             <item>
                                 <ref target="http://d-nb.info/gnd/4074038-9">
                                     <title>GND</title>
                                 </ref>
                             </item>
-                        <item><ref target="https://viaf.org/viaf/237710601"><title>VIAF</title></ref></item>
-                    </list>
+                            <item>
+                                <ref target="https://viaf.org/viaf/237710601">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                        </list>
                     </note>
                 </org>
-               
+                
                 <org xml:id="org_157833663">
                     <orgName type="display" source="bodl">Hornbach (Rheinland-Pfalz), <affiliation>Benedictine</affiliation> abbey of St Peter</orgName>
                     <!-- record originally created from https://viaf.org/viaf/157833663/viaf.xml at 2019-03-13 14:59:56.815236 -->
                     <orgName type="variant" subtype="corporate" source="DNB">Kloster, Hornbach</orgName>
                     <orgName type="crossref" subtype="corporate" source="DNB">Abtei</orgName>
-                    <orgName type="crossref" subtype="corporate" source="DNB">Benediktinerabtei</orgName>
-                    <orgName type="variant" subtype="corporate" source="DNB">Benediktinerkloster</orgName>
+                    <orgName type="crossref" subtype="corporate" source="DNB" >Benediktinerabtei</orgName>
+                    <orgName type="variant" subtype="corporate" source="DNB" >Benediktinerkloster</orgName>
                     <location source="http://klosterdatenbank.germania-sacra.de/gsn/40091">
                         <geo>49.186954,7.369469</geo>
                     </location>
                     <note>Co-ordinates from Germania Sacra</note>
                     <note type="links">
                         <list type="links">
-                            <item><ref target="http://klosterdatenbank.germania-sacra.de/gsn/40091"><title>Germania Sacra</title></ref></item>
+                            <item>
+                                <ref target="http://klosterdatenbank.germania-sacra.de/gsn/40091">
+                                    <title>Germania Sacra</title>
+                                </ref>
+                            </item>
                             <item>
                                 <ref target="http://d-nb.info/gnd/5081987-2">
                                     <title>GND</title>
                                 </ref>
                             </item>
-                            <item><ref target="https://viaf.org/viaf/157833663"><title>VIAF</title></ref></item>
+                            <item>
+                                <ref target="https://viaf.org/viaf/157833663">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
                 <org xml:id="org_298413710">
-                    <orgName type="display" source="bodl">Aulhausen (Marienhausen), <affiliation>Cistercian nunnery</affiliation></orgName>
+                    <orgName type="display" source="bodl">Aulhausen (Marienhausen), <affiliation>Cistercian nunnery</affiliation> </orgName>
                     <!-- record originally created from https://viaf.org/viaf/298413710/viaf.xml at 2019-03-13 14:59:59.872856 -->
                     <orgName type="variant" subtype="corporate" source="DNB">Kloster Aulhausen</orgName>
-                    <orgName type="crossref" subtype="corporate" source="DNB">Ehemaliges
-                        Zisterzienserinnen-Kloster Marienhausen</orgName>
+                    <orgName type="crossref" subtype="corporate" source="DNB">Ehemaliges Zisterzienserinnen-Kloster Marienhausen</orgName>
                     <location source="http://klosterdatenbank.germania-sacra.de/gsn/3804">
                         <geo>49.996022,7.895565</geo>
                     </location>
                     <note>Co-ordinates from Germania Sacra</note>
                     <note type="links">
                         <list type="links">
-                            <item><ref target="http://klosterdatenbank.germania-sacra.de/gsn/3804"><title>Germania Sacra</title></ref></item>
+                            <item>
+                                <ref target="http://klosterdatenbank.germania-sacra.de/gsn/3804">
+                                    <title>Germania Sacra</title>
+                                </ref>
+                            </item>
                             <item>
                                 <ref target="http://d-nb.info/gnd/1033492574">
                                     <title>GND</title>
@@ -19875,7 +20367,7 @@
                             </item>
                         </list>
                     </note>
-                </org> 
+                </org>
                 
                 <org xml:id="org_143763943">
                     <orgName type="display" source="bodl">Lorsch, <affiliation>Benedictine</affiliation> (later Cistercian and Premonastratensian) abbey</orgName>
@@ -19883,23 +20375,34 @@
                     <orgName type="variant" subtype="corporate" source="LC">Kloster Lorsch</orgName>
                     <orgName type="variant" subtype="corporate" source="DNB">Abbatia Lorsch</orgName>
                     <orgName type="variant" subtype="corporate" source="DNB">Abtei Lorsch</orgName>
-                    <orgName type="variant" subtype="corporate" source="DNB">Benediktinerabtei,
-                        Lorsch</orgName>
-                    <orgName type="variant" subtype="corporate" source="DNB">Benediktinerkloster
-                        Lorsch</orgName>
+                    <orgName type="variant" subtype="corporate" source="DNB">Benediktinerabtei, Lorsch</orgName>
+                    <orgName type="variant" subtype="corporate" source="DNB">Benediktinerkloster Lorsch</orgName>
                     <orgName type="variant" subtype="corporate" source="DNB">Reichsabtei Lorsch</orgName>
                     <orgName type="variant" source="LC">Kloster Lorsch</orgName>
-                    <orgName type="variant" source="http://klosterdatenbank.germania-sacra.de/gsn/30243">Benediktinerkloster Altenmünster, Lorsch</orgName>
-                    <orgName type="variant" source="http://klosterdatenbank.germania-sacra.de/gsn/30244">Benediktinerkloster, später Prämonstratenserstift Lorsch</orgName>
+                    <orgName type="variant" source="http://klosterdatenbank.germania-sacra.de/gsn/30243" >Benediktinerkloster Altenmünster, Lorsch</orgName>
+                    <orgName type="variant" source="http://klosterdatenbank.germania-sacra.de/gsn/30244" >Benediktinerkloster, später Prämonstratenserstift Lorsch</orgName>
                     <location source="http://klosterdatenbank.germania-sacra.de/gsn/30244">
                         <geo>49.65364153,8.569858137</geo>
                     </location>
                     <note>Co-ordinates from Germania Sacra</note>
                     <note type="links">
                         <list type="links">
-                            <item><ref target="http://klosterdatenbank.germania-sacra.de/gsn/30243"><title>Germania Sacra</title><note>(Altenmünster)</note></ref></item>
-                            <item><ref target="http://klosterdatenbank.germania-sacra.de/gsn/30244"><title>Germania Sacra</title></ref></item>
-                            <item><ref target="https://viaf.org/viaf/143763943"><title>VIAF</title></ref></item>
+                            <item>
+                                <ref target="http://klosterdatenbank.germania-sacra.de/gsn/30243">
+                                    <title>Germania Sacra</title>
+                                    <note>(Altenmünster)</note>
+                                </ref>
+                            </item>
+                            <item>
+                                <ref target="http://klosterdatenbank.germania-sacra.de/gsn/30244">
+                                    <title>Germania Sacra</title>
+                                </ref>
+                            </item>
+                            <item>
+                                <ref target="https://viaf.org/viaf/143763943">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
                             <item>
                                 <ref target="http://id.loc.gov/authorities/names/n85227962">
                                     <title>LC</title>
@@ -19925,6 +20428,11 @@
                                     <title>GND</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000106981127">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -19932,25 +20440,23 @@
                 <org xml:id="org_240455434">
                     <orgName type="display" source="bodl">Mödingen, <affiliation>Dominican nunnery</affiliation> of Maria Medingen</orgName>
                     <!-- record originally created from https://viaf.org/viaf/240455434/viaf.xml at 2019-03-13 15:00:05.910094 -->
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Maria Himmelfahrt,
-                        Mödingen</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Klosterkirche Maria Medingen,
-                        Mödingen</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Klosterkirche Mödingen,
-                        Mödingen</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Maria Medingen,
-                        Mödingen</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Maria Mödingen,
-                        Mödingen</orgName>
-                    <orgName type="variant" subtype="unknownOrder" source="DNB">Maria-Medingen,
-                        Mödingen</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Maria Himmelfahrt, Mödingen</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Klosterkirche Maria Medingen, Mödingen</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Klosterkirche Mödingen, Mödingen</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Maria Medingen, Mödingen</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Maria Mödingen, Mödingen</orgName>
+                    <orgName type="variant" subtype="unknownOrder" source="DNB">Maria-Medingen, Mödingen</orgName>
                     <location source="http://klosterdatenbank.germania-sacra.de/gsn/60239">
                         <geo>48.6317,10.4364</geo>
                     </location>
                     <note>Co-ordinates from Germania Sacra</note>
                     <note type="links">
                         <list type="links">
-                            <item><ref target="http://klosterdatenbank.germania-sacra.de/gsn/60239"><title>Germania Sacra</title></ref></item>
+                            <item>
+                                <ref target="http://klosterdatenbank.germania-sacra.de/gsn/60239">
+                                    <title>Germania Sacra</title>
+                                </ref>
+                            </item>
                             <item>
                                 <ref target="http://d-nb.info/gnd/4279596-5">
                                     <title>GND</title>
@@ -19969,9 +20475,7 @@
                         </list>
                     </note>
                 </org>
-                
                 <!-- new -->
-                
                 <org xml:id="org_198876802">
                     <orgName type="display" source="bodl">Witham, Somerset, <affiliation>Carthusian</affiliation> abbey</orgName>
                     <location>
@@ -19985,12 +20489,17 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/198876802">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
                 <org xml:id="org_23151110643437060950">
-                    <orgName type="display" source="bodl">Newark [in Send with Ripley, Surrey], <affiliation>Augustinian</affiliation> priory</orgName>    
+                    <orgName type="display" source="bodl">Newark [in Send with Ripley, Surrey], <affiliation>Augustinian</affiliation> priory</orgName>
                     <location source="https://www.wikidata.org/wiki/Q7016731">
                         <geo>51.3089,-0.5068</geo>
                     </location>
@@ -20002,35 +20511,155 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/nb2017023198">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/23151110643437060950">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
                 
                 <org xml:id="org_220044785">
+<!-- ***** Old VIAF ID now redirects to 239003182 ***** -->
                     <orgName type="display" source="bodl">Rouen, cathedral</orgName>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/n85279743">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/239003182">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q476516">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
                 
                 <org xml:id="org_155945511">
                     <orgName type="display" source="bodl">Würzburg, University Library (Universitätsbibliothek)</orgName>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000121914029">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/n81022725">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/155945511">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://catalogue.bnf.fr/ark:/12148/cb120466878">
+                                    <title>BNF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q1247229">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
-               
+                
                 <org xml:id="org_271051505">
                     <orgName type="display" source="bodl">Ranshofen, <affiliation>Augustinian</affiliation> priory</orgName>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/271051505">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q2348629">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
                 
                 <org xml:id="org_135843477">
                     <orgName type="display" source="bodl">Salzburg, <affiliation>Benedictine</affiliation> abbey of St Peter</orgName>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000122904965">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/n50048723">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/135843477">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q1469125">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
                 
                 <org xml:id="org_152906198">
                     <orgName type="display">Denny Abbey (Cambridgeshire, England)</orgName>
+                    <note type="links">
+                        <list type="links">
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/nr2003040649">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/152906198">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                        </list>
+                    </note>
                 </org>
                 
                 <org xml:id="org_132676429">
                     <orgName type="display" source="bodl">Bridlington, Augustinian priory of St Mary</orgName>
                     <note type="links">
                         <list type="links">
-                            <item><ref target="http://viaf.org/viaf/132676429"><title>VIAF</title></ref></item>
+                            <item>
+                                <ref target="http://viaf.org/viaf/132676429">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://id.loc.gov/authorities/names/n93068449">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -20039,18 +20668,25 @@
                     <orgName type="display" source="bodl">Alzey, Cistercian nunnery of the Holy Spirit and St John</orgName>
                     <note type="links">
                         <list type="links">
-                            <item><ref target="http://viaf.org/viaf/308748070"><title>VIAF</title></ref></item>
-                            <item><ref target="http://klosterdatenbank.germania-sacra.de/gsn/40008"><title>Germania Sacra</title></ref></item>
-                            <item><ref target="http://d-nb.info/gnd/1052125573"><title>GND</title></ref></item>
+                            <item>
+                                <ref target="http://viaf.org/viaf/308748070">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item>
+                                <ref target="http://klosterdatenbank.germania-sacra.de/gsn/40008">
+                                    <title>Germania Sacra</title>
+                                </ref>
+                            </item>
+                            <item>
+                                <ref target="http://d-nb.info/gnd/1052125573">
+                                    <title>GND</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
-                
-                
-                
                 <!-- the following 'VIAF' entries are problematic (e.g. contain incorrect merges) and should not be altered or (yet) given VIAF refs: -->
-               
-                
                 <org xml:id="org_268217466">
                     <orgName type="display" source="bodl">Doesburg, Holland, <affiliation>Brothers of the Common Life</affiliation> (Domus Clericorum)</orgName>
                     <note type="links">
@@ -20058,6 +20694,16 @@
                             <item>
                                 <ref target="http://d-nb.info/gnd/1705105-8">
                                     <title>GND</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/268217466">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q42346432">
+                                    <title>Wikidata</title>
                                 </ref>
                             </item>
                         </list>
@@ -20069,9 +20715,17 @@
                     <orgName type="variant" source="LC">Saint-Pierre de Maguelone</orgName>
                     <note type="links">
                         <list type="links">
-                            <item><ref target="https://id.loc.gov/authorities/names/n2004007799"><title>LC</title></ref></item>
-                            <item><ref target="https://viaf.org/viaf/124309014"><title>VIAF</title></ref></item>
-                    </list>
+                            <item>
+                                <ref target="https://id.loc.gov/authorities/names/n2004007799">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item>
+                                <ref target="https://viaf.org/viaf/124309014">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                        </list>
                     </note>
                 </org>
                 
@@ -20085,38 +20739,77 @@
                     <orgName type="variant" source="LC">Abbaye cardinale de la Trinité de Vendôme (Vendôme, France)</orgName>
                     <note type="links">
                         <list type="links">
-                            <item><ref target="http://id.loc.gov/authorities/names/n81024723"><title>LC</title></ref></item>
-                            <item><ref target="https://viaf.org/viaf/146618633"><title>VIAF</title></ref></item>
-                    </list>
+                            <item>
+                                <ref target="http://id.loc.gov/authorities/names/n81024723">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item>
+                                <ref target="https://viaf.org/viaf/146618633">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000123424015">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://catalogue.bnf.fr/ark:/12148/cb144831618">
+                                    <title>BNF</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://www.wikidata.org/wiki/Q306128">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
+                        </list>
                     </note>
                 </org>
-                
                 
                 <org xml:id="org_139909575">
                     <orgName type="display" source="bodl">Gosnay, Carthusian nunnery of Mont-Sainte-Marie</orgName>
                     <orgName type="variant" source="LC">Chartreuse de Gosnay (Gosnay, France)</orgName>
-                    
                     <note type="links">
                         <list type="links">
                             <item>
                                 <ref target="http://d-nb.info/gnd/1086922336">
-                                    <title>GND</title></ref></item>
+                                    <title>GND</title>
+                                </ref>
+                            </item>
+                            <item>
+                                <ref target="http://id.loc.gov/authorities/names/no2004122519">
+                                    <title>LC</title>
+                                </ref>
+                            </item>
+                            <item>
+                                <ref target="http://viaf.org/viaf/797145857991523021596">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
+                            <item>
+                                <ref target="http://www.wikidata.org/entity/Q2961293">
+                                    <title>Wikidata</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="http://www.isni.org/isni/0000000106658936">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
+                            <item source="#VL1">
+                                <ref target="https://viaf.org/viaf/139909575">
+                                    <title>VIAF</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
-                    <note type="links">
-                        <list type="links">
-                            <item><ref target="http://id.loc.gov/authorities/names/no2004122519"><title>LC</title></ref></item> <item><ref target="http://viaf.org/viaf/797145857991523021596"><title>VIAF</title></ref></item>
-                        <item>
-                                <ref target="http://www.wikidata.org/entity/Q2961293">
-                                    <title>Wikidata</title></ref></item>
-                        </list> 
-                    </note>
                 </org>
-                
-                
-                
             </listOrg>
-            
+
+
+
             <listOrg type="local">
                 
                 <org xml:id="org_124557775">


### PR DESCRIPTION
As ISNI contains names of organizations as well as people, I thought it was worth running the same script as used in #332, to lookup entries with VIAF IDs in the VIAF API, but on the `org` elements in the places.xml file.

The result is:

- 148 organizations have had at least one link added, of which 27 had no links before
- 251 links added, of which:
   -  88 are ISNI
   -  66 are Wikidata
   -  42 are VIAF
   -  39 are LC
   -  16 are BNF

VIAF did return GND links, but random sampling indicated most of them didn't resolve, so I removed them.

This means, out of 528 total organizations:

- 360 have VIAF
- 273 have LC
- 235 have Wikidata
- 176 have GND
- 133 are local only
- 122 have BNF
- 88 have ISNI