### PR TITLE
ISNI Lookup May 2021

### DIFF
--- a/places.xml
+++ b/places.xml
@@ -14,6 +14,7 @@
             <notesStmt>
                 <note xml:id="VL1">Elements with source attributes of "#VL1" were retrieved from VIAF by lookup-viaf-info.xsl on 2020-06-30</note>
                 <note xml:id="IL1">Elements with source attributes of "#IL1" were retrieved from ISNI and added by add-from-isni.xsl on 2020-08-18</note>
+                <note xml:id="IL2">Elements with source attributes of "#IL2" were retrieved from ISNI and added by add-from-isni.xsl on 2021-05-20</note>
             </notesStmt>
             <sourceDesc>
                 <p>Information about the source</p>
@@ -10313,6 +10314,7 @@
                             <item><ref target="http://viaf.org/viaf/167697464"><title>VIAF</title></ref></item>
                             <item><ref target="http://d-nb.info/gnd/4439938-8"><title>DNB</title></ref></item>
                             <item><ref target="http://klosterdatenbank.germania-sacra.de/gsn/60297"><title>Germania Sacra</title></ref></item>
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/0000000121992705"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -10338,6 +10340,7 @@
                             <item><ref target="http://d-nb.info/gnd/4465326-8"><title>GND</title></ref></item>
                             <item><ref target="http://viaf.org/viaf/246947660"><title>VIAF</title></ref></item>
                             <item><ref target="http://klosterdatenbank.germania-sacra.de/gsn/60437"><title>Germania Sacra</title></ref></item>
+                            <!--No match found in ISNI for VIAF ID 246947660 on 2021-05-20-->
                         </list></note>
                 </org>
                 <org xml:id="org_128563333">
@@ -10370,7 +10373,7 @@
                                     <title>BNF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 313181544 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 313181544 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -10389,7 +10392,7 @@
                                     <title>Germania Sacra</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 000000009147691X-->
+                            <!--No match found in ISNI for VIAF ID 133893958 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -10412,7 +10415,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000106305137-->
+                            <!--No match found in ISNI for VIAF ID 159512263 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -10435,7 +10438,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 17149233273676510291 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 17149233273676510291 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -10453,7 +10456,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 000000009990646X-->
+                            <!--Provisional ISNI ID as of 2021-05-20: 000000009990646X-->
                         </list>
                     </note>
                 </org>
@@ -10534,7 +10537,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 272891581 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 272891581 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -10557,7 +10560,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 146831170 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 146831170 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -10580,7 +10583,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000087356739-->
+                            <!--No match found in ISNI for VIAF ID 126774004 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -10603,7 +10606,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000094904852-->
+                            <!--No match found in ISNI for VIAF ID 139803826 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -10654,7 +10657,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 000000012194480X-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/000000012194480X"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -10713,7 +10716,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 295127444 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 295127444 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -10730,7 +10733,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 310514352 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 310514352 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -10788,7 +10791,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000086169587-->
+                            <!--No match found in ISNI for VIAF ID 124680895 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -10844,7 +10847,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000106403837-->
+                            <!--No match found in ISNI for VIAF ID 159672632 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -10862,7 +10865,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 246264651 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 246264651 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -10916,7 +10919,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 251338225 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 251338225 on 2021-05-20-->
                         </list>
                         <!--<list type="links">
                                <item><ref target="http://viaf.org/viaf/135337488"><title>VIAF</title></ref></item>
