### PR TITLE
ISNI Lookup August 2020

### DIFF
--- a/places.xml
+++ b/places.xml
@@ -13,6 +13,7 @@
             </publicationStmt>
             <notesStmt>
                 <note xml:id="VL1">Elements with source attributes of "#VL1" were retrieved from VIAF by lookup-viaf-info.xsl on 2020-06-30</note>
+                <note xml:id="IL1">Elements with source attributes of "#IL1" were retrieved from ISNI and added by add-from-isni.xsl on 2020-08-18</note>
             </notesStmt>
             <sourceDesc>
                 <p>Information about the source</p>
@@ -9311,6 +9312,7 @@
                                     <title>BNF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 313181544 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -9330,6 +9332,7 @@
                                     <title>Germania Sacra</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 000000009147691X-->
                         </list>
                     </note>
                 </org>
@@ -9353,6 +9356,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000106305137-->
                         </list>
                     </note>
                 </org>
@@ -9377,6 +9381,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 17149233273676510291 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -9395,6 +9400,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 000000009990646X-->
                         </list>
                     </note>
                 </org>
@@ -9478,6 +9484,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 272891581 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -9496,6 +9503,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 146831170 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -9519,6 +9527,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000087356739-->
                         </list>
                     </note>
                 </org>
@@ -9542,6 +9551,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000094904852-->
                         </list>
                     </note>
                 </org>
@@ -9593,6 +9603,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 000000012194480X-->
                         </list>
                     </note>
                 </org>
@@ -9653,6 +9664,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 295127444 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -9670,6 +9682,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 310514352 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -9729,6 +9742,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000086169587-->
                         </list>
                     </note>
                 </org>
@@ -9786,6 +9800,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000106403837-->
                         </list>
                     </note>
                 </org>
@@ -9799,6 +9814,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 246264651 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -9849,6 +9865,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 251338225 on 2020-08-18-->
                         </list>
                         <!--<list type="links">
                                <item><ref target="http://viaf.org/viaf/135337488"><title>VIAF</title></ref></item>
@@ -9942,6 +9959,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000092341435-->
                         </list>
                     </note>
                 </org>
@@ -9969,6 +9987,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 247467479 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -10029,6 +10048,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 241899093 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -10095,6 +10115,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 304919952 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -10154,6 +10175,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000100688659-->
                         </list>
                     </note>
                 </org>
@@ -10178,6 +10200,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 243863172 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -10205,6 +10228,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 49145542365096640921 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -10248,6 +10272,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000090705135-->
                         </list>
                     </note>
                 </org>
@@ -10274,6 +10299,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 147596326 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -10357,6 +10383,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 304912099 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -10404,6 +10431,7 @@
                                     <title>LC</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 123429486 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -10444,6 +10472,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 270753550 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -10479,6 +10508,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 313198488 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -10515,6 +10545,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000087563404-->
                         </list>
                     </note>
                 </org>
@@ -10600,6 +10631,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 217095146 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -10623,6 +10655,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000101585782-->
                         </list>
                     </note>
                 </org>
@@ -10681,6 +10714,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 235558512 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -10705,6 +10739,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 239193232 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -10819,6 +10854,7 @@
                                     <title>BNF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000100184311--><!--Provisional ISNI ID as of 2020-08-18: 0000000099504209-->
                         </list>
                     </note>
                 </org>
@@ -10841,6 +10877,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 292385856 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -10867,6 +10904,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000092035243-->
                         </list>
                     </note>
                 </org>
@@ -10905,6 +10943,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000105637439-->
                         </list>
                     </note>
                 </org>
@@ -10936,6 +10975,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000092258711-->
                         </list>
                     </note>
                 </org>
@@ -11047,6 +11087,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000101634660--><!--No match found in ISNI for VIAF ID 202396473 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -11102,6 +11143,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000093989305-->
                         </list>
                     </note>
                 </org>
@@ -11181,6 +11223,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 313492968 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -11209,6 +11252,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000088962298-->
                         </list>
                     </note>
                 </org>
