### PR TITLE
MS. Canon. Misc. 573: New description

### DIFF
--- a/collections/Canon_Misc/MS_Canon_Misc_573.xml
+++ b/collections/Canon_Misc/MS_Canon_Misc_573.xml
@@ -164,8 +164,8 @@
                   </physDesc>
                   <history>
                      <origin>
-                        <origPlace key="place_7006464">Prague</origPlace>
-                        <origDate calendar="Gregorian" when="1385">1384–85</origDate>, as indicated through closing rubrics for each book.</origin>
+                        <origPlace><country key="place_7006470">Bohemia</country>, <settlement key="place_7006464">Prague</settlement></origPlace>
+                        <origDate cert="high" calendar="Gregorian" when="1385">1384–85</origDate>, as indicated through closing rubrics for each book.</origin>
                      <provenance>Canons regular of <orgName key="org_238824653" role="fmo">Santa Maria della Carità, Venice</orgName>: inscribed, <quote>Iste liber est monasterii sancte Marie de Caritate Venetiarum.</quote> (fol. 162r); <quote>Statio huius libri est in septima sede.</quote> (fol. 163r). Similar inscriptions are also found in MS. Canon. Pat. Lat. 52; MS. Lat. th. d. 28; and Aberdeen, University Library, MS 242.</provenance>
                   </history>
                </msPart>

--- a/collections/Canon_Misc/MS_Canon_Misc_573.xml
+++ b/collections/Canon_Misc/MS_Canon_Misc_573.xml
@@ -8,17 +8,10 @@
             <title>MS. Canon. Misc. 573</title>
             <title type="collection">MSS. Canon. Misc. (Canonici Miscellaneous)</title>
             <respStmt>
-               <resp>Summary description</resp>
-               <persName>Elizabeth Solopova</persName><persName>Matthew Holford</persName>
+               <resp>Description</resp>
+               <persName>Andrew Dunning</persName>
             </respStmt>
          </titleStmt>