@@ -11007,7 +11010,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000092341435-->
+                            <!--No match found in ISNI for VIAF ID 135319659 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -11034,7 +11037,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 247467479 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 247467479 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -11094,7 +11097,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 241899093 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 241899093 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -11164,7 +11167,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 304919952 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 304919952 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -11223,7 +11226,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000100688659-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/0000000100688659"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -11247,7 +11250,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 243863172 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 243863172 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -11274,7 +11277,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 49145542365096640921 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 49145542365096640921 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -11317,7 +11320,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000090705135-->
+                            <!--No match found in ISNI for VIAF ID 132571192 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -11344,7 +11347,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 147596326 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 147596326 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -11426,7 +11429,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 304912099 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 304912099 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -11473,7 +11476,7 @@
                                     <title>LC</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 123429486 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 123429486 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -11513,7 +11516,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 270753550 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 270753550 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -11548,7 +11551,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 313198488 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 313198488 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -11584,7 +11587,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000087563404-->
+                            <!--No match found in ISNI for VIAF ID 127077483 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -11669,7 +11672,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 217095146 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 217095146 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -11692,7 +11695,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000101585782-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/0000000101585782"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -11751,7 +11754,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 235558512 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 235558512 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -11775,7 +11778,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 239193232 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 239193232 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -11888,8 +11891,8 @@
                                     <title>BNF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000100184311-->
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000099504209-->
+                            <!--No match found in ISNI for VIAF ID 148943477 on 2021-05-20-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/0000000099504209"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -11911,7 +11914,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 292385856 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 292385856 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -11937,7 +11940,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000092035243-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/0000000092035243"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -11975,7 +11978,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000105637439-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/0000000105637439"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -12006,7 +12009,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000092258711-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/0000000092258711"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -12116,8 +12119,8 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000101634660-->
-                            <!--No match found in ISNI for VIAF ID 202396473 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 151430091 on 2021-05-20-->
+                            <!--No match found in ISNI for VIAF ID 202396473 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -12172,7 +12175,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000093989305-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/0000000093989305"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -12250,7 +12253,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 313492968 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 313492968 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -12278,7 +12281,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000088962298-->
+                            <!--No match found in ISNI for VIAF ID 129471242 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -12356,7 +12359,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 129279786 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 129279786 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -12435,7 +12438,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 148042626 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 148042626 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -12475,7 +12478,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000122532313-->
+                            <!--No match found in ISNI for VIAF ID 172327788 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -12518,8 +12521,8 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000123248576-->
-                            <!--No match found in ISNI for VIAF ID 173026705 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 143145136 on 2021-05-20-->
+                            <!--No match found in ISNI for VIAF ID 173026705 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -12548,7 +12551,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000104217555-->
+                            <!--No match found in ISNI for VIAF ID 155912077 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -12569,7 +12572,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 313493631 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 313493631 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -12605,7 +12608,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 205808165 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 205808165 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -12681,7 +12684,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000098121767-->
+                            <!--No match found in ISNI for VIAF ID 145388823 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -12701,7 +12704,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000092084299-->
+                            <!--No match found in ISNI for VIAF ID 134950157 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -12751,7 +12754,7 @@
                                     <title>Wikidata</title>
                                 </ref> this entry is odd
                             </item>-->
-                            <!--No match found in ISNI for VIAF ID 138242961 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 138242961 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -12789,7 +12792,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 000000009111357X-->
+                            <!--Provisional ISNI ID as of 2021-05-20: 000000009111357X-->
                         </list>
                     </note>
                 </org>
@@ -12809,7 +12812,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 144397095 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 144397095 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -12881,7 +12884,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000087883926-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/0000000087883926"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -12962,7 +12965,7 @@
                                     <title>BNF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 211447911 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 211447911 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -12991,7 +12994,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 315944440 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 315944440 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -13026,7 +13029,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000092033782-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/0000000092033782"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -13048,7 +13051,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000086069260-->
