### PR TITLE
Test links to HathiTrust

### DIFF
--- a/collections/Ash_Rolls/MS_Ash_Rolls_38.xml
+++ b/collections/Ash_Rolls/MS_Ash_Rolls_38.xml
@@ -74,7 +74,7 @@
                      </supportDesc>
                   </objectDesc>
                   <decoDesc>
-                     <decoNote resp="#PA" type="miniature">Good miniatures (coloured drawings), borders. (P&amp;A iii. 535)</decoNote>
+                     <decoNote resp="#PA" type="miniature">Good miniatures (coloured drawings), borders. (<ref target="https://catalog.hathitrust.org/Record/000468709">P&amp;A</ref> iii. 535)</decoNote>
                      <decoNote resp="#DD" type="diagram">Coloured miniatures and diagrams, parts of text in red.</decoNote>
                      <decoNote resp="#ES">Miniature of King Edward I on the throne (damaged). Circular diagram showing the kingdoms of Heptarchy. Borders, framing the roll on either side, are illustrated with portraits and scenes from the lives of various rulers, kings and queens, begining with Brutus and Cormeus, and ending with Edward I and Edward II. Pen drawings of grotesques and folliage fill larger spaces between the lines of text.</decoNote>
                   </decoDesc>
@@ -95,8 +95,8 @@
                   <adminInfo>
                      <recordHist>
                         <source>Description adapted (2018) from Watson and Pächt and Alexander (see bibliography), incorporating additional description of decoration by Elizabeth Solopova, c. 2000. Previously described in the Quarto Catalogue (W. H. Black, <title>A descriptive, analytical, and critical catalogue of the manuscripts bequeathed unto the University of Oxford by Elias Ashmole Esq....</title>, Quarto Catalogues X, 1845). <listBibl>
-                              <bibl facs="aeh0010.gif" type="QUARTO">Quarto Catalogue X, col. 10 (no. 23)</bibl>
-                              <bibl facs="aaq0486.gif" type="SC">Summary Catalogue, vol. 2, part 2, p. 1127</bibl>
+                              <bibl><ref target="https://hdl.handle.net/2027/uc1.31158010681335?urlappend=%3Bseq=15">Quarto Catalogues X, col. 10 (no. 23)</ref></bibl>
+                              <bibl><ref target="https://hdl.handle.net/2027/mdp.39015008709282?urlappend=%3Bseq=489"><title>Summary Catalogue</title>, vol. 2, part 2, p. 1127</ref></bibl>
                            </listBibl>
                         </source>
                      </recordHist>
@@ -105,8 +105,8 @@
                         <note>(2 images from 35mm slides)</note></bibl></surrogates>
                   <listBibl type="WRAPPER">
                      <listBibl>
-                        <bibl>A. G. Watson, <title>Catalogue of Dated and Datable Manuscripts c.435–1600 in Oxford Libraries</title> (Oxford, 1984), no. 38</bibl>
-                        <bibl>Otto Pächt and J. J. G. Alexander, <title>Illuminated Manuscripts in the Bodleian Library Oxford</title>, III (1973), no. 535</bibl>
+                        <bibl><ref target="https://catalog.hathitrust.org/Record/000310664">A. G. Watson, <title>Catalogue of Dated and Datable Manuscripts c.435–1600 in Oxford Libraries</title> (Oxford, 1984), no. 38</ref></bibl>
+                        <bibl><ref target="https://catalog.hathitrust.org/Record/000468709">Otto Pächt and J. J. G. Alexander, <title>Illuminated Manuscripts in the Bodleian Library, Oxford</title>, III (1973), no. 535</ref></bibl>
                      </listBibl>
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>

--- a/collections/Ash_Rolls/MS_Ash_Rolls_38.xml
+++ b/collections/Ash_Rolls/MS_Ash_Rolls_38.xml
@@ -94,24 +94,21 @@
                <additional>
                   <adminInfo>
                      <recordHist>
-                        <source>Description adapted (2018) from Watson and Pächt and Alexander (see bibliography), incorporating additional description of decoration by Elizabeth Solopova, c. 2000. Previously described in the Quarto Catalogue (W. H. Black, <title>A descriptive, analytical, and critical catalogue of the manuscripts bequeathed unto the University of Oxford by Elias Ashmole Esq....</title>, Quarto Catalogues X, 1845). <listBibl>
-                              <bibl><ref target="https://hdl.handle.net/2027/uc1.31158010681335?urlappend=%3Bseq=15">Quarto Catalogues X, col. 10 (no. 23)</ref></bibl>
-                              <bibl><ref target="https://hdl.handle.net/2027/mdp.39015008709282?urlappend=%3Bseq=489"><title>Summary Catalogue</title>, vol. 2, part 2, p. 1127</ref></bibl>
-                           </listBibl>
-                        </source>
+                        <source>Description adapted (2018) from Watson and Pächt and Alexander (see bibliography), incorporating additional description of decoration by Elizabeth Solopova, c. 2000.</source>
                      </recordHist>
                   </adminInfo>
                   <surrogates><bibl subtype="partial" type="digital-facsimile"><ref target="https://digital.bodleian.ox.ac.uk/objects/ff06fc08-3038-429b-9d3d-f913160b972b/"><title>Digital Bodleian</title></ref>
                         <note>(2 images from 35mm slides)</note></bibl></surrogates>