@@ -11288,6 +11332,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 129279786 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -11366,6 +11411,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 148042626 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -11406,6 +11452,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000122532313-->
                         </list>
                     </note>
                 </org>
@@ -11449,6 +11496,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000123248576--><!--No match found in ISNI for VIAF ID 173026705 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -11478,6 +11526,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000104217555-->
                         </list>
                     </note>
                 </org>
@@ -11499,6 +11548,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 313493631 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -11535,6 +11585,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 205808165 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -11612,6 +11663,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000098121767-->
                         </list>
                     </note>
                 </org>
@@ -11632,6 +11684,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000092084299-->
                         </list>
                     </note>
                 </org>
@@ -11682,6 +11735,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 138242961 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -11720,6 +11774,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 000000009111357X-->
                         </list>
                     </note>
                 </org>
@@ -11740,6 +11795,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 144397095 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -11813,6 +11869,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000087883926-->
                         </list>
                     </note>
                 </org>
@@ -11895,6 +11952,7 @@
                                     <title>BNF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 211447911 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -11924,6 +11982,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 315944440 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -11959,6 +12018,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000092033782-->
                         </list>
                     </note>
                 </org>
@@ -11981,6 +12041,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000086069260-->
                         </list>
                     </note>
                 </org>
@@ -12007,6 +12068,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000099129621-->
                         </list>
                     </note>
                 </org>
@@ -12139,6 +12201,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000098958612-->
                         </list>
                     </note>
                 </org>
@@ -12158,6 +12221,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000087357301-->
                         </list>
                     </note>
                 </org>
@@ -12404,6 +12468,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 246265108 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -12446,6 +12511,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000086646494-->
                         </list>
                     </note>
                 </org>
@@ -12601,6 +12667,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000090034626-->
                         </list>
                     </note>
                 </org>
@@ -12616,6 +12683,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000094363590-->
                         </list>
                     </note>
                 </org>
@@ -12632,6 +12700,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 126047237 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -12677,6 +12746,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 415145858126223022295 on 2020-08-18--><!--No match found in ISNI for VIAF ID 213945938 on 2020-08-18--><!--Provisional ISNI ID as of 2020-08-18: 0000000096113683-->
                         </list>
                     </note>
                 </org>
@@ -12706,6 +12776,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000122178422-->
                         </list>
                     </note>
                 </org>
@@ -12735,6 +12806,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000107199495-->
                         </list>
                     </note>
                 </org>
@@ -12767,6 +12839,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 245287151 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -12827,6 +12900,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000088680450-->
                         </list>
                     </note>
                 </org>
@@ -12849,6 +12923,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000098402235-->
                         </list>
                     </note>
                 </org>
@@ -12873,6 +12948,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 243886719 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -12898,6 +12974,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 240542197 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -12924,6 +13001,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 245037741 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -12952,6 +13030,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000123622628-->
                         </list>
                     </note>
                 </org>
@@ -13015,6 +13094,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000123549379-->
                         </list>
                     </note>
                 </org>
@@ -13090,6 +13170,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 126666939 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -13159,6 +13240,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 241197056 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -13195,6 +13277,7 @@
                                     <title>BNF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 000000010690544X-->
                         </list>
                     </note>
                 </org>
@@ -13224,6 +13307,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000085582679-->
                         </list>
                     </note>
                 </org>
@@ -13260,6 +13344,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 000000012034831X-->
                         </list>
                     </note>
                 </org>
@@ -13286,6 +13371,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000085277746-->
                         </list>
                     </note>
                 </org>
@@ -13307,6 +13393,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 000000008871135X-->
                         </list>
                     </note>
                 </org>
@@ -13359,6 +13446,7 @@
                                     <title>Germania Sacra</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000092140377-->
                         </list>
                     </note>
                 </org>
@@ -13491,6 +13579,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000115445203-->
                         </list>
                     </note>
                 </org>
@@ -13518,6 +13607,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 172374812 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -13539,6 +13629,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 232929480 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -13570,6 +13661,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 249304112 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -13601,6 +13693,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000090322150-->
                         </list>
                     </note>
                 </org>