+                            <!--No match found in ISNI for VIAF ID 124540557 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -13074,7 +13077,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000099129621-->
+                            <!--No match found in ISNI for VIAF ID 147036231 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -13205,7 +13208,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000098958612-->
+                            <!--No match found in ISNI for VIAF ID 146807988 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -13224,7 +13227,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000087357301-->
+                            <!--No match found in ISNI for VIAF ID 126774688 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -13470,7 +13473,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 246265108 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 246265108 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -13513,7 +13516,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000086646494-->
+                            <!--No match found in ISNI for VIAF ID 125552867 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -13669,7 +13672,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000090034626-->
+                            <!--No match found in ISNI for VIAF ID 131409984 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -13685,7 +13688,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000094363590-->
+                            <!--No match found in ISNI for VIAF ID 138814996 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -13702,7 +13705,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 126047237 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 126047237 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -13748,9 +13751,9 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 415145858126223022295 on 2020-08-18-->
-                            <!--No match found in ISNI for VIAF ID 213945938 on 2020-08-18-->
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000096113683-->
+                            <!--No match found in ISNI for VIAF ID 415145858126223022295 on 2021-05-20-->
+                            <!--No match found in ISNI for VIAF ID 213945938 on 2021-05-20-->
+                            <!--No match found in ISNI for VIAF ID 141918870 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -13780,7 +13783,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000122178422-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/0000000122178422"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -13810,7 +13813,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000107199495-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/0000000107199495"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -13843,7 +13846,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 245287151 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 245287151 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -13904,7 +13907,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000088680450-->
+                            <!--No match found in ISNI for VIAF ID 129065993 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -13927,7 +13930,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000098402235-->
+                            <!--No match found in ISNI for VIAF ID 145804112 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -13952,7 +13955,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 243886719 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 243886719 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -13978,7 +13981,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 240542197 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 240542197 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -14006,7 +14009,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 245037741 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 245037741 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -14035,7 +14038,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000123622628-->
+                            <!--No match found in ISNI for VIAF ID 173532247 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -14099,7 +14102,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000123549379-->
+                            <!--No match found in ISNI for VIAF ID 173408842 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -14175,7 +14178,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 126666939 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 126666939 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -14245,7 +14248,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 241197056 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 241197056 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -14282,7 +14285,7 @@
                                     <title>BNF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 000000010690544X-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/000000010690544X"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -14312,7 +14315,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000085582679-->
+                            <!--No match found in ISNI for VIAF ID 123624907 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -14349,7 +14352,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 000000012034831X-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/000000012034831X"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -14376,7 +14379,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000085277746-->
+                            <!--No match found in ISNI for VIAF ID 123184663 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -14398,7 +14401,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 000000008871135X-->
+                            <!--No match found in ISNI for VIAF ID 129111728 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -14451,7 +14454,7 @@
                                     <title>Germania Sacra</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000092140377-->
+                            <!--No match found in ISNI for VIAF ID 135038090 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -14583,7 +14586,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000115445203-->
+                            <!--No match found in ISNI for VIAF ID 153715381 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -14611,7 +14614,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 172374812 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 172374812 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -14633,7 +14636,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 232929480 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 232929480 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -14665,7 +14668,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 249304112 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 249304112 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -14697,7 +14700,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000090322150-->
+                            <!--No match found in ISNI for VIAF ID 131824444 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -14752,7 +14755,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 247412105 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 247412105 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -14782,7 +14785,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 169654564 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 169654564 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -14803,7 +14806,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000103653064-->
+                            <!--No match found in ISNI for VIAF ID 154915206 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -14834,7 +14837,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 145941484 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 145941484 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -14855,7 +14858,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 316390117 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 316390117 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -14879,7 +14882,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 153848390 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 153848390 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -14900,7 +14903,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 238824653 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 238824653 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -14919,7 +14922,7 @@
                                     <title>LC</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000096868445-->
+                            <!--No match found in ISNI for VIAF ID 143202638 on 2021-05-20-->
                         </list>
                         <list type="links">
                             <item>