-                  <listBibl type="WRAPPER">
-                     <listBibl>
-                        <bibl><ref target="https://catalog.hathitrust.org/Record/000310664">A. G. Watson, <title>Catalogue of Dated and Datable Manuscripts c.435–1600 in Oxford Libraries</title> (Oxford, 1984), no. 38</ref></bibl>
-                        <bibl><ref target="https://catalog.hathitrust.org/Record/000468709">Otto Pächt and J. J. G. Alexander, <title>Illuminated Manuscripts in the Bodleian Library, Oxford</title>, III (1973), no. 535</ref></bibl>
-                     </listBibl>
-                     <listBibl type="INTERNET">
-                        <head>Online resources:</head>
-                        <bibl><ref target="http://jonas.irht.cnrs.fr/manuscrit/39784"><title>JONAS: Répertoire des textes et des manuscrits médiévaux d'oc et d'oïl</title></ref></bibl>
-                     </listBibl>
+                  <listBibl>
+                     <bibl><ref target="https://hdl.handle.net/2027/uc1.31158010681335?urlappend=%3Bseq=15">Black, Henry, <title>A Descriptive, Analytical and Critical Catalogue of the Manuscripts Bequeathed unto the University of Oxford by Elias Ashmole</title>, Quarto Catalogues, 10 (Oxford, 1845), col. 10 (no. 23)</ref>
+                        <note>(full text open-access)</note></bibl>
+                     <bibl><ref target="http://jonas.irht.cnrs.fr/manuscrit/39784"><title>JONAS: Répertoire des textes et des manuscrits médiévaux d'oc et d'oïl</title></ref></bibl>
+                     <bibl><ref target="https://catalog.hathitrust.org/Record/000468709">Pächt, Otto, and J. J. G. Alexander, <title>Illuminated Manuscripts in the Bodleian Library, Oxford</title>, vol. III (Oxford, 1973), no. 535</ref>
+                        <note>(full text open-access)</note></bibl>
+                     <bibl><ref target="https://hdl.handle.net/2027/mdp.39015008709282?urlappend=%3Bseq=489"><title>A Summary Catalogue of Western Manuscripts in the Bodleian Library at Oxford</title>, vol. II, part 2 (Oxford, 1937), p. 1127 (no. 7079)</ref>
+                        <note>(full text open-access)</note></bibl>
+                     <bibl><ref target="https://catalog.hathitrust.org/Record/000310664">Watson, A. G., <title>Catalogue of Dated and Datable Manuscripts c.435–1600 in Oxford Libraries</title> (Oxford, 1984), no. 38</ref>
+                        <note>(full text open-access)</note></bibl>
                   </listBibl>
                </additional>
             </msDesc>

--- a/collections/Ash_Rolls/MS_Ash_Rolls_38.xml
+++ b/collections/Ash_Rolls/MS_Ash_Rolls_38.xml
@@ -74,7 +74,7 @@
                      </supportDesc>
                   </objectDesc>
                   <decoDesc>
-                     <decoNote resp="#PA" type="miniature">Good miniatures (coloured drawings), borders. (<ref target="https://catalog.hathitrust.org/Record/000468709">P&amp;A</ref> iii. 535)</decoNote>
+                     <decoNote resp="#PA" type="miniature">Good miniatures (coloured drawings), borders. (<ref target="https://catalog.hathitrust.org/Record/000468709">Pächt and Alexander</ref> iii. 535)</decoNote>
                      <decoNote resp="#DD" type="diagram">Coloured miniatures and diagrams, parts of text in red.</decoNote>
                      <decoNote resp="#ES">Miniature of King Edward I on the throne (damaged). Circular diagram showing the kingdoms of Heptarchy. Borders, framing the roll on either side, are illustrated with portraits and scenes from the lives of various rulers, kings and queens, begining with Brutus and Cormeus, and ending with Edward I and Edward II. Pen drawings of grotesques and folliage fill larger spaces between the lines of text.</decoNote>
                   </decoDesc>


### PR DESCRIPTION
This is a sample for finding the best way to link to HathiTrust for our printed catalogues rather than or as well as local GIF files.

The Watson and P&A catalogues are now available for anyone to view. As there are no page references, it's likely not a good use of time to try linking to precise locations.

We can also replace our GIF files of the *Summary Catalogue* and Quarto Catalogues with HathiTrust links. This has the advantages of allowing the user to scroll directly to other pages rather than needing a separate link for each image; giving a more accessible link through OCR availability; providing a higher-resolution image; and creating more consistent markup.