@@ -13656,6 +13749,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 247412105 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -13685,6 +13779,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 169654564 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -13705,6 +13800,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000103653064-->
                         </list>
                     </note>
                 </org>
@@ -13735,6 +13831,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 145941484 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -13755,6 +13852,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 316390117 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -13778,6 +13876,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 153848390 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -13798,6 +13897,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 238824653 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -13817,6 +13917,7 @@
                                     <title>LC</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000096868445-->
                         </list>
                         <list type="links">
                             <item>
@@ -13829,6 +13930,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000096868445-->
                         </list>
                     </note>
                 </org>
@@ -13863,6 +13965,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 315687992 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -13883,6 +13986,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 315686151 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -13921,6 +14025,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 168089114 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -13949,6 +14054,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 128793507 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -13979,6 +14085,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 313533333 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -14000,6 +14107,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000101296702-->
                         </list>
                     </note>
                 </org>
@@ -14020,6 +14128,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 310513586 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -14044,6 +14153,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 152531224 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -14072,6 +14182,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000106350480-->
                         </list>
                     </note>
                 </org>
@@ -14148,6 +14259,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000102982261-->
                         </list>
                     </note>
                 </org>
@@ -14173,6 +14285,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000095512383-->
                         </list>
                     </note>
                 </org>
@@ -14203,6 +14316,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000092802297-->
                         </list>
                     </note>
                 </org>
@@ -14243,6 +14357,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000092152802-->
                         </list>
                     </note>
                 </org>
@@ -14278,6 +14393,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000123648457--><!--No match found in ISNI for VIAF ID 156148995743759750417 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -14296,6 +14412,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000090101577-->
                         </list>
                     </note>
                 </org>
@@ -14329,6 +14446,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000088623982-->
                         </list>
                     </note>
                 </org>
@@ -14356,6 +14474,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 139688379 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -14389,6 +14508,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000121111728-->
                         </list>
                     </note>
                 </org>
@@ -14582,6 +14702,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 371144782732650928555 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -14610,6 +14731,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000088191585-->
                         </list>
                     </note>
                 </org>
@@ -14662,6 +14784,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000085514916-->
                         </list>
                     </note>
                 </org>
@@ -14723,6 +14846,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000105798291-->
                         </list>
                     </note>
                     <bibl>Knowles &amp; Hadcock, pp. 112, 116</bibl>
@@ -14790,6 +14914,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000122371361-->
                         </list>
                     </note>
                 </org>
@@ -14809,6 +14934,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 145707239 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -14837,6 +14963,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 140811075 on 2020-08-18-->
                         </list>
                     </note>
                     <note>Coordinates for the settlement of Trois-Fontaines, from the <ref
@@ -14866,6 +14993,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 294361980 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -14894,6 +15022,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000086620964-->
                         </list>
                     </note>
                 </org>
@@ -14969,6 +15098,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000091809403-->
                         </list>
                     </note>
                 </org>
@@ -14989,6 +15119,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 2142145857037522921207 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -15013,6 +15144,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000090867249-->
                         </list>
                     </note>
                 </org>
@@ -15036,6 +15168,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000100413065-->
                         </list>
                     </note>
                 </org>
@@ -15161,6 +15294,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000100221039-->
                         </list>
                     </note>
                 </org>
@@ -15190,6 +15324,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000112558456-->
                         </list>
                     </note>
                 </org>
@@ -15237,6 +15372,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000105893109-->
                         </list>
                     </note>
                 </org>
@@ -15294,6 +15430,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000085705202-->
                         </list>
                     </note>
                 </org>
@@ -15312,6 +15449,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 260127654 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -15348,6 +15486,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000115231942-->
                         </list>
                     </note>
                 </org>
@@ -15404,6 +15543,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 442146997389818892504 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -15434,6 +15574,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 269197839 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -15457,6 +15598,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000086230595-->
                         </list>
                     </note>
                 </org>