@@ -14932,7 +14935,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000096868445-->
+                            <!--No match found in ISNI for VIAF ID 143202638 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -14967,7 +14970,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 315687992 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 315687992 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -14987,7 +14990,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 315686151 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 315686151 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -15025,7 +15028,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 168089114 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 168089114 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -15053,7 +15056,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 128793507 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 128793507 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -15083,7 +15086,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 313533333 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 313533333 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -15104,7 +15107,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000101296702-->
+                            <!--Provisional ISNI ID as of 2021-05-20: 0000000101296702-->
                         </list>
                     </note>
                 </org>
@@ -15124,7 +15127,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 310513586 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 310513586 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -15148,7 +15151,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 152531224 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 152531224 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -15176,7 +15179,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000106350480-->
+                            <!--No match found in ISNI for VIAF ID 159581566 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -15251,7 +15254,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000102982261-->
+                            <!--No match found in ISNI for VIAF ID 153760063 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -15276,7 +15279,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000095512383-->
+                            <!--No match found in ISNI for VIAF ID 140865145 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -15306,7 +15309,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000092802297-->
+                            <!--No match found in ISNI for VIAF ID 136179651 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -15346,7 +15349,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000092152802-->
+                            <!--No match found in ISNI for VIAF ID 135058831 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -15381,8 +15384,8 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000123648457-->
-                            <!--No match found in ISNI for VIAF ID 156148995743759750417 on 2020-08-18-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/0000000123648457"><title>ISNI</title></ref></item>
+                            <!--No match found in ISNI for VIAF ID 156148995743759750417 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -15400,7 +15403,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000090101577-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/0000000090101577"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -15433,7 +15436,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000088623982-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/0000000088623982"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -15460,7 +15463,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 139688379 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 139688379 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -15493,7 +15496,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000121111728-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/0000000121111728"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -15682,7 +15685,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 371144782732650928555 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 371144782732650928555 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -15710,7 +15713,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000088191585-->
+                            <!--No match found in ISNI for VIAF ID 128177579 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -15761,7 +15764,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000085514916-->
+                            <!--No match found in ISNI for VIAF ID 123537181 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -15821,7 +15824,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000105798291-->
+                            <!--No match found in ISNI for VIAF ID 158596637 on 2021-05-20-->
                         </list>
                     </note>
                     <bibl>Knowles &amp; Hadcock, pp. 112, 116</bibl>
@@ -15887,7 +15890,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000122371361-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/0000000122371361"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -15906,7 +15909,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 145707239 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 145707239 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -15934,7 +15937,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 140811075 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 140811075 on 2021-05-20-->
                         </list>
                     </note>
                     <note>Coordinates for the settlement of Trois-Fontaines, from the <ref target="http://www.getty.edu/research/tools/vocabularies/tgn/">Getty Thesaurus of Geographic Names</ref>, copyright 2017 the J. Paul Getty Trust, released under the <ref target="https://opendatacommons.org/licenses/by/1-0/">Open Data Commons Attribution License (ODC-By) 1.0</ref>.</note>
@@ -15958,7 +15961,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 294361980 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 294361980 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -15986,7 +15989,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000086620964-->
+                            <!--No match found in ISNI for VIAF ID 125513925 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -16060,7 +16063,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000091809403-->
+                            <!--Provisional ISNI ID as of 2021-05-20: 0000000091809403-->
                         </list>
                     </note>
                 </org>
@@ -16080,7 +16083,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 2142145857037522921207 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 2142145857037522921207 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -16104,7 +16107,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000090867249-->
+                            <!--Provisional ISNI ID as of 2021-05-20: 0000000090867249-->
                         </list>
                     </note>
                 </org>
@@ -16127,7 +16130,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000100413065-->
+                            <!--No match found in ISNI for VIAF ID 149286387 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -16250,7 +16253,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000100221039-->
+                            <!--No match found in ISNI for VIAF ID 148998848 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -16279,7 +16282,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000112558456-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/0000000112558456"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -16326,7 +16329,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000105893109-->
+                            <!--No match found in ISNI for VIAF ID 158720589 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -16382,7 +16385,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000085705202-->
+                            <!--Provisional ISNI ID as of 2021-05-20: 0000000085705202-->
                         </list>
                     </note>
                 </org>