-         <editionStmt>
-            <edition>TEI P5</edition>
-            <respStmt>
-               <resp>Conversion to TEI based on earlier work for the ENRICH project (enrich@oucs.ox.ac.uk; http://tei.oucs.ox.ac.uk/ENRICH/)</resp>
-               <persName>Matthew Holford</persName>
-            </respStmt>
-         </editionStmt>
          <publicationStmt>
             <publisher>Special Collections, Bodleian Libraries</publisher>
             <address>
@@ -52,15 +45,31 @@
                   </altIdentifier>
                </msIdentifier>
                <physDesc>
-                  <p n="composite">Composite: two parts</p>
+                  <objectDesc form="codex">
+                     <supportDesc material="mixed">
+                        <support>parchment and paper</support>
+                        <extent>i + 377 + i leaves</extent>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding notBefore="1700" notAfter="1900">
+                        <p>Brown tanned calf; red and gold tooling.<!-- TODO: check --></p>
+                     </binding>
+                  </bindingDesc>
                </physDesc>
-               <history><provenance notBefore="1727" notAfter="1805" resp="#MMM"><persName role="fmo" key="person_2384880">Matteo Luigi Canonici, 1727-1805</persName></provenance><provenance notAfter="1807" resp="#MMM"><persName role="fmo" key="person_446">Giuseppe Canonici , -1807</persName></provenance><acquisition when="1817" resp="#MMM">Purchased by the Bodleian in 1817</acquisition></history><additional>
+               <history>
+                  <provenance notBefore="1727" notAfter="1805" resp="#MMM">
+                     <persName role="fmo" key="person_2384880">Matteo Luigi Canonici, 1727-1805</persName>
+                  </provenance>
+                  <provenance notAfter="1807" resp="#MMM">
+                     <persName role="fmo" key="person_446">Giuseppe Canonici, -1807</persName>
+                  </provenance>
+                  <acquisition when="1817" resp="#MMM">Purchased by the Bodleian in 1817</acquisition>
+               </history>
+               <additional>
                   <adminInfo>
                      <recordHist>
-                        <source><ref target="https://medieval.bodleian.ox.ac.uk/about">Summary description</ref> abbreviated from the Quarto Catalogue (H. O. Coxe,  <title>Catalogi codicum manuscriptorum Bibliothecæ Bodleianæ pars tertia codices Græcos et Latinos Canonicianos complectens</title>, Quarto Catalogues III, 1854) 
-                            
-                            
-                            <listBibl>
+                        <source>Description by Andrew Dunning (January 2021), adapted from Steven J. Livesey, <q>Antonius de Carlenis, O. P. Four Questions on the Subalternation of the Sciences</q>, <title>Transactions of the American Philosophical Society</title>, n.s., 84 (1994), pp. 55–57. Previously described in the Quarto Catalogue (H. O. Coxe, <title>Catalogi codicum manuscriptorum Bibliothecæ Bodleianæ pars tertia codices Græcos et Latinos Canonicianos complectens</title>, Quarto Catalogues III, 1854) <listBibl>
                               <bibl type="QUARTO" facs="abz0441.gif">Quarto Catalogue, cols. 869-70</bibl>
                               <bibl type="SC" facs="aaz0424.gif">Summary Catalogue, vol. 4, p. 405</bibl>
                            </listBibl>
@@ -71,82 +80,191 @@
                <msPart xml:id="MS_Canon_Misc_573-part1">
                   <msIdentifier>
                      <altIdentifier type="partial">
-                        <idno type="part">MS. Canon. Misc. 573 - Part 1</idno>
+                        <idno type="part">MS. Canon. Misc. 573, fols. 1–171</idno>
                      </altIdentifier>
                   </msIdentifier>
                   <msContents>
+                     <textLang mainLang="la">Latin</textLang>
                      <msItem xml:id="MS_Canon_Misc_573-part1-item1" n="1">
-                        <author key="person_37722126">
-                           Conradus de Ebraco
-                        </author>
-                        <title key="work_1310">Commentary on Peter Lombard, Sentences</title>
+                        <locus>(fols. 1r–165r)</locus>
+                        <author key="person_37722126">Conrad of Ebrach</author>
+                        <title key="work_1310">Opus super quatuor libros Sententiarum</title>
                         <bibl type="commentedOn">
-                           <author key="person_51797933">
-                              Peter Lombard
-                           </author>
+                           <author key="person_51797933">Peter Lombard</author>
                            <title>Sentences</title>
                         </bibl>
-                        <textLang mainLang="la">Latin</textLang>
+                        <msItem>
+                           <bibl>Liber I</bibl>
+                           <msItem>
+                              <incipit><locus>(fol. 1ra)</locus> Flumen Dei repletum est aquis Psalmo xl sexto. Spiritali dulcedine celestium fluentorum inebriata</incipit>
+                              <explicit><locus>(fol. 32va)</locus> et sic est finis istius questionis. etc.</explicit>
+                           </msItem>
+                           <msItem>
+                              <incipit><locus>(fol. 33ra)</locus> Vtrum hec consequentia est bona: Spiritus sanctus non procedit</incipit>
+                              <explicit><locus>(fol. 53va)</locus> et sic est finis istius questionis et per consequens questionum totius libri Sententiarum primi. Per fratrem Johannem de Reiz Australem nacione qui eas finiuit Prague sabato in uigilia sancti Jacobi apostoli anno domini MCCCLXXXIIII Dominus sit benedictus. Amen dicant omnia etc.</explicit>
+                           </msItem>
+                        </msItem>
+                        <msItem>
+                           <bibl>Liber II</bibl>
+                           <incipit><locus>(fol. 54ra)</locus> Flumen Dei repletum est aquis Psalmo ix sexto. Fons sapientie uerbum Dei inexpressis</incipit>
+                           <explicit><locus>(fol. 93vb)</locus> et sic est finis questionum Sententiarum libri secundi qui est finitus anno domini MCCCLXXXIIII feria sexta in die sancte ludmille martiris et uidue in terra boemie qui dies celebratur in sequenti die octaue natiuitatis sancte marie.</explicit>
+                        </msItem>
+                        <msItem>
+                           <bibl>Liber III</bibl>
+                           <incipit><locus>(fol. 94ra)</locus> Flumen dei repletum est aquis Psalmo quarto. Dulcissimum sancti spirite organum</incipit>
+                           <explicit><locus>(fol. 108va)</locus> et sic est finis questionum tertii libri Sententiarum anno domini MCCCLXXXIIII feria quarta finite in sancti martiris Wenheslay, Boemorum ducis. Deo laus in eternum. Amen.</explicit>
+                        </msItem>
+                        <msItem>
+                           <bibl>Liber IV</bibl>
+                           <incipit><locus>(fol. 109ra)</locus> Flumen Dei repletum est aquis Psalmo sexagesimo quarta. Doctor melliflus uenerabilis</incipit>
+                           <explicit><locus>(fol. 156rb)</locus> et sic est finis libri quarti Sententiarum reuer endi magistri Conradi de Ebraco ordinis sancti Bernardi Clareuallis abbatis.</explicit>
+                        </msItem>
+                        <msItem>
+                           <incipit><locus>(fol. 156va)</locus> Questio in uesperiis. Utrum latitudo in cuiuslibet culpe mortalis ymaginalis sit mensuranda penes discessum uoluntatis</incipit>
+                        </msItem>
+                        <finalRubric><locus>(fol. 162rb)</locus> Explicit opus questionum super quatuor libros sententiarum reuerendi magistri Conradi de Ebraco, ordinis Cystersiensium. Scriptum Prage in conuentu sancti Thome manus fratris Johannis de Reiz, ordinis fratrum heremitarum sancti Augustini, pro tunc ibidem studentis, sub anno millesimo tricentesimo octuagesimo quinto, feria sexta octauas Penthecostes; Deo laus in eternum. Amen. Qui te furetur in furca uita priuetur.</finalRubric>
+                        <msItem>
+                           <locus>(fol. 162va)</locus>
+                           <bibl>Index prohemium</bibl>
+                        </msItem>
+                        <msItem>
+                           <locus>(fol. 163v-164r)</locus>
+                           <note>blank</note>
+                        </msItem>
+                        <msItem>
+                           <locus>(fol. 164va-165ra)</locus>
+                           <bibl>Index questionum</bibl>
+                        </msItem>
+                        <msItem>
+                           <locus>(fol. 165rb-171r)</locus>
+                           <note>blank</note>
+                        </msItem>
                      </msItem>
                   </msContents>
                   <physDesc>
                      <objectDesc form="codex">
-                        <supportDesc material="chart">
-                           <support>paper</support>
+                        <supportDesc material="mixed">
+                           <support>parchment and paper</support>
+                           <extent>171 leaves <dimensions unit="mm" type="leaf">
+                                 <height>296</height>
+                                 <width>205</width>
+                              </dimensions>
+                           </extent>
+                           <foliation>Modern foliation.</foliation>
+                           <collation>1–6<hi rend="superscript">16</hi>, 7<hi rend="superscript">14</hi>, 8–10<hi rend="superscript">16</hi>, 11<hi rend="superscript">16</hi> (wants 3). <catchwords>Catchwords at the foot of the last page of each quire (except for the first two).</catchwords></collation>
                         </supportDesc>
+                        <layoutDesc>
+                           <layout writtenLines="57 62" columns="2">2 columns of 57–62 lines, ruled space <dimensions unit="mm" type="ruled">
+                                 <height>225</height>
+                                 <width>153</width>
+                              </dimensions>
+                           </layout>
+                        </layoutDesc>
                      </objectDesc>
                   </physDesc>
                   <history>
                      <origin>
-                        <origDate calendar="Gregorian" when="1385">1385</origDate>
-                        
-                     </origin>
+                        <origPlace key="place_7006464">Prague</origPlace>
+                        <origDate calendar="Gregorian" when="1385">1384–85</origDate>, as indicated through closing rubrics for each book.</origin>
+                     <provenance>Canons regular of <orgName key="org_238824653" role="fmo">Santa Maria della Carità, Venice</orgName>: inscribed, <quote>Iste liber est monasterii sancte Marie de Caritate Venetiarum.</quote> (fol. 162r); <quote>Statio huius libri est in septima sede.</quote> (fol. 163r). Similar inscriptions are also found in MS. Canon. Pat. Lat. 52; MS. Lat. th. d. 28; and Aberdeen, University Library, MS 242.</provenance>
                   </history>
                </msPart>
                <msPart xml:id="MS_Canon_Misc_573-part2">
                   <msIdentifier>
                      <altIdentifier type="partial">
-                        <idno type="part">MS. Canon. Misc. 573 - Part 2</idno>
+                        <idno type="part">MS. Canon. Misc. 573, fols. 172–377</idno>
                      </altIdentifier>
                   </msIdentifier>
                   <msContents>
+                     <textLang mainLang="la">Latin</textLang>
                      <msItem xml:id="MS_Canon_Misc_573-part2-item1" n="1">
-                        <author key="person_90390161">
-                           Antonius de Carlenis
-                        </author>
-                        <!-- the other VIAF entry confuses 2 people -->
-                        <title key="work_605">Commentary on Peter Lombard, Sentences</title>
+                        <author key="person_90390161">Antonius de Carlenis</author>
+                        <title key="work_605">Liber questionum super quatuor libros Sententiarum</title>
                         <bibl type="commentedOn">
-                           <author key="person_51797933">
-                              Peter Lombard
-                           </author>
+                           <author key="person_51797933">Peter Lombard</author>
                            <title>Sentences</title>
                         </bibl>
-                        <textLang mainLang="la">Latin</textLang>
-                        <textLang mainLang="la">Latin</textLang>
+                        <msItem>
+                           <locus>(fol. 172ra)</locus>
+                           <incipit defective="true">dicit theologiam esse scientiam subalternam</incipit>
+                           <explicit><locus>(fol. 271va)</locus> predestinatus enim erat quod partibus gregorii saluaretur.</explicit>
+                           <finalRubric>Sequitur secundus liber Sententiarum</finalRubric>
+                        </msItem>
+                        <msItem>
+                           <locus>(fols. 272-273)</locus>
+                           <note>blank</note>
+                        </msItem>
+                        <msItem>
+                           <bibl>Liber II</bibl>
+                           <rubric><locus>(fol. 274ra)</locus> Secundus liber.</rubric>
+                           <incipit>Circa primam diuisionem secundi libri Sententiarum, queritur utrum mundi productio extrinsica de necessitate presupponat productiones intrinsicas in diuinis</incipit>
+                           <explicit><locus>(fol. 310vb)</locus> ut dictum est in responsione ad 12m.</explicit>
+                        </msItem>
+                        <msItem>
+                           <locus>(fol. 311)</locus>
+                           <note>blank</note>
+                        </msItem>
+                        <msItem>
+                           <bibl>Liber III</bibl>
+                           <rubric><locus>(fol. 312ra)</locus> Tertius liber Sententiarum.</rubric>
+                           <incipit>Queritur utrum tres persones potuerunt accipere unam naturam</incipit>
+                           <explicit><locus>(fol. 347ra)</locus> secundum seminalem rationem in Adam. Laus Deo. Amen.</explicit>
+                        </msItem>
+                        <msItem>
+                           <locus>(fol. 247v)</locus>
+                           <note>blank</note>
+                        </msItem>
+                        <msItem>
+                           <bibl>Liber IV</bibl>
+                           <incipit><locus>(fol. 348ra)</locus> Queritur utrum in sacramento sit aliqua Christus creatiua gratie</incipit>
+                           <explicit><locus>(fol. 375rb)</locus> qualis sit sanctorum gloria. Deo gratia. Amen.</explicit>
+                        </msItem>
+                        <msItem>
+                           <bibl>Index questionum</bibl>
+                           <rubric><locus>(fol. 375va)</locus> Super primum, et primo circa prohemium.</rubric>
+                           <incipit>Queritur utrum doctrina sacra sit scientia</incipit>
+                           <finalRubric><locus>(fol. 377ra)</locus> Explicit liber super quatuor libros Sententiarum compositus a reuerendissimo domino Domno A. archiepiscopo Amalphitano, sacre theologie magister Praedicatorum dignissimo, etc. Amen.</finalRubric>
+                        </msItem>
+                        <msItem>
+                           <locus>(fol. 377v)</locus>
+                           <note>blank</note>
+                        </msItem>
                      </msItem>
                   </msContents>
                   <physDesc>
                      <objectDesc form="codex">
                         <supportDesc material="chart">
-                           <support>paper</support>
+                           <support>paper, with three watermarks: <watermark>licorne of the Italian type (similar to Briquet nos. 9957, 9960, 9971)</watermark>; <watermark>té (Briquet no. 14089)</watermark>; <watermark>unidentified circular design</watermark>.</support>
+                           <extent>206 leaves <dimensions unit="mm" type="leaf">
+                                 <height>294</height>
+                                 <width>210</width>
+                              </dimensions>
+                           </extent>
+                           <collation>1–4<hi rend="superscript">12</hi>, 5<hi rend="superscript">12</hi> (wants one), 6–8<hi rend="superscript">12</hi>, 9<hi rend="superscript">8</hi>, 10–11<hi rend="superscript">2</hi>, 12<hi rend="superscript">6</hi>, 13<hi rend="superscript">8</hi>, 14–18<hi rend="superscript">12</hi>, 19<hi rend="superscript">10</hi> (wants 4). <catchwords>Catchwords at the foot of the last page of each quire.</catchwords></collation>
                         </supportDesc>
+                        <layoutDesc>
+                           <layout writtenLines="34 37" columns="2">2 columns of 34–37 lines, ruled space <dimensions unit="mm" type="ruled">
+                                 <height>202</height>
+                                 <width>137</width>
+                              </dimensions>
+                           </layout>
+                        </layoutDesc>
                      </objectDesc>
                   </physDesc>
                   <history>
                      <origin>
+                        <origPlace key="place_1000080">Italy</origPlace>
                         <origDate calendar="Gregorian" notAfter="1500" notBefore="1400">15th century</origDate>
-                        
                      </origin>
                   </history>
                </msPart>
             </msDesc>
          </sourceDesc>
-      </fileDesc>       
-      <revisionDesc><change when="2018-10-14" xml:id="MMM"><persName>Mitch Fraas/Mapping Manuscript Migrations</persName>
-      Provenance and acquisition information added using <ref target="https://github.com/littlegustv/oxfordupdates/blob/master/test_case_for_oxford_prov.rb">https://github.com/littlegustv/oxfordupdates/blob/master/test_case_for_oxford_prov.rb</ref>
-      in collaboration with the <ref target="http://mappingmanuscriptmigrations.org/">Mapping Manuscript Migrations</ref> project.'
-    </change>          <change when="2017-07-01">First online publication.</change>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2021-01-13"><persName>Andrew Dunning</persName> New description.</change>
+         <change when="2018-10-14" xml:id="MMM"><persName>Mitch Fraas/Mapping Manuscript Migrations</persName> Provenance and acquisition information added using <ref target="https://github.com/littlegustv/oxfordupdates/blob/master/test_case_for_oxford_prov.rb">https://github.com/littlegustv/oxfordupdates/blob/master/test_case_for_oxford_prov.rb</ref> in collaboration with the <ref target="http://mappingmanuscriptmigrations.org/">Mapping Manuscript Migrations</ref> project.' </change>
+         <change when="2017-07-01">First online publication.</change>
 
          <change when="2017-05-29">
             <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>


### PR DESCRIPTION
Adapted from [an edition using this manuscript](https://www.jstor.org/stable/1006612) – still missing some standard information, but will fill these in when there is an opportunity.