@@ -15562,6 +15704,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000105226277-->
                         </list>
                     </note>
                 </org>
@@ -15580,6 +15723,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000092081709-->
                         </list>
                     </note>
                 </org>
@@ -15608,6 +15752,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 313533276 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -15636,6 +15781,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000112398085-->
                         </list>
                     </note>
                 </org>
@@ -15666,6 +15812,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000123536244-->
                         </list>
                     </note>
                 </org>
@@ -15696,6 +15843,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 244595494 on 2020-08-18-->
                         </list>
                     </note>
                     <note type="source">Co-ordinates (for the island of Reichenau) from the <ref
@@ -15804,6 +15952,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 27148207842000341517 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -15835,6 +15984,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 000000010222249X-->
                         </list>
                     </note>
                 </org>
@@ -15853,6 +16003,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000122711055-->
                         </list>
                     </note>
                 </org>
@@ -15872,6 +16023,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 313222993 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -15945,6 +16097,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 135326103 on 2020-08-18-->
                         </list>
                     </note>
                     <!-- check the date? -->
@@ -16005,6 +16158,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 146685036 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -16037,6 +16191,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 132688628 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -16063,6 +16218,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 311465280 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -16096,6 +16252,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000097600854-->
                         </list>
                     </note>
                 </org>
@@ -16114,6 +16271,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 154868239 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -16132,6 +16290,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000087592061-->
                         </list>
                     </note>
                 </org>
@@ -16165,6 +16324,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 305126922 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -16207,6 +16367,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000102255558-->
                         </list>
                     </note>
                 </org>
@@ -16310,6 +16471,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000098227123-->
                         </list>
                     </note>
                 </org>
@@ -16328,6 +16490,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 145675476 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -16349,6 +16512,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 234338663 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -16382,6 +16546,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000092758636-->
                         </list>
                     </note>
                 </org>
@@ -16410,6 +16575,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000112766482-->
                         </list>
                     </note>
                 </org>
@@ -16433,6 +16599,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000085976344-->
                         </list>
                     </note>
                 </org>
@@ -16453,6 +16620,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000101843876-->
                         </list>
                     </note>
                 </org>
@@ -16481,6 +16649,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000096397268-->
                         </list>
                     </note>
                 </org>
@@ -16524,6 +16693,11 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <item source="#IL1">
+                                <ref target="http://www.isni.org/isni/0000000110931720">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -16542,6 +16716,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 000000008737729X-->
                         </list>
                     </note>
                 </org>
@@ -16623,6 +16798,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 239220402 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -16659,6 +16835,7 @@
                                     <title>LC</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000090603892-->
                         </list>
                     </note>
                 </org>
@@ -16682,6 +16859,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000094967001-->
                         </list>
                     </note>
                 </org>
@@ -16700,6 +16878,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 119144647640953754712 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -16757,6 +16936,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 242823650 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -16775,6 +16955,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 267912669 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -16798,6 +16979,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 258918407 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -16822,6 +17004,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 248915895 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -16888,6 +17071,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000090842033-->
                         </list>
                     </note>
                 </org>
@@ -16906,6 +17090,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 175175470 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -16924,6 +17109,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000104345645-->
                         </list>
                     </note>
                 </org>
@@ -16956,6 +17142,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000093892941-->
                         </list>
                     </note>
                 </org>
@@ -17078,6 +17265,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000104451632-->
                         </list>
                     </note>
                 </org>
@@ -17096,6 +17284,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000106518706-->
                         </list>
                     </note>
                 </org>
@@ -17166,6 +17355,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 244228863 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -17194,6 +17384,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 141420298 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -17286,6 +17477,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000091361055-->
                         </list>
                     </note>
                 </org>
@@ -17308,6 +17500,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000095053359-->
                         </list>
                     </note>
                 </org>
@@ -17339,6 +17532,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 267407979 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -17369,6 +17563,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 150071244 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -17405,6 +17600,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000105222495-->
                         </list>
                     </note>
                 </org>