@@ -16400,7 +16403,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 260127654 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 260127654 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -16436,7 +16439,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000115231942-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/0000000115231942"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -16491,7 +16494,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 442146997389818892504 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 442146997389818892504 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -16521,7 +16524,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 269197839 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 269197839 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -16544,7 +16547,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000086230595-->
+                            <!--No match found in ISNI for VIAF ID 124759589 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -16647,7 +16650,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000105226277-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/0000000105226277"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -16665,7 +16668,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000092081709-->
+                            <!--No match found in ISNI for VIAF ID 134946326 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -16693,7 +16696,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 313533276 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 313533276 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -16721,7 +16724,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000112398085-->
+                            <!--No match found in ISNI for VIAF ID 163769115 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -16751,7 +16754,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000123536244-->
+                            <!--Provisional ISNI ID as of 2021-05-20: 0000000123536244-->
                         </list>
                     </note>
                 </org>
@@ -16781,7 +16784,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 244595494 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 244595494 on 2021-05-20-->
                         </list>
                     </note>
                     <note type="source">Co-ordinates (for the island of Reichenau) from the <ref target="http://www.getty.edu/research/tools/vocabularies/tgn/">Getty Thesaurus of Geographic Names</ref>, copyright 2017 the J. Paul Getty Trust, released under the <ref target="https://opendatacommons.org/licenses/by/1-0/">Open Data Commons Attribution License (ODC-By) 1.0</ref>.</note>
@@ -16882,7 +16885,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 27148207842000341517 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 27148207842000341517 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -16913,7 +16916,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 000000010222249X-->
+                            <!--No match found in ISNI for VIAF ID 152458362 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -16931,7 +16934,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000122711055-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/0000000122711055"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -16950,7 +16953,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 313222993 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 313222993 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17022,7 +17025,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 135326103 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 135326103 on 2021-05-20-->
                         </list>
                     </note>
                     <!-- check the date? -->
@@ -17079,7 +17082,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 146685036 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 146685036 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17111,7 +17114,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 132688628 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 132688628 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17137,7 +17140,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 311465280 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 311465280 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17170,7 +17173,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000097600854-->
+                            <!--No match found in ISNI for VIAF ID 144471224 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17188,7 +17191,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 154868239 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 154868239 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17206,7 +17209,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000087592061-->
+                            <!--No match found in ISNI for VIAF ID 127113314 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17239,7 +17242,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 305126922 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 305126922 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17281,7 +17284,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000102255558-->
+                            <!--No match found in ISNI for VIAF ID 152509582 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17382,7 +17385,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000098227123-->
+                            <!--No match found in ISNI for VIAF ID 145549427 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17400,7 +17403,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 145675476 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 145675476 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17421,7 +17424,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 234338663 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 234338663 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17454,7 +17457,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000092758636-->
+                            <!--No match found in ISNI for VIAF ID 136115337 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17482,7 +17485,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000112766482-->
+                            <!--Provisional ISNI ID as of 2021-05-20: 0000000112766482-->
                         </list>
                     </note>
                 </org>
@@ -17505,7 +17508,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000085976344-->
+                            <!--No match found in ISNI for VIAF ID 124391636 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17525,7 +17528,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000101843876-->
+                            <!--No match found in ISNI for VIAF ID 151723892 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17553,7 +17556,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000096397268-->
+                            <!--No match found in ISNI for VIAF ID 142329853 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17618,7 +17621,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 000000008737729X-->
+                            <!--No match found in ISNI for VIAF ID 126805565 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17698,7 +17701,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 239220402 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 239220402 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17734,7 +17737,7 @@
                                     <title>LC</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000090603892-->
+                            <!--Provisional ISNI ID as of 2021-05-20: 0000000090603892-->
                         </list>
                     </note>
                 </org>
