### PR TITLE
MS. Laud Misc. 276: Change two refs in one bibl to two bibl children of surrogates

### DIFF
--- a/collections/Laud_Misc/MS_Laud_Misc_276.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_276.xml
@@ -179,6 +179,8 @@
                      <bibl subtype="full" type="digital-facsimile">
                         <ref target="https://digital.bodleian.ox.ac.uk/objects/7f11d6f9-38a5-4a5d-9f32-406d6d911ca9/"><title>Digital Bodleian</title></ref>
                         <note>(full digital facsimile)</note>
+                     </bibl>
+                     <bibl subtype="full" type="digital-facsimile">
                         <ref target="http://bibliotheca-laureshamensis-digital.de/view/bodleian_mslaudmisc276"><title>Bibliotheca Laureshamensis – digital</title></ref>
                         <note>(full facsimile)</note>
                      </bibl>


### PR DESCRIPTION
I found this instance of two refs in one surrogates/bibl. I've changed it to two bibl instead.

I'm submitting this as a pull request to double-check that the second one, on a German web site, is a full facsimile, not a partial one?