@@ -17487,6 +17683,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 308185589 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -17532,6 +17729,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 248254900 on 2020-08-18--><!--Provisional ISNI ID as of 2020-08-18: 0000000097762415-->
                         </list>
                     </note>
                 </org>
@@ -17594,6 +17792,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 134239581 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -17614,6 +17813,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 240554317 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -17657,6 +17857,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000098746337-->
                         </list>
                     </note>
                 </org>
@@ -17720,6 +17921,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000106196487-->
                         </list>
                     </note>
                 </org>
@@ -17772,6 +17974,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000095557709-->
                         </list>
                     </note>
                 </org>
@@ -17796,6 +17999,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 126334887 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -17825,6 +18029,7 @@
                                     <title>LC</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 146323850 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -17851,6 +18056,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000102448229-->
                         </list>
                     </note>
                 </org>
@@ -17874,6 +18080,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 235700069 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -17915,6 +18122,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000104535764-->
                         </list>
                     </note>
                 </org>
@@ -17943,6 +18151,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000097695582-->
                         </list>
                     </note>
                 </org>
@@ -17976,6 +18185,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 242730887 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -18085,6 +18295,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 160939265 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -18107,6 +18318,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000086772175-->
                         </list>
                     </note>
                 </org>
@@ -18144,6 +18356,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 150190778 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -18273,6 +18486,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 175619750 on 2020-08-18--><!--Provisional ISNI ID as of 2020-08-18: 0000000086652069-->
                         </list>
                     </note>
                 </org>
@@ -18294,6 +18508,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 295377124 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -18316,6 +18531,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000099537844-->
                         </list>
                     </note>
                 </org>
@@ -18345,6 +18561,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 263208235 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -18430,6 +18647,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 295820821 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -18462,6 +18680,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 317069910 on 2020-08-18-->
                         </list>
                     </note>
                     <bibl>Cottineau II, col. 3062</bibl>
@@ -18542,6 +18761,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 145597689 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -18586,6 +18806,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000123534134-->
                         </list>
                     </note>
                 </org>
@@ -18618,6 +18839,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 150552322 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -18741,6 +18963,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000086396157-->
                         </list>
                     </note>
                 </org>
@@ -18817,6 +19040,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 240561051 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -18848,6 +19072,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000085309576-->
                         </list>
                     </note>
                 </org>
@@ -18889,6 +19114,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 212968081 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -18917,6 +19143,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 141000452 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -18933,6 +19160,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 254121248 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -18949,6 +19177,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 254633607 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -18990,6 +19219,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000106884570-->
                         </list>
                     </note>
                 </org>
@@ -19016,6 +19246,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 266189883 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -19049,6 +19280,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 157389164 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -19069,6 +19301,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 250806462 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -19090,6 +19323,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 223669083 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -19117,6 +19351,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 254016085 on 2020-08-18-->
                         </list>
                     </note>
                     <!-- NB several apparent entries in VIAF not merged -->
@@ -19163,6 +19398,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 208896312 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -19238,6 +19474,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000105640216-->
                         </list>
                     </note>
                 </org>
@@ -19312,6 +19549,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 310746171 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -19376,6 +19614,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 128317513 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -19396,6 +19635,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 234315879 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -19417,6 +19657,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000098288487-->
                         </list>
                     </note>
                 </org>
@@ -19437,6 +19678,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 243910020 on 2020-08-18-->
                         </list>
                     </note>
                     <!-- not in cottineau -->
@@ -19486,6 +19728,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 138342928 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -19507,6 +19750,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 243166021 on 2020-08-18-->
                         </list>
                     </note>
                     <bibl>Knowles &amp; Hadcock, pp. 419, 443</bibl>
@@ -19528,6 +19772,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 1115145857069622921436 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -19559,6 +19804,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 135655543 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -19588,6 +19834,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 266852074 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -19628,6 +19875,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 173376610 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -19652,6 +19900,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 240145542525596640761 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -19704,6 +19953,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 138512183 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -19734,6 +19984,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 246948936 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -19755,6 +20006,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000104917076-->
                         </list>
                     </note>
                 </org>