@@ -17757,7 +17760,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000094967001-->
+                            <!--No match found in ISNI for VIAF ID 139886776 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17775,7 +17778,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 119144647640953754712 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 119144647640953754712 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17831,7 +17834,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 242823650 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 242823650 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17849,7 +17852,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 267912669 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 267912669 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17872,7 +17875,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 258918407 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 258918407 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17896,7 +17899,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 248915895 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 248915895 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17961,7 +17964,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000090842033-->
+                            <!--No match found in ISNI for VIAF ID 132788727 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17979,7 +17982,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 175175470 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 175175470 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -17997,7 +18000,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000104345645-->
+                            <!--No match found in ISNI for VIAF ID 156111581 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -18029,7 +18032,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000093892941-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/0000000093892941"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -18149,7 +18152,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000104451632-->
+                            <!--No match found in ISNI for VIAF ID 156265118 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -18167,7 +18170,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000106518706-->
+                            <!--No match found in ISNI for VIAF ID 159826695 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -18236,7 +18239,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 244228863 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 244228863 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -18264,7 +18267,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 141420298 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 141420298 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -18355,7 +18358,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000091361055-->
+                            <!--No match found in ISNI for VIAF ID 133706555 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -18377,7 +18380,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000095053359-->
+                            <!--No match found in ISNI for VIAF ID 139999868 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -18408,7 +18411,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 267407979 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 267407979 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -18438,7 +18441,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 150071244 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 150071244 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -18474,7 +18477,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000105222495-->
+                            <!--No match found in ISNI for VIAF ID 157558711 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -18555,7 +18558,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 308185589 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 308185589 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -18600,8 +18603,8 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 248254900 on 2020-08-18-->
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000097762415-->
+                            <!--No match found in ISNI for VIAF ID 248254900 on 2021-05-20-->
+                            <!--No match found in ISNI for VIAF ID 144687938 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -18662,7 +18665,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 134239581 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 134239581 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -18683,7 +18686,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 240554317 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 240554317 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -18726,7 +18729,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000098746337-->
+                            <!--Provisional ISNI ID as of 2021-05-20: 0000000098746337-->
                         </list>
                     </note>
                 </org>
@@ -18788,7 +18791,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000106196487-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/0000000106196487"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -18839,7 +18842,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000095557709-->
+                            <!--No match found in ISNI for VIAF ID 140943552 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -18863,7 +18866,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 126334887 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 126334887 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -18892,7 +18895,7 @@
                                     <title>LC</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 146323850 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 146323850 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -18918,7 +18921,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000102448229-->
+                            <!--No match found in ISNI for VIAF ID 152797746 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -18941,7 +18944,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 235700069 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 235700069 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -18982,7 +18985,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000104535764-->
+                            <!--No match found in ISNI for VIAF ID 156374852 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -19010,7 +19013,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000097695582-->
+                            <!--No match found in ISNI for VIAF ID 144600874 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -19043,7 +19046,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 242730887 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 242730887 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -19150,7 +19153,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 160939265 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 160939265 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -19172,7 +19175,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000086772175-->
+                            <!--No match found in ISNI for VIAF ID 125752208 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -19209,7 +19212,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 150190778 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 150190778 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -19337,8 +19340,8 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 175619750 on 2020-08-18-->
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000086652069-->
+                            <!--No match found in ISNI for VIAF ID 175619750 on 2021-05-20-->
+                            <!--No match found in ISNI for VIAF ID 125561252 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -19359,7 +19362,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 295377124 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 295377124 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -19381,7 +19384,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000099537844-->
+                            <!--No match found in ISNI for VIAF ID 147818232 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -19410,7 +19413,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 263208235 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 263208235 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -19494,7 +19497,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 295820821 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 295820821 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -19526,7 +19529,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 317069910 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 317069910 on 2021-05-20-->
                         </list>
                     </note>
                     <bibl>Cottineau II, col. 3062</bibl>