@@ -19808,6 +20060,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000086916044-->
                         </list>
                     </note>
                 </org>
@@ -19838,6 +20091,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 123598658 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -19917,6 +20171,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 312805416 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -19946,6 +20201,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 148097195 on 2020-08-18-->
                         </list>
                     </note>
                     <note>Co-ordinates from Wikipedia.</note>
@@ -19987,6 +20243,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 245815193 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -20040,6 +20297,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000087375446-->
                         </list>
                     </note>
                 </org>
@@ -20064,6 +20322,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 139637930 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -20101,6 +20360,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000094993306-->
                         </list>
                     </note>
                 </org>
@@ -20139,6 +20399,11 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <item source="#IL1">
+                                <ref target="http://www.isni.org/isni/0000000121963840">
+                                    <title>ISNI</title>
+                                </ref>
+                            </item>
                         </list>
                     </note>
                 </org>
@@ -20173,6 +20438,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 264519246 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -20215,6 +20481,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000092779381-->
                         </list>
                     </note>
                 </org>
@@ -20261,6 +20528,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 211935376 on 2020-08-18--><!--Provisional ISNI ID as of 2020-08-18: 000000010585867X-->
                         </list>
                     </note>
                 </org>
@@ -20291,6 +20559,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 000000008054354X-->
                         </list>
                     </note>
                 </org>
@@ -20328,6 +20597,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 237710601 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -20360,6 +20630,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000105366763-->
                         </list>
                     </note>
                 </org>
@@ -20390,6 +20661,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 298413710 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -20497,6 +20769,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 240455434 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -20519,6 +20792,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 198876802 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -20546,6 +20820,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 23151110643437060950 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -20570,6 +20845,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 239003182 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -20621,6 +20897,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 271051505 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -20667,6 +20944,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 000000010253141X-->
                         </list>
                     </note>
                 </org>
@@ -20685,6 +20963,7 @@
                                     <title>LC</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000090773197-->
                         </list>
                     </note>
                 </org>
@@ -20708,6 +20987,7 @@
                                     <title>GND</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 308748070 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -20731,6 +21011,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
+                            <!--No match found in ISNI for VIAF ID 268217466 on 2020-08-18-->
                         </list>
                     </note>
                 </org>
@@ -20750,6 +21031,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
+                            <!--Provisional ISNI ID as of 2020-08-18: 0000000085925045-->
                         </list>
                     </note>
                 </org>

--- a/processing/batch_conversion/add-from-isni.xsl
+++ b/processing/batch_conversion/add-from-isni.xsl
@@ -28,7 +28,7 @@
                 <xsl:map-entry key="$viafid">
                     <xsl:choose>
                         <xsl:when test="$isnidoc/ZiNG:numberOfRecords[1]/text() = '0'">
-                            <xsl:comment> No match found in ISNI for VIAF ID <xsl:value-of select="$viafid"/> on <xsl:value-of select="$today"/> </xsl:comment>
+                            <xsl:comment>No match found in ISNI for VIAF ID <xsl:value-of select="$viafid"/> on <xsl:value-of select="$today"/> </xsl:comment>
                         </xsl:when>
                         <xsl:when test="$isnidoc/ZiNG:numberOfRecords[1]/text() = '1'">
                             <xsl:variable name="isniiddatafield" as="element(marc:datafield)*" select="$isnidoc//marc:collection/marc:record/marc:datafield[@tag='003E']"/>

--- a/processing/batch_conversion/add-from-isni.xsl
+++ b/processing/batch_conversion/add-from-isni.xsl
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+    xmlns:tei="http://www.tei-c.org/ns/1.0"
+    xmlns:ZiNG="urn:z3950:ZiNG:Service"
+    xmlns:marc="http://www.loc.gov/MARC21/slim"
+    xmlns="http://www.tei-c.org/ns/1.0"
+    xpath-default-namespace="http://www.tei-c.org/ns/1.0"
+    exclude-result-prefixes="xs map tei ZiNG marc"
+    version="3.0">
+    
+    <xsl:output method="xml" indent="yes" encoding="UTF-8"/>
+    
+    <!-- This adds ISNIs, or comments when a record exists in the ISNI database but is not yet approved, from the results of 
+         calls to the ISNI API saved locally in a temporary folder (done separately via curl as username/password is required) -->
+    
+    <xsl:variable name="newline" as="xs:string" select="'&#10;'"/>
+    <xsl:variable name="today" as="xs:string" select="format-date(current-date(), '[Y0001]-[M01]-[D01]')"/>
+    <xsl:variable name="sourcenoteid" as="xs:string" select="concat('IL', count(/TEI/teiHeader/fileDesc/notesStmt[1]/note[starts-with(@xml:id, 'IL')])+1)"/>
+    <xsl:variable name="isniapiresults" select="collection('file:///tmp/isni/output/?select=*.xml')/ZiNG:searchRetrieveResponse"/>
+    <xsl:variable name="viaf2isni" as="map(xs:string, node())">
+        <xsl:map>
+            <xsl:for-each select="$isniapiresults">
+                <xsl:variable name="isnidoc" select="."/>
+                <xsl:variable name="viafid" as="xs:string*" select="tokenize($isnidoc/ZiNG:echoedRequest[1]/*[local-name()='query'][1]/text()[1], '%..')[string-length(.) gt 0][position() eq last()]"/>
+                <xsl:if test="count($viafid) ne 1"><xsl:message terminate="yes">Cannot find VIAF ID in <xsl:value-of select="$isnidoc/ZiNG:echoedRequest[1]"/></xsl:message></xsl:if>
+                <xsl:map-entry key="$viafid">
+                    <xsl:choose>
+                        <xsl:when test="$isnidoc/ZiNG:numberOfRecords[1]/text() = '0'">
+                            <xsl:comment> No match found in ISNI for VIAF ID <xsl:value-of select="$viafid"/> on <xsl:value-of select="$today"/> </xsl:comment>
+                        </xsl:when>
+                        <xsl:when test="$isnidoc/ZiNG:numberOfRecords[1]/text() = '1'">
+                            <xsl:variable name="isniiddatafield" as="element(marc:datafield)*" select="$isnidoc//marc:collection/marc:record/marc:datafield[@tag='003E']"/>
+                            <xsl:choose>
+                                <xsl:when test="$isniiddatafield/marc:subfield[@code='a']/text()[1] = 'assigned'">
+                                    <item source="#{ $sourcenoteid }">
+                                        <ref target="http://www.isni.org/isni/{ $isniiddatafield/marc:subfield[@code='0']/text()[1] }">
+                                            <title>ISNI</title>
+                                        </ref>
+                                    </item>
+                                </xsl:when>
+                                <xsl:when test="$isniiddatafield/marc:subfield[@code='a']/text()[1] = 'provisional'">
+                                    <xsl:comment>Provisional ISNI ID as of <xsl:value-of select="$today"/>: <xsl:value-of select="$isniiddatafield/marc:subfield[@code='0']/text()[1]"/></xsl:comment>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:comment>Unexpected ISNI API response for <xsl:value-of select="$viafid"/></xsl:comment>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:comment>Multiple matches found in ISNI on <xsl:value-of select="$today"/></xsl:comment>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:map-entry>
+            </xsl:for-each>
+        </xsl:map>
+    </xsl:variable>
+    
+    <!-- Root template -->
+    
+    <xsl:template match="/">
+        <xsl:apply-templates/>
+    </xsl:template>
+    
+    <!-- Keep header PIs on separate lines -->
+    
+    <xsl:template match="processing-instruction('xml-model')">
+        <xsl:if test="not(preceding-sibling::processing-instruction('xml-model'))"><xsl:value-of select="$newline"/></xsl:if>
+        <xsl:copy/>
+        <xsl:value-of select="$newline"/>
+    </xsl:template>
+    
+    <!-- Add note to header to serve as target for source attributes in links added below -->
+    
+    <xsl:template match="/TEI/teiHeader/fileDesc/notesStmt[1]">
+        <xsl:copy>
+            <xsl:copy-of select="@*"/>
+            <xsl:apply-templates/>
+            <note xml:id="{ $sourcenoteid }">Elements with source attributes of "#<xsl:value-of select="$sourcenoteid"/>" were retrieved from ISNI and added by add-from-isni.xsl on <xsl:value-of select="$today"/></note>
+        </xsl:copy>
+    </xsl:template>
+    
+    <xsl:template match="/TEI/text/body/listPerson/person[@xml:id]/note/list">
+        <xsl:variable name="viafurls" as="xs:string*" select="item/ref[title/text()[1] = 'VIAF']/@target"/>
+        <xsl:variable name="viafids" as="xs:string*" select="for $url in $viafurls return tokenize($url, '/')[string-length(.) gt 0][position() eq last()]"/>
+        <xsl:copy>
+            <xsl:copy-of select="@*"/>
+            <xsl:apply-templates/>
+            <xsl:for-each select="$viafids">
+                <xsl:if test="exists($viaf2isni(.))">
+                    <xsl:copy-of select="$viaf2isni(.)"/>
+                </xsl:if>
+            </xsl:for-each>
+        </xsl:copy>
+    </xsl:template>
+    
+    <!-- Default templates -->
+    
+    <xsl:template match="*">
+        <xsl:copy>
+            <xsl:copy-of select="@*"/>
+            <xsl:apply-templates/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <xsl:template match="text()|comment()|processing-instruction()">
+        <xsl:copy/>
+    </xsl:template>
+    
+</xsl:stylesheet>