@@ -19605,7 +19608,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 145597689 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 145597689 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -19649,7 +19652,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000123534134-->
+                            <!--No match found in ISNI for VIAF ID 150912735 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -19681,7 +19684,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 150552322 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 150552322 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -19802,7 +19805,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000086396157-->
+                            <!--Provisional ISNI ID as of 2021-05-20: 0000000086396157-->
                         </list>
                     </note>
                 </org>
@@ -19877,7 +19880,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 240561051 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 240561051 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -19908,7 +19911,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000085309576-->
+                            <!--No match found in ISNI for VIAF ID 123233264 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -19949,7 +19952,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 212968081 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 212968081 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -19977,7 +19980,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 141000452 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 141000452 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -19993,7 +19996,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 254121248 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 254121248 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -20009,7 +20012,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 254633607 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 254633607 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -20050,7 +20053,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000106884570-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/0000000106884570"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -20076,7 +20079,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 266189883 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 266189883 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -20109,7 +20112,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 157389164 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 157389164 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -20129,7 +20132,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 250806462 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 250806462 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -20150,7 +20153,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 223669083 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 223669083 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -20177,7 +20180,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 254016085 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 254016085 on 2021-05-20-->
                         </list>
                     </note>
                     <!-- NB several apparent entries in VIAF not merged -->
@@ -20223,7 +20226,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 208896312 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 208896312 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -20297,7 +20300,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000105640216-->
+                            <!--No match found in ISNI for VIAF ID 158357258 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -20370,7 +20373,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 310746171 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 310746171 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -20433,7 +20436,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 128317513 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 128317513 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -20453,7 +20456,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 234315879 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 234315879 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -20474,7 +20477,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000098288487-->
+                            <!--No match found in ISNI for VIAF ID 145653569 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -20494,7 +20497,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 243910020 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 243910020 on 2021-05-20-->
                         </list>
                     </note>
                     <!-- not in cottineau -->
@@ -20543,7 +20546,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 138342928 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 138342928 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -20564,7 +20567,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 243166021 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 243166021 on 2021-05-20-->
                         </list>
                     </note>
                     <bibl>Knowles &amp; Hadcock, pp. 419, 443</bibl>
@@ -20585,7 +20588,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 1115145857069622921436 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 1115145857069622921436 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -20616,7 +20619,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 135655543 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 135655543 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -20645,7 +20648,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 266852074 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 266852074 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -20686,7 +20689,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 173376610 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 173376610 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -20710,7 +20713,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 240145542525596640761 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 240145542525596640761 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -20761,7 +20764,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 138512183 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 138512183 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -20792,7 +20795,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 246948936 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 246948936 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -20813,7 +20816,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000104917076-->
+                            <!--No match found in ISNI for VIAF ID 157113813 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -20866,7 +20869,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000086916044-->
+                            <!--No match found in ISNI for VIAF ID 125940881 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -20896,7 +20899,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 123598658 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 123598658 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -20974,7 +20977,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 312805416 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 312805416 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -21003,7 +21006,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 148097195 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 148097195 on 2021-05-20-->
                         </list>
                     </note>
                     <note>Co-ordinates from Wikipedia.</note>
@@ -21044,7 +21047,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 245815193 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 245815193 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -21097,7 +21100,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000087375446-->
+                            <!--No match found in ISNI for VIAF ID 126802421 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -21121,7 +21124,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 139637930 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 139637930 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -21158,7 +21161,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000094993306-->
+                            <!--No match found in ISNI for VIAF ID 139922418 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -21234,7 +21237,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 264519246 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 264519246 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -21277,7 +21280,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000092779381-->
+                            <!--No match found in ISNI for VIAF ID 136144523 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -21323,8 +21326,8 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 211935376 on 2020-08-18-->
-                            <!--Provisional ISNI ID as of 2020-08-18: 000000010585867X-->
+                            <!--No match found in ISNI for VIAF ID 211935376 on 2021-05-20-->
+                            <!--No match found in ISNI for VIAF ID 158676805 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -21354,7 +21357,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 000000008054354X-->
+                            <item source="#IL2"><ref target="http://www.isni.org/isni/000000008054354X"><title>ISNI</title></ref></item>
                         </list>
                     </note>
                 </org>
@@ -21391,7 +21394,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 237710601 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 237710601 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -21423,7 +21426,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000105366763-->
+                            <!--Provisional ISNI ID as of 2021-05-20: 0000000105366763-->
                         </list>
                     </note>
                 </org>
@@ -21454,7 +21457,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 298413710 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 298413710 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -21560,7 +21563,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 240455434 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 240455434 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -21587,7 +21590,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 198876802 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 198876802 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -21614,7 +21617,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 23151110643437060950 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 23151110643437060950 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -21638,7 +21641,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 239003182 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 239003182 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -21688,7 +21691,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 271051505 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 271051505 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -21733,7 +21736,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 000000010253141X-->
+                            <!--No match found in ISNI for VIAF ID 152906198 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -21751,7 +21754,7 @@
                                     <title>LC</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000090773197-->
+                            <!--No match found in ISNI for VIAF ID 132676429 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -21774,7 +21777,7 @@
                                     <title>GND</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 308748070 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 308748070 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -21798,7 +21801,7 @@
                                     <title>Wikidata</title>
                                 </ref>
                             </item>
-                            <!--No match found in ISNI for VIAF ID 268217466 on 2020-08-18-->
+                            <!--No match found in ISNI for VIAF ID 268217466 on 2021-05-20-->
                         </list>
                     </note>
                 </org>
@@ -21817,7 +21820,7 @@
                                     <title>VIAF</title>
                                 </ref>
                             </item>
-                            <!--Provisional ISNI ID as of 2020-08-18: 0000000085925045-->
+                            <!--No match found in ISNI for VIAF ID 124309014 on 2021-05-20-->
                         </list>
                     </note>
                 </org>

--- a/processing/batch_conversion/add-from-isni.xsl
+++ b/processing/batch_conversion/add-from-isni.xsl
@@ -16,7 +16,7 @@
          calls to the ISNI API saved locally in a temporary folder (done separately via curl as username/password is required) -->
     
     <!-- Queries to send to ISNI API can be generated with this XPath:
-         /TEI/text/body/*/(person|org)[not(note/list/item/ref[contains(@target, 'isni.org')])]/note/list/item/ref[contains(@target, 'viaf.org')]/@target/concat('pica.cn+%3D+%22VIAF%2B', substring-after(., '/viaf/'), '%22')
+         /TEI/text/body/*/(person|org)[not(note/list/item/ref[contains(@target, 'isni.org')])]/note/list/item/ref[contains(@target, 'viaf.org')]/@target/concat('pica.cn+%3D+%22VIAF%2B', tokenize(., '/')[5], '%22')
          The output of that can then be passed to a Bash command like:
          xargs -I {} bash -c 'curl -k -o "/tmp/isni/output/{}.xml" "https://isni-m.oclc.nl/sru/username=____/password=____/DB=1.3/?query={}"; sleep 2;'
          Finally transform either persons.xml or places.xml using this stylesheet, and it will retrieve the ISNI API responses to add to the authority file. -->


### PR DESCRIPTION
I queried the ISNI API for all the VIAF IDs of people for which we have a VIAF ID (some more than one) but not an ISNI. The results are:

 * 86 new links added to ISNIs which have approved status
 * 552 provisional ISNI IDs found, added as comments
 * 460 VIAF ID not matched in ISNI database

The provisional ones cannot be added as links, because they don't work yet (some have been deleted since the last time, so they're not always approved.)