--- a/processing/batch_conversion/add-from-isni.xsl
+++ b/processing/batch_conversion/add-from-isni.xsl
@@ -10,10 +10,14 @@
     exclude-result-prefixes="xs map tei ZiNG marc"
     version="3.0">
     
-    <xsl:output method="xml" indent="yes" encoding="UTF-8"/>
+    <xsl:output method="xml" indent="no" encoding="UTF-8"/>
     
     <!-- This adds ISNIs, or comments when a record exists in the ISNI database but is not yet approved, from the results of 
          calls to the ISNI API saved locally in a temporary folder (done separately via curl as username/password is required) -->
+    
+    <!-- Queries to send to ISNI API can be generated with this XPath:
+         /TEI/text/body/*/(person|org)[not(note/list/item/ref[contains(@target, 'isni.org')])]/note/list/item/ref[contains(@target, 'viaf.org')]/@target/concat('pica.cn+%3D+%22VIAF%2B', substring-after(., '/viaf/'), '%22')
+    -->
     
     <xsl:variable name="newline" as="xs:string" select="'&#10;'"/>
     <xsl:variable name="today" as="xs:string" select="format-date(current-date(), '[Y0001]-[M01]-[D01]')"/>
@@ -81,7 +85,9 @@
         </xsl:copy>
     </xsl:template>
     
-    <xsl:template match="/TEI/text/body/listPerson/person[@xml:id]/note/list">
+    <!-- Add links or comments to authority entries -->
+    
+    <xsl:template match="/TEI/text/body/(listPerson|listOrg)/(person|org)[@xml:id]/note/list">
         <xsl:variable name="viafurls" as="xs:string*" select="item/ref[title/text()[1] = 'VIAF']/@target"/>
         <xsl:variable name="viafids" as="xs:string*" select="for $url in $viafurls return tokenize($url, '/')[string-length(.) gt 0][position() eq last()]"/>
         <xsl:copy>


### PR DESCRIPTION
I queried the ISNI API for all the VIAF IDs of people for which we have a VIAF ID (some more than one) but not an ISNI. The results are:

- 72 new links added to ISNIs which have approved status
- 646 provisional ISNI IDs found, added as comments
- 152 VIAF ID not matched in ISNI database

The provisional ones cannot be added as links, because they don't work yet (assuming they're eventually approved.)