### PR TITLE
Add work subjects

### DIFF
--- a/collections/authority-schematron.sch
+++ b/collections/authority-schematron.sch
@@ -27,7 +27,7 @@
    </pattern>
    <pattern>
       <rule context="tei:text/tei:body/tei:listBibl/tei:bibl[not(tei:author)]">
-         <assert test="tei:note[@type = 'subject']">Works without an author should have one or more subject headings</assert>
+         <assert test="tei:term[@ref]">Works without an author should have one or more terms</assert>
       </rule>
    </pattern>
 </schema>

--- a/collections/authority-schematron.sch
+++ b/collections/authority-schematron.sch
@@ -29,5 +29,9 @@
       <rule context="tei:text/tei:body/tei:listBibl/tei:bibl[not(tei:author)]">
          <assert test="tei:term[@ref]">Works without an author should have one or more terms</assert>
       </rule>
+      <rule context="tei:term">
+         <let name="categoryids" value="/tei:TEI/tei:teiHeader/tei:encodingDesc/tei:classDecl/tei:taxonomy/tei:category/@xml:id"/>
+         <assert test="every $r in tokenize(@ref, '\s*#')[string-length() gt 0] satisfies $r = $categoryids">Term does not reference the ID of a category</assert>
+      </rule>
    </pattern>
 </schema>

--- a/processing/batch_conversion/add-work-subjects.xsl
+++ b/processing/batch_conversion/add-work-subjects.xsl
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+    xmlns="http://www.tei-c.org/ns/1.0"
+    xpath-default-namespace="http://www.tei-c.org/ns/1.0"
+    exclude-result-prefixes="xs map"
+    version="3.0">
+    
+    <!-- Load lookup file mapping work ID to subjects -->
+    <xsl:variable name="newsubjects" as="map(xs:string, xs:string*)">
+        <xsl:map>
+            <xsl:for-each select="tokenize(unparsed-text('work_subjects_june_2021.tsv', 'utf-8'), '\r?\n')[starts-with(., 'work_')]">
+                <xsl:variable name="columns" as="xs:string*" select="tokenize(., '\t')"/>
+                <xsl:map-entry key="$columns[1]" select="distinct-values($columns[position() gt 1][string-length() gt 0])"/>
+            </xsl:for-each>
+        </xsl:map>
+    </xsl:variable>
+
+    <!-- Root template -->
+    <xsl:template match="/">
+        <xsl:apply-templates/>
+    </xsl:template>
+    
+    <!-- Add new subject terms to works which don't currently have any -->
+    <xsl:template match="/TEI/text/body/listBibl/bibl[@xml:id and @xml:id = map:keys($newsubjects) and not(note[@type='subject'])]">
+        <xsl:copy>
+            <xsl:copy-of select="@*"/>
+            <xsl:apply-templates/>
+            <xsl:for-each select="map:get($newsubjects, @xml:id)">
+                <xsl:if test="position() eq 1">
+                    <xsl:text>  </xsl:text>
+                </xsl:if>
+                <term ref="{.}"/>
+                <xsl:value-of select="'&#10;'"/>
+                <xsl:choose>
+                    <xsl:when test="position() ne last()">
+                        <xsl:text>          </xsl:text>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:text>        </xsl:text>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:for-each>
+        </xsl:copy>
+    </xsl:template>
+    
+    <!-- Replace subjects in works that already have them, in the same place as before -->
+    <xsl:template match="/TEI/text/body/listBibl/bibl[@xml:id and @xml:id = map:keys($newsubjects)]/note[@type='subject'][not(preceding-sibling::note[@type='subject'])]">
+        <xsl:for-each select="map:get($newsubjects, parent::bibl/@xml:id)">
+            <term ref="{.}"/>
+            <xsl:if test="position() ne last()">
+                <xsl:value-of select="'&#10;'"/>
+                <xsl:text>          </xsl:text>
+            </xsl:if>
+        </xsl:for-each>
+    </xsl:template>
+    <xsl:template match="/TEI/text/body/listBibl/bibl[@xml:id and @xml:id = map:keys($newsubjects)]/note[@type='subject'][preceding-sibling::note[@type='subject']]"/>
+    
+    <!-- Convert subject notes to terms in works that aren't in the lookup file -->
+    <xsl:template match="/TEI/text/body/listBibl/bibl[@xml:id and not(@xml:id = map:keys($newsubjects))]/note[@type='subject']">
+        <term ref="#subject_{replace(normalize-space(lower-case(string())), '\s+', '_')}"/>
+    </xsl:template>
+    
+    <!-- Copy everything else as-is -->
+    <xsl:template match="*">
+        <xsl:copy>
+            <xsl:copy-of select="@*"/>
+            <xsl:apply-templates/>
+        </xsl:copy>
+    </xsl:template>
+    <xsl:template match="text()|comment()|processing-instruction()">
+        <xsl:copy/>
+    </xsl:template>
+    
+    
+</xsl:stylesheet>

--- a/processing/batch_conversion/work_subjects_june_2021.tsv
+++ b/processing/batch_conversion/work_subjects_june_2021.tsv
@@ -1,0 +1,11428 @@
+WORK ID	SUBJECT 1	SUBJECT 2	SUBJECT 3	SUBJECT 4	SUBJECT 5	SUBJECT 6	SUBJECT 7	SUBJECT 8	SUBJECT 9
+work_10915	#subject_history								
+work_11052	#subject_history								
+work_11053	#subject_law	#subject_geography	#subject_history						
+work_11054	#subject_law	#subject_geography	#subject_history						
+work_11055	#subject_history								
+work_11327	#subject_history								
+work_11730	#subject_law								
+work_12403	#subject_theology								
+work_13081	#subject_literature								
+work_194	#subject_history								
+work_13605	#subject_law								
+work_13986	#subject_documents	#subject_history							
+work_14045	#subject_philosophy	#subject_science							
+work_14182	#subject_bible								
+work_14183	#subject_law								
+work_17150	#subject_hagiography								
+work_14532	#subject_literature								
+work_14821	#subject_bible								
+work_14474	#subject_music	#subject_literature							
+work_14528	#subject_music	#subject_literature							
+work_14529	#subject_history								
+work_15350	#subject_christian_literature	#subject_monasticism_and_religious_orders							
+work_10433	#subject_hagiography								
+work_11550	#subject_science								
+work_13330	#subject_theology	#subject_christian_literature							
+work_13827	#subject_theology	#subject_christian_literature							
+work_14007	#subject_philosophy								
+work_14407	#subject_christian_literature								
+work_16199	#subject_christian_literature								
+work_15383	#subject_christian_literature	#subject_literature							
+work_10002	#subject_christian_literature								
+work_10003	#subject_christian_literature	#subject_theology							
+work_177844569	#subject_history								
+work_210	#subject_hagiography								
+work_10004	#subject_theology								
+work_10005	#subject_grammar								
+work_3490	#subject_theology								
+work_213	#subject_science								
+work_214	#subject_science								
+work_215	#subject_science								
+work_216	#subject_science								
+work_211	#subject_science								
+work_218	#subject_science								
+work_212	#subject_philosophy	#subject_science							
+work_10006	#subject_documents								
+work_10007	#subject_literature								
+work_17004	#subject_grammar								
+work_10008	#subject_theology	#subject_christian_literature							
+work_10009	#subject_documents								
+work_10010	#subject_documents								
+work_10011	#subject_documents								
+work_10012	#subject_documents								
+work_10013	#subject_documents								
+work_10014	#subject_documents								
+work_10015	#subject_documents								
+work_10016	#subject_documents								
+work_10017	#subject_documents								
+work_10018	#subject_history								
+work_10019	#subject_history								
+work_10020	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10021	#subject_geography								
+work_10022	#subject_documents								
+work_10023	#subject_documents								
+work_10024	#subject_documents								
+work_10025	#subject_documents								
+work_10026	#subject_documents								
+work_10027	#subject_history								
+work_10028	#subject_documents								
+work_10033	#subject_documents								
+work_10034	#subject_history								
+work_10035	#subject_history								
+work_10036	#subject_documents								
+work_10038	#subject_history	#subject_monasticism_and_religious_orders							
+work_10042	#subject_documents								
+work_10043	#subject_history	#subject_monasticism_and_religious_orders	#subject_hagiography						
+work_10044	#subject_documents								
+work_10045	#subject_documents								
+work_10046	#subject_documents								
+work_10047	#subject_documents								
+work_10048	#subject_documents								
+work_10049	#subject_documents								
+work_10050	#subject_documents								
+work_10051	#subject_documents								
+work_10052	#subject_geography								
+work_10054	#subject_documents								
+work_10056	#subject_documents								
+work_10057	#subject_documents								
+work_10029	#subject_history								
+work_10030	#subject_history								
+work_10031	#subject_history								
+work_10032	#subject_history								
+work_10037	#subject_history								
+work_10039	#subject_history								
+work_10040	#subject_history								
+work_10041	#subject_history	#subject_monasticism_and_religious_orders							
+work_10053	#subject_history								
+work_10055	#subject_history								
+work_10058	#subject_documents								
+work_10059	#subject_documents								
+work_10060	#subject_documents								
+work_10061	#subject_documents								
+work_10064	#subject_documents								
+work_10062	#subject_documents								
+work_10063	#subject_documents								
+work_10065	#subject_documents								
+work_10066	#subject_documents								
+work_10067	#subject_documents								
+work_10068	#subject_documents								
+work_10069	#subject_documents								
+work_10072	#subject_documents								
+work_10073	#subject_documents								
+work_10074	#subject_documents								
+work_10075	#subject_documents								
+work_10070	#subject_documents								
+work_10071	#subject_documents								
+work_10076	#subject_monasticism_and_religious_orders	#subject_documents							
+work_10077	#subject_documents								
+work_220	#subject_science								
+work_221	#subject_sermons								
+work_222	#subject_theology								
+work_223	#subject_classical_literature								
+work_10078	#subject_documents								
+work_10079	#subject_documents								
+work_10080	#subject_documents								
+work_10081	#subject_documents								
+work_10082	#subject_documents								
+work_10083	#subject_documents								
+work_10084	#subject_liturgy								
+work_978	#subject_conduct								
+work_979	#subject_philosophy								
+work_3820	#subject_classical_literature								
+work_10085	#subject_documents	#subject_law							
+work_10086	#subject_documents	#subject_law							
+work_10087	#subject_documents	#subject_law	#subject_hagiography						
+work_10088	#subject_documents								
+work_10089	#subject_documents	#subject_law	#subject_hagiography						
+work_10090	#subject_law	#subject_monasticism_and_religious_orders							
+work_15481	#subject_hagiography								
+work_16099	#subject_bible								
+work_2613	#subject_law								
+work_10102	#subject_clergy	#subject_law							
+work_10108	#subject_bible								
+work_10110	#subject_hagiography								
+work_10103	#subject_clergy								
+work_10104	#subject_clergy								
+work_10105	#subject_clergy	#subject_law							
+work_10106	#subject_documents								
+work_10107	#subject_clergy	#subject_law							
+work_10109	#subject_law								
+work_16288	#subject_hagiography								
+work_224	#subject_theology								
+work_225	#subject_rhetoric								
+work_6368	#subject_conduct								
+work_231	#subject_grammar								
+work_238	#subject_history								
+work_173	#subject_monasticism_and_religious_orders								
+work_229	#subject_hagiography								
+work_236	#subject_hagiography								
+work_237	#subject_hagiography								
+work_235	#subject_theology								
+work_232	#subject_philosophy								
+work_7207	#subject_philosophy								
+work_7206	#subject_philosophy								
+work_7214	#subject_philosophy								
+work_233	#subject_philosophy								
+work_7237	#subject_philosophy								
+work_234	#subject_theology	#subject_bible							
+work_239	#subject_grammar								
+work_230	#subject_theology								
+work_10113	#subject_documents								
+work_240	#subject_philosophy								
+work_5675	#subject_science								
+work_241	#subject_christian_literature								
+work_242	#subject_law								
+work_17093	#subject_documents								
+work_3414	#subject_law								
+work_243	#subject_theology								
+work_1748	#subject_medicine								
+work_1751	#subject_medicine								
+work_1759	#subject_theology								
+work_249	#subject_sermons								
+work_251	#subject_conduct								
+work_6439	#subject_theology	#subject_conduct							
+work_252	#subject_bible								
+work_253	#subject_hagiography								
+work_254	#subject_politics_and_government								
+work_255	#subject_politics_and_government								
+work_4141	#subject_christian_literature								
+work_261	#subject_philosophy								
+work_262	#subject_history								
+work_5959	#subject_monasticism_and_religious_orders								
+work_292	#subject_monasticism_and_religious_orders								
+work_263	#subject_monasticism_and_religious_orders								
+work_264	#subject_monasticism_and_religious_orders								
+work_265	#subject_sermons								
+work_266	#subject_theology								
+work_293	#subject_hagiography								
+work_268	#subject_theology	#subject_philosophy							
+work_273	#subject_classical_literature	#subject_rhetoric							
+work_274	#subject_classical_literature	#subject_rhetoric							
+work_275	#subject_classical_literature								
+work_276	#subject_classical_literature								
+work_277	#subject_classical_literature								
+work_5206	#subject_classical_literature								
+work_279	#subject_classical_literature								
+work_278	#subject_classical_literature								
+work_5200	#subject_classical_literature								
+work_280	#subject_classical_literature								
+work_5204	#subject_classical_literature								
+work_10114	#subject_grammar								
+work_16269	#subject_grammar								
+work_281	#subject_monasticism_and_religious_orders								
+work_174	#subject_natural_history								
+work_282	#subject_medicine								
+work_10116	#subject_documents								
+work_3134	#subject_law								
+work_4699	#subject_christian_literature								
+work_4700	#subject_rhetoric								
+work_283	#subject_politics_and_government								
+work_284	#subject_geography								
+work_287	#subject_monasticism_and_religious_orders								
+work_10117	#subject_documents								
+work_10118	#subject_documents								
+work_10119	#subject_documents								
+work_10120	#subject_documents								
+work_4471	#subject_literature								
+work_10121	#subject_history								
+work_288	#subject_grammar								
+work_3184	#subject_theology								
+work_3185	#subject_indexes								
+work_3608	#subject_theology								
+work_3609	#subject_christian_literature								
+work_3611	#subject_theology	#subject_politics_and_government							
+work_10122	#subject_literature								
+work_295	#subject_history								
+work_294	#subject_hagiography								
+work_6247	#subject_hagiography								
+work_10123	#subject_liturgy								
+work_10124	#subject_liturgy								
+work_305	#subject_sermons								
+work_311	#subject_philosophy								
+work_312	#subject_philosophy								
+work_313	#subject_theology								
+work_7434	#subject_theology	#subject_conduct							
+work_308	#subject_theology								
+work_314	#subject_theology								
+work_315	#subject_theology								
+work_309	#subject_theology								
+work_6281	#subject_literature	#subject_theology							
+work_310	#subject_sermons	#subject_rhetoric							
+work_306	#subject_literature								
+work_307	#subject_hagiography								
+work_1085	#subject_science								
+work_316	#subject_natural_history								
+work_318	#subject_law								
+work_326	#subject_history								
+work_322	#subject_theology								
+work_323	#subject_philosophy								
+work_321	#subject_theology								
+work_324	#subject_theology								
+work_2934	#subject_science								
+work_2935	#subject_science								
+work_2946	#subject_literature								
+work_350	#subject_monasticism_and_religious_orders	#subject_theology							
+work_356	#subject_medicine								
+work_352	#subject_philosophy								
+work_319	#subject_philosophy								
+work_7198	#subject_grammar								
+work_353	#subject_philosophy								
+work_354	#subject_science								
+work_349	#subject_bible								
+work_355	#subject_bible								
+work_3822	#subject_conduct								
+work_6156	#subject_bible								
+work_3821	#subject_theology								
+work_7102	#subject_bible								
+work_3823	#subject_theology								
+work_3824	#subject_science								
+work_3825	#subject_natural_history								
+work_3826	#subject_natural_history								
+work_327	#subject_philosophy								
+work_328	#subject_philosophy								
+work_7191	#subject_philosophy								
+work_7263	#subject_philosophy								
+work_7260	#subject_philosophy								
+work_7264	#subject_philosophy								
+work_7265	#subject_philosophy								
+work_7268	#subject_philosophy								
+work_7259	#subject_philosophy								
+work_7193	#subject_philosophy								
+work_7192	#subject_philosophy								
+work_7269	#subject_philosophy								
+work_329	#subject_philosophy								
+work_7267	#subject_philosophy								
+work_7266	#subject_philosophy								
+work_7270	#subject_philosophy								
+work_7257	#subject_philosophy								
+work_330	#subject_philosophy								
+work_7262	#subject_philosophy								
+work_7256	#subject_philosophy								
+work_332	#subject_philosophy								
+work_333	#subject_philosophy								
+work_334	#subject_philosophy								
+work_335	#subject_philosophy								
+work_336	#subject_philosophy								
+work_337	#subject_philosophy								
+work_7261	#subject_philosophy								
+work_338	#subject_philosophy								
+work_7254	#subject_philosophy								
+work_339	#subject_philosophy								
+work_340	#subject_philosophy								
+work_341	#subject_bible								
+work_342	#subject_philosophy								
+work_343	#subject_philosophy								
+work_344	#subject_philosophy								
+work_7255	#subject_philosophy								
+work_348	#subject_medicine	#subject_philosophy							
+work_345	#subject_science								
+work_347	#subject_philosophy								
+work_6432	#subject_philosophy								
+work_3827	#subject_philosophy								
+work_357	#subject_science								
+work_317	#subject_christian_literature								
+work_359	#subject_medicine								
+work_10126	#subject_literature								
+work_360	#subject_science								
+work_361	#subject_science								
+work_362	#subject_science								
+work_363	#subject_science								
+work_364	#subject_science								
+work_365	#subject_science								
+work_366	#subject_science								
+work_367	#subject_science								
+work_372	#subject_science								
+work_368	#subject_science								
+work_7248	#subject_science								
+work_369	#subject_science								
+work_370	#subject_science								
+work_371	#subject_science								
+work_373	#subject_science								
+work_3429	#subject_theology								
+work_10128	#subject_science								
+work_10129	#subject_medicine	#subject_science							
+work_10130	#subject_science								
+work_10131	#subject_science								
+work_10132	#subject_science								
+work_10133	#subject_science								
+work_10135	#subject_science								
+work_10136	#subject_science								
+work_10139	#subject_science								
+work_10140	#subject_science	#subject_literature							
+work_10141	#subject_science								
+work_10142	#subject_science								
+work_10143	#subject_science								
+work_10144	#subject_science								
+work_10145	#subject_science								
+work_10151	#subject_science								
+work_10155	#subject_science								
+work_10157	#subject_science								
+work_10158	#subject_science								
+work_10149	#subject_science								
+work_10147	#subject_science								
+work_10148	#subject_science								
+work_10150	#subject_science								
+work_10152	#subject_science								
+work_10153	#subject_science								
+work_10160	#subject_literature	#subject_science							
+work_10161	#subject_literature	#subject_science							
+work_10162	#subject_science								
+work_10163	#subject_science								
+work_10137	#subject_science	#subject_law	#subject_science						
+work_10138	#subject_science	#subject_medicine							
+work_10154	#subject_science								
+work_509	#subject_law								
+work_374	#subject_rhetoric								
+work_7413	#subject_literature								
+work_376	#subject_bible								
+work_377	#subject_philosophy								
+work_378	#subject_bible								
+work_6339	#subject_grammar								
+work_379	#subject_conduct								
+work_380	#subject_philosophy								
+work_381	#subject_conduct								
+work_382	#subject_bible								
+work_383	#subject_rhetoric								
+work_6211	#subject_hagiography								
+work_7505	#subject_theology								
+work_6151	#subject_liturgy								
+work_384	#subject_conduct								
+work_386	#subject_conduct								
+work_387	#subject_conduct								
+work_388	#subject_theology								
+work_7508	#subject_grammar								
+work_389	#subject_theology								
+work_392	#subject_medicine								
+work_390	#subject_medicine								
+work_391	#subject_theology								
+work_10164	#subject_literature								
+work_5958	#subject_bible								
+work_5627	#subject_conduct								
+work_409	#subject_science								
+work_410	#subject_grammar								
+work_411	#subject_science								
+work_396	#subject_theology								
+work_6371	#subject_theology								
+work_397	#subject_law								
+work_398	#subject_law								
+work_420	#subject_bible								
+work_414	#subject_philosophy								
+work_394	#subject_philosophy								
+work_412	#subject_philosophy								
+work_7247	#subject_philosophy								
+work_395	#subject_philosophy								
+work_413	#subject_philosophy								
+work_6087	#subject_philosophy	#subject_classical_literature							
+work_5631	#subject_bible								
+work_415	#subject_hagiography								
+work_416	#subject_hagiography	#subject_liturgy							
+work_6078	#subject_liturgy	#subject_bible							
+work_5613	#subject_conduct								
+work_417	#subject_grammar								
+work_418	#subject_theology								
+work_406	#subject_theology								
+work_419	#subject_medicine								
+work_3615	#subject_law								
+work_408	#subject_politics_and_government								
+work_7337	#subject_medicine								
+work_10165	#subject_literature								
+work_421	#subject_law								
+work_422	#subject_law								
+work_7332	#subject_medicine								
+work_443	#subject_documents								
+work_444	#subject_science								
+work_424	#subject_philosophy								
+work_425	#subject_natural_history								
+work_426	#subject_natural_history								
+work_427	#subject_natural_history								
+work_428	#subject_philosophy								
+work_429	#subject_history								
+work_430	#subject_philosophy								
+work_431	#subject_philosophy								
+work_432	#subject_philosophy								
+work_375	#subject_science								
+work_433	#subject_science								
+work_434	#subject_natural_history								
+work_7351	#subject_science								
+work_10166	#subject_theology								
+work_10167	#subject_literature								
+work_10168	#subject_clergy	#subject_bible	#subject_history						
+work_10169	#subject_theology								
+work_10170	#subject_theology	#subject_hagiography							
+work_10171	#subject_bible								
+work_10172	#subject_bible	#subject_theology							
+work_10173	#subject_theology								
+work_5954	#subject_theology								
+work_4349	#subject_philosophy								
+work_10174	#subject_literature								
+work_10175	#subject_science								
+work_442	#subject_science								
+work_10176	#subject_grammar								
+work_10178	#subject_indexes								
+work_17067	#subject_indexes								
+work_17065	#subject_indexes								
+work_17066	#subject_indexes								
+work_10179	#subject_medicine								
+work_10181	#subject_grammar								
+work_10182	#subject_medicine								
+work_445	#subject_sermons								
+work_10183	#subject_literature	#subject_literature							
+work_10184	#subject_literature								
+work_447	#subject_rhetoric								
+work_448	#subject_liturgy								
+work_449	#subject_liturgy								
+work_450	#subject_liturgy								
+work_1179	#subject_history	#subject_literature							
+work_5153	#subject_classical_literature								
+work_3829	#subject_theology								
+work_3830	#subject_theology								
+work_3831	#subject_theology								
+work_5133	#subject_theology								
+work_6214	#subject_hagiography								
+work_3832	#subject_theology								
+work_3833	#subject_theology								
+work_6456	#subject_theology								
+work_452	#subject_bible								
+work_453	#subject_bible								
+work_454	#subject_bible								
+work_455	#subject_theology								
+work_456	#subject_theology								
+work_457	#subject_theology								
+work_6607	#subject_theology								
+work_458	#subject_bible								
+work_6609	#subject_bible								
+work_459	#subject_liturgy	#subject_theology	#subject_clergy						
+work_460	#subject_bible								
+work_6608	#subject_theology								
+work_462	#subject_theology								
+work_463	#subject_theology								
+work_6610	#subject_theology								
+work_464	#subject_theology								
+work_465	#subject_theology								
+work_466	#subject_theology								
+work_467	#subject_theology								
+work_468	#subject_liturgy	#subject_theology	#subject_clergy						
+work_469	#subject_theology								
+work_470	#subject_theology								
+work_472	#subject_theology								
+work_473	#subject_theology								
+work_475	#subject_theology								
+work_482	#subject_theology								
+work_476	#subject_theology								
+work_477	#subject_bible								
+work_478	#subject_bible								
+work_480	#subject_theology								
+work_484	#subject_theology								
+work_485	#subject_theology								
+work_487	#subject_bible								
+work_1970	#subject_medicine								
+work_10185	#subject_literature								
+work_6094	#subject_grammar								
+work_6095	#subject_grammar								
+work_491	#subject_grammar								
+work_492	#subject_philosophy								
+work_5879	#subject_theology								
+work_5703	#subject_theology								
+work_494	#subject_hagiography								
+work_16016	#subject_bible								
+work_5798	#subject_sermons								
+work_6174	#subject_history	#subject_theology							
+work_6040	#subject_theology								
+work_501	#subject_theology								
+work_498	#subject_bible								
+work_499	#subject_theology								
+work_6149	#subject_theology								
+work_6082	#subject_science								
+work_6238	#subject_science								
+work_502	#subject_rhetoric	#subject_classical_literature							
+work_10186	#subject_monasticism_and_religious_orders								
+work_507	#subject_literature								
+work_506	#subject_literature								
+work_7190	#subject_philosophy								
+work_587	#subject_philosophy								
+work_510	#subject_literature								
+work_516	#subject_bible								
+work_517	#subject_bible								
+work_5855	#subject_theology								
+work_5801	#subject_sermons								
+work_5876	#subject_hagiography								
+work_518	#subject_philosophy								
+work_6004	#subject_theology								
+work_519	#subject_christian_literature								
+work_525	#subject_science								
+work_10187	#subject_christian_literature								
+work_10188	#subject_history								
+work_10189	#subject_history								
+work_10195	#subject_history								
+work_10192	#subject_monasticism_and_religious_orders	#subject_documents	#subject_history						
+work_10193	#subject_history								
+work_10196	#subject_history								
+work_10190	#subject_history								
+work_10191	#subject_history								
+work_10198	#subject_documents								
+work_16369	#subject_politics_and_government								
+work_526	#subject_monasticism_and_religious_orders								
+work_548	#subject_bible								
+work_549	#subject_bible								
+work_3834	#subject_theology								
+work_3835	#subject_theology								
+work_3840	#subject_theology								
+work_3841	#subject_theology								
+work_3837	#subject_theology								
+work_3838	#subject_theology								
+work_3839	#subject_theology								
+work_527	#subject_theology								
+work_528	#subject_theology								
+work_529	#subject_theology								
+work_530	#subject_theology								
+work_531	#subject_theology								
+work_542	#subject_theology								
+work_5763	#subject_theology								
+work_5765	#subject_liturgy	#subject_theology	#subject_clergy						
+work_5764	#subject_theology								
+work_532	#subject_theology								
+work_533	#subject_theology								
+work_534	#subject_theology								
+work_535	#subject_theology								
+work_545	#subject_theology								
+work_543	#subject_theology								
+work_536	#subject_theology								
+work_5748	#subject_theology								
+work_546	#subject_theology								
+work_547	#subject_theology								
+work_537	#subject_theology								
+work_544	#subject_theology								
+work_538	#subject_theology								
+work_5766	#subject_grammar								
+work_5769	#subject_theology								
+work_540	#subject_theology								
+work_541	#subject_theology								
+work_550	#subject_sermons								
+work_10199	#subject_literature								
+work_10200	#subject_liturgy								
+work_10202	#subject_literature	#subject_theology							
+work_551	#subject_theology	#subject_monasticism_and_religious_orders							
+work_10203	#subject_monasticism_and_religious_orders								
+work_10204	#subject_documents								
+work_16311	#subject_medicine								
+work_10205	#subject_medicine								
+work_553	#subject_christian_literature								
+work_552	#subject_sermons								
+work_554	#subject_classical_literature								
+work_10206	#subject_liturgy								
+work_10216	#subject_liturgy								
+work_10207	#subject_liturgy	#subject_music							
+work_10211	#subject_liturgy								
+work_10209	#subject_liturgy								
+work_10210	#subject_liturgy								
+work_10212	#subject_liturgy								
+work_10213	#subject_liturgy								
+work_10214	#subject_liturgy								
+work_10215	#subject_liturgy								
+work_10219	#subject_liturgy								
+work_10220	#subject_liturgy								
+work_10221	#subject_liturgy								
+work_10222	#subject_history	#subject_documents							
+work_588	#subject_geography								
+work_559	#subject_theology								
+work_560	#subject_theology								
+work_561	#subject_theology								
+work_562	#subject_theology								
+work_563	#subject_liturgy								
+work_564	#subject_law								
+work_565	#subject_theology	#subject_law							
+work_566	#subject_law								
+work_567	#subject_theology								
+work_568	#subject_theology								
+work_558	#subject_law	#subject_theology							
+work_569	#subject_law								
+work_556	#subject_law								
+work_570	#subject_law								
+work_571	#subject_law								
+work_572	#subject_law								
+work_573	#subject_law								
+work_574	#subject_theology								
+work_5650	#subject_literature								
+work_575	#subject_literature								
+work_577	#subject_christian_literature								
+work_606	#subject_literature								
+work_598	#subject_theology								
+work_589	#subject_grammar								
+work_5652	#subject_literature								
+work_5866	#subject_hagiography								
+work_608	#subject_philosophy								
+work_599	#subject_medicine								
+work_609	#subject_classical_literature	#subject_science							
+work_610	#subject_classical_literature	#subject_rhetoric							
+work_6416	#subject_classical_literature								
+work_611	#subject_classical_literature								
+work_10241	#subject_literature	#subject_literature							
+work_10243	#subject_bible								
+work_10246	#subject_bible								
+work_10247	#subject_bible								
+work_10249	#subject_bible								
+work_10248	#subject_bible								
+work_10250	#subject_hagiography	#subject_hagiography	#subject_bible						
+work_612	#subject_medicine								
+work_5688	#subject_sermons								
+work_3843	#subject_bible	#subject_christian_literature							
+work_3844	#subject_classical_literature								
+work_10251	#subject_literature								
+work_621	#subject_rhetoric								
+work_619	#subject_science								
+work_618	#subject_classical_literature								
+work_620	#subject_classical_literature	#subject_philosophy							
+work_615	#subject_classical_literature								
+work_616	#subject_classical_literature								
+work_617	#subject_grammar								
+work_10253	#subject_monasticism_and_religious_orders	#subject_literature							
+work_10254	#subject_literature	#subject_monasticism_and_religious_orders							
+work_10255	#subject_monasticism_and_religious_orders	#subject_literature							
+work_10256	#subject_literature	#subject_monasticism_and_religious_orders							
+work_16296	#subject_theology								
+work_6355	#subject_philosophy								
+work_6354	#subject_theology								
+work_6351	#subject_literature								
+work_6357	#subject_literature								
+work_6356	#subject_literature								
+work_6353	#subject_literature								
+work_6352	#subject_liturgy								
+work_3186	#subject_literature								
+work_10258	#subject_science								
+work_623	#subject_history								
+work_622	#subject_history								
+work_10259	#subject_documents								
+work_10261	#subject_documents								
+work_10264	#subject_documents								
+work_10260	#subject_documents								
+work_10262	#subject_documents								
+work_10263	#subject_documents								
+work_10265	#subject_documents								
+work_10266	#subject_documents								
+work_10267	#subject_documents								
+work_10268	#subject_documents								
+work_3845	#subject_science								
+work_10269	#subject_documents								
+work_3846	#subject_medicine								
+work_3847	#subject_medicine								
+work_7103	#subject_classical_literature								
+work_624	#subject_classical_literature								
+work_625	#subject_classical_literature								
+work_626	#subject_classical_literature								
+work_7377	#subject_philosophy								
+work_4129	#subject_philosophy								
+work_4130	#subject_liturgy	#subject_theology	#subject_clergy						
+work_4131	#subject_theology								
+work_4785	#subject_theology								
+work_4753	#subject_bible								
+work_4754	#subject_theology	#subject_bible							
+work_5614	#subject_philosophy								
+work_4755	#subject_philosophy								
+work_4756	#subject_philosophy								
+work_7240	#subject_philosophy								
+work_7242	#subject_philosophy								
+work_7231	#subject_philosophy								
+work_7217	#subject_philosophy								
+work_7219	#subject_philosophy								
+work_7229	#subject_philosophy								
+work_7227	#subject_philosophy								
+work_7215	#subject_philosophy								
+work_4757	#subject_theology								
+work_4758	#subject_philosophy								
+work_4759	#subject_theology								
+work_4760	#subject_theology								
+work_4762	#subject_theology								
+work_4763	#subject_theology								
+work_4764	#subject_theology								
+work_4765	#subject_liturgy	#subject_theology	#subject_clergy						
+work_4766	#subject_philosophy								
+work_4767	#subject_philosophy								
+work_5955	#subject_theology								
+work_4768	#subject_theology								
+work_7201	#subject_natural_history								
+work_4769	#subject_theology								
+work_4770	#subject_natural_history								
+work_4784	#subject_theology								
+work_4771	#subject_theology								
+work_5957	#subject_theology								
+work_7232	#subject_theology								
+work_7070	#subject_theology	#subject_liturgy							
+work_4773	#subject_theology	#subject_bible							
+work_4774	#subject_philosophy								
+work_4775	#subject_theology								
+work_4776	#subject_theology								
+work_4778	#subject_theology								
+work_4779	#subject_theology								
+work_4781	#subject_theology								
+work_4780	#subject_theology								
+work_5803	#subject_indexes								
+work_4782	#subject_theology								
+work_4783	#subject_theology								
+work_10270	#subject_theology								
+work_627	#subject_history	#subject_theology							
+work_7501	#subject_literature								
+work_628	#subject_science								
+work_17012	#subject_law								
+work_16372	#subject_theology								
+work_629	#subject_medicine								
+work_630	#subject_science								
+work_5635	#subject_hagiography								
+work_2614	#subject_medicine								
+work_3612	#subject_medicine								
+work_2616	#subject_medicine								
+work_10271	#subject_literature								
+work_393	#subject_geography								
+work_1535	#subject_literature								
+work_1536	#subject_literature								
+work_6180	#subject_science	#subject_classical_literature							
+work_633	#subject_music								
+work_172	#subject_classical_literature								
+work_291	#subject_classical_literature								
+work_1	#subject_classical_literature								
+work_15	#subject_classical_literature								
+work_30	#subject_classical_literature								
+work_31	#subject_classical_literature								
+work_32	#subject_classical_literature								
+work_56	#subject_classical_literature								
+work_57	#subject_classical_literature								
+work_59	#subject_classical_literature								
+work_81	#subject_classical_literature								
+work_83	#subject_classical_literature								
+work_84	#subject_classical_literature								
+work_85	#subject_classical_literature								
+work_87	#subject_classical_literature								
+work_90	#subject_classical_literature								
+work_94	#subject_classical_literature								
+work_95	#subject_classical_literature								
+work_100	#subject_classical_literature								
+work_631	#subject_classical_literature								
+work_257	#subject_classical_literature								
+work_117	#subject_classical_literature								
+work_118	#subject_classical_literature								
+work_119	#subject_classical_literature								
+work_124	#subject_classical_literature								
+work_126	#subject_classical_literature								
+work_256	#subject_classical_literature								
+work_131	#subject_classical_literature								
+work_632	#subject_classical_literature								
+work_634	#subject_literature								
+work_635	#subject_literature								
+work_636	#subject_literature								
+work_637	#subject_literature								
+work_639	#subject_literature								
+work_6314	#subject_philosophy								
+work_3849	#subject_philosophy								
+work_5673	#subject_philosophy								
+work_3850	#subject_philosophy								
+work_5626	#subject_philosophy								
+work_3851	#subject_philosophy								
+work_5625	#subject_philosophy								
+work_5671	#subject_philosophy								
+work_3853	#subject_philosophy								
+work_3854	#subject_philosophy								
+work_3855	#subject_philosophy								
+work_3856	#subject_philosophy								
+work_3857	#subject_philosophy								
+work_5735	#subject_politics_and_government								
+work_3860	#subject_philosophy								
+work_5649	#subject_politics_and_government								
+work_3861	#subject_philosophy								
+work_3858	#subject_philosophy								
+work_3859	#subject_philosophy								
+work_3862	#subject_philosophy								
+work_3863	#subject_philosophy								
+work_12	#subject_philosophy								
+work_641	#subject_philosophy								
+work_13	#subject_philosophy								
+work_642	#subject_philosophy								
+work_6427	#subject_philosophy								
+work_643	#subject_philosophy								
+work_7275	#subject_philosophy								
+work_644	#subject_philosophy								
+work_646	#subject_philosophy								
+work_645	#subject_philosophy								
+work_647	#subject_philosophy								
+work_648	#subject_philosophy								
+work_649	#subject_philosophy								
+work_43	#subject_philosophy								
+work_650	#subject_philosophy								
+work_7236	#subject_philosophy								
+work_7292	#subject_philosophy								
+work_7230	#subject_philosophy								
+work_651	#subject_philosophy								
+work_7228	#subject_philosophy								
+work_652	#subject_philosophy								
+work_653	#subject_philosophy								
+work_5932	#subject_philosophy								
+work_654	#subject_philosophy								
+work_655	#subject_philosophy								
+work_6410	#subject_philosophy								
+work_656	#subject_philosophy								
+work_657	#subject_philosophy								
+work_658	#subject_philosophy								
+work_659	#subject_philosophy								
+work_660	#subject_philosophy								
+work_661	#subject_philosophy								
+work_5622	#subject_philosophy								
+work_5623	#subject_philosophy								
+work_5624	#subject_philosophy								
+work_662	#subject_philosophy								
+work_663	#subject_philosophy								
+work_7150	#subject_philosophy								
+work_664	#subject_philosophy								
+work_665	#subject_philosophy								
+work_666	#subject_philosophy								
+work_667	#subject_philosophy								
+work_7295	#subject_philosophy								
+work_668	#subject_philosophy								
+work_669	#subject_philosophy								
+work_670	#subject_philosophy								
+work_671	#subject_philosophy								
+work_6444	#subject_philosophy								
+work_672	#subject_philosophy								
+work_673	#subject_philosophy								
+work_5651	#subject_rhetoric								
+work_674	#subject_philosophy								
+work_640	#subject_philosophy								
+work_132	#subject_philosophy								
+work_675	#subject_philosophy								
+work_139	#subject_philosophy								
+work_676	#subject_philosophy								
+work_678	#subject_philosophy								
+work_679	#subject_philosophy								
+work_10273	#subject_science								
+work_10274	#subject_science								
+work_10275	#subject_science								
+work_10276	#subject_science								
+work_10277	#subject_science								
+work_10278	#subject_science								
+work_10279	#subject_heraldry								
+work_10280	#subject_heraldry								
+work_682	#subject_theology								
+work_683	#subject_theology								
+work_684	#subject_theology								
+work_685	#subject_sermons								
+work_686	#subject_theology								
+work_6272	#subject_philosophy								
+work_3866	#subject_medicine								
+work_7394	#subject_medicine								
+work_6098	#subject_medicine	#subject_science							
+work_3864	#subject_history								
+work_3865	#subject_science								
+work_7168	#subject_medicine								
+work_7169	#subject_medicine								
+work_7172	#subject_medicine								
+work_7170	#subject_medicine								
+work_687	#subject_medicine								
+work_689	#subject_medicine								
+work_688	#subject_medicine								
+work_7171	#subject_medicine	#subject_philosophy							
+work_691	#subject_medicine								
+work_692	#subject_bible								
+work_694	#subject_medicine								
+work_693	#subject_medicine								
+work_695	#subject_medicine								
+work_698	#subject_law								
+work_680	#subject_liturgy								
+work_6090	#subject_sermons								
+work_697	#subject_natural_history								
+work_702	#subject_literature								
+work_703	#subject_theology								
+work_700	#subject_classical_literature								
+work_701	#subject_monasticism_and_religious_orders								
+work_699	#subject_science								
+work_704	#subject_history								
+work_705	#subject_philosophy								
+work_706	#subject_geography								
+work_10281	#subject_medicine								
+work_10282	#subject_medicine								
+work_10283	#subject_science								
+work_10284	#subject_science								
+work_16294	#subject_christian_literature	#subject_theology							
+work_10285	#subject_christian_literature	#subject_theology							
+work_16290	#subject_sermons								
+work_708	#subject_theology								
+work_10286	#subject_documents								
+work_10287	#subject_documents								
+work_10288	#subject_literature								
+work_10289	#subject_literature								
+work_10290	#subject_documents								
+work_10291	#subject_documents								
+work_10294	#subject_law								
+work_10292	#subject_theology								
+work_10293	#subject_theology								
+work_10295	#subject_heraldry								
+work_10296	#subject_documents								
+work_10297	#subject_documents								
+work_10298	#subject_theology								
+work_10299	#subject_theology								
+work_10300	#subject_theology								
+work_10301	#subject_theology								
+work_10302	#subject_theology								
+work_7335	#subject_medicine								
+work_714	#subject_science								
+work_7334	#subject_medicine								
+work_3480	#subject_classical_literature								
+work_715	#subject_politics_and_government								
+work_5905	#subject_science								
+work_10305	#subject_documents								
+work_10306	#subject_documents								
+work_10307	#subject_documents								
+work_10308	#subject_documents								
+work_10309	#subject_law								
+work_17146	#subject_law								
+work_17147	#subject_law								
+work_17148	#subject_law								
+work_716	#subject_sermons	#subject_bible							
+work_5910	#subject_sermons	#subject_hagiography							
+work_5667	#subject_hagiography								
+work_5988	#subject_bible								
+work_717	#subject_law	#subject_theology							
+work_10310	#subject_science								
+work_10312	#subject_science								
+work_10315	#subject_science								
+work_10313	#subject_science								
+work_10314	#subject_science								
+work_10316	#subject_science								
+work_10318	#subject_history	#subject_science							
+work_10319	#subject_science								
+work_10320	#subject_science	#subject_medicine							
+work_10321	#subject_science								
+work_10322	#subject_science								
+work_10323	#subject_science	#subject_literature							
+work_10324	#subject_science								
+work_10326	#subject_science								
+work_10327	#subject_science								
+work_10328	#subject_science								
+work_10329	#subject_science								
+work_10331	#subject_science								
+work_10332	#subject_science								
+work_10333	#subject_science								
+work_10334	#subject_science								
+work_10335	#subject_science								
+work_10336	#subject_science								
+work_10343	#subject_science								
+work_10344	#subject_science								
+work_10345	#subject_science								
+work_10346	#subject_science								
+work_16030	#subject_science								
+work_10338	#subject_science								
+work_10342	#subject_science								
+work_10349	#subject_science	#subject_medicine							
+work_10337	#subject_science								
+work_10339	#subject_science								
+work_10340	#subject_science								
+work_10341	#subject_science								
+work_10350	#subject_science								
+work_10351	#subject_science								
+work_10352	#subject_science								
+work_10353	#subject_literature	#subject_science							
+work_10354	#subject_science								
+work_10325	#subject_science	#subject_music	#subject_science	#subject_rhetoric					
+work_10330	#subject_science	#subject_science							
+work_10347	#subject_theology	#subject_science							
+work_10355	#subject_science								
+work_10356	#subject_science								
+work_10357	#subject_science								
+work_10358	#subject_science								
+work_10360	#subject_science								
+work_10359	#subject_science								
+work_10361	#subject_science								
+work_10362	#subject_science								
+work_10363	#subject_science	#subject_science							
+work_10364	#subject_science	#subject_science							
+work_10365	#subject_science								
+work_10366	#subject_science	#subject_science							
+work_10367	#subject_science	#subject_music							
+work_10368	#subject_science								
+work_10369	#subject_science								
+work_10370	#subject_science	#subject_science							
+work_10373	#subject_science								
+work_10374	#subject_science	#subject_science							
+work_10375	#subject_science	#subject_science							
+work_10376	#subject_science	#subject_science							
+work_10378	#subject_science	#subject_science							
+work_10377	#subject_science								
+work_10380	#subject_science								
+work_10381	#subject_science								
+work_10382	#subject_science								
+work_10383	#subject_science								
+work_10384	#subject_science								
+work_10388	#subject_science	#subject_magic							
+work_10389	#subject_science								
+work_10392	#subject_science								
+work_10393	#subject_science								
+work_10394	#subject_science								
+work_10395	#subject_science								
+work_10396	#subject_science								
+work_10397	#subject_science								
+work_10398	#subject_science								
+work_10399	#subject_science								
+work_10400	#subject_science								
+work_10401	#subject_science								
+work_10402	#subject_science								
+work_10403	#subject_science	#subject_science							
+work_10390	#subject_science								
+work_10391	#subject_science								
+work_10404	#subject_science								
+work_10411	#subject_science								
+work_10412	#subject_science								
+work_10413	#subject_science								
+work_10414	#subject_science	#subject_natural_history							
+work_10406	#subject_science								
+work_10407	#subject_science								
+work_10408	#subject_science								
+work_10415	#subject_science								
+work_10405	#subject_science								
+work_10409	#subject_science								
+work_10410	#subject_science								
+work_10416	#subject_science								
+work_10417	#subject_science								
+work_10418	#subject_science								
+work_10372	#subject_science	#subject_science							
+work_10379	#subject_medicine	#subject_bible	#subject_science	#subject_science					
+work_10385	#subject_science	#subject_grammar	#subject_philosophy						
+work_10386	#subject_science	#subject_science	#subject_history						
+work_10387	#subject_science	#subject_music							
+work_10421	#subject_theology								
+work_10420	#subject_theology								
+work_724	#subject_law								
+work_5891	#subject_theology								
+work_5892	#subject_theology								
+work_5154	#subject_theology								
+work_720	#subject_hagiography								
+work_6007	#subject_theology								
+work_5894	#subject_theology								
+work_6312	#subject_monasticism_and_religious_orders								
+work_722	#subject_theology								
+work_721	#subject_theology								
+work_5898	#subject_theology								
+work_5884	#subject_theology								
+work_3867	#subject_theology								
+work_5663	#subject_theology								
+work_5896	#subject_theology								
+work_6048	#subject_theology								
+work_5731	#subject_theology								
+work_5900	#subject_theology								
+work_5847	#subject_theology								
+work_6006	#subject_theology								
+work_3868	#subject_theology								
+work_5901	#subject_theology								
+work_5899	#subject_theology								
+work_3869	#subject_theology								
+work_5887	#subject_theology								
+work_6011	#subject_theology								
+work_6012	#subject_theology								
+work_6008	#subject_theology								
+work_5893	#subject_theology								
+work_5885	#subject_theology								
+work_6010	#subject_theology								
+work_5897	#subject_theology								
+work_6009	#subject_theology								
+work_727	#subject_theology								
+work_5889	#subject_theology								
+work_5890	#subject_theology								
+work_5895	#subject_theology								
+work_5882	#subject_theology								
+work_728	#subject_theology								
+work_5883	#subject_theology								
+work_5886	#subject_theology								
+work_718	#subject_theology								
+work_5155	#subject_theology								
+work_725	#subject_hagiography								
+work_726	#subject_theology								
+work_723	#subject_theology								
+work_6419	#subject_classical_literature								
+work_6114	#subject_theology								
+work_6115	#subject_theology	#subject_philosophy							
+work_10424	#subject_documents								
+work_10425	#subject_theology								
+work_14319	#subject_literature								
+work_2619	#subject_literature								
+work_2453	#subject_law								
+work_830	#subject_theology								
+work_5832	#subject_theology								
+work_3882	#subject_theology								
+work_3890	#subject_theology								
+work_3871	#subject_theology								
+work_6453	#subject_theology								
+work_3872	#subject_theology								
+work_3873	#subject_theology								
+work_5771	#subject_theology								
+work_3874	#subject_theology								
+work_3875	#subject_theology								
+work_759	#subject_theology								
+work_3876	#subject_theology								
+work_7344	#subject_theology								
+work_5774	#subject_theology								
+work_3878	#subject_theology								
+work_6283	#subject_theology								
+work_3879	#subject_theology								
+work_7435	#subject_theology								
+work_6100	#subject_theology								
+work_3880	#subject_theology								
+work_3881	#subject_theology								
+work_3883	#subject_theology								
+work_5776	#subject_theology								
+work_3885	#subject_theology								
+work_3886	#subject_theology								
+work_3888	#subject_theology								
+work_3887	#subject_theology								
+work_6184	#subject_theology								
+work_3889	#subject_theology								
+work_3893	#subject_theology								
+work_3894	#subject_theology								
+work_3897	#subject_theology								
+work_3895	#subject_theology								
+work_3896	#subject_theology								
+work_3898	#subject_theology								
+work_3899	#subject_theology								
+work_7112	#subject_theology								
+work_3901	#subject_theology								
+work_3902	#subject_theology								
+work_3903	#subject_theology								
+work_7113	#subject_theology								
+work_3904	#subject_theology								
+work_3905	#subject_theology								
+work_3906	#subject_theology								
+work_3907	#subject_theology								
+work_3908	#subject_theology								
+work_3909	#subject_theology								
+work_3912	#subject_theology								
+work_3913	#subject_theology								
+work_3915	#subject_theology								
+work_5808	#subject_theology								
+work_5945	#subject_theology								
+work_5949	#subject_bible								
+work_5947	#subject_theology								
+work_729	#subject_theology								
+work_730	#subject_theology								
+work_832	#subject_theology								
+work_739	#subject_theology								
+work_5753	#subject_theology								
+work_740	#subject_theology								
+work_6286	#subject_theology								
+work_741	#subject_theology								
+work_742	#subject_theology								
+work_5946	#subject_theology								
+work_743	#subject_theology								
+work_744	#subject_theology								
+work_745	#subject_theology								
+work_746	#subject_theology								
+work_5779	#subject_theology								
+work_6077	#subject_theology								
+work_747	#subject_theology								
+work_748	#subject_theology								
+work_749	#subject_theology								
+work_750	#subject_theology								
+work_751	#subject_theology								
+work_753	#subject_theology								
+work_752	#subject_theology								
+work_754	#subject_theology								
+work_756	#subject_theology								
+work_757	#subject_theology								
+work_758	#subject_theology								
+work_760	#subject_theology								
+work_761	#subject_theology								
+work_5810	#subject_theology								
+work_762	#subject_theology								
+work_5782	#subject_theology								
+work_6150	#subject_theology								
+work_763	#subject_theology								
+work_6602	#subject_theology								
+work_5752	#subject_theology								
+work_764	#subject_theology								
+work_833	#subject_theology								
+work_5948	#subject_theology								
+work_766	#subject_theology								
+work_765	#subject_theology								
+work_5780	#subject_theology								
+work_5809	#subject_theology								
+work_767	#subject_theology								
+work_768	#subject_theology								
+work_769	#subject_theology								
+work_6606	#subject_theology								
+work_770	#subject_theology								
+work_5811	#subject_theology								
+work_5804	#subject_theology								
+work_771	#subject_theology								
+work_5791	#subject_theology								
+work_772	#subject_theology								
+work_773	#subject_theology								
+work_5807	#subject_theology								
+work_774	#subject_theology								
+work_775	#subject_monasticism_and_religious_orders								
+work_776	#subject_theology								
+work_5772	#subject_theology								
+work_834	#subject_theology								
+work_5790	#subject_theology								
+work_5781	#subject_theology								
+work_777	#subject_theology								
+work_778	#subject_theology								
+work_779	#subject_theology								
+work_780	#subject_theology								
+work_835	#subject_theology								
+work_784	#subject_theology								
+work_783	#subject_theology								
+work_785	#subject_theology								
+work_786	#subject_theology								
+work_5751	#subject_theology								
+work_5814	#subject_theology								
+work_805	#subject_theology								
+work_787	#subject_theology								
+work_790	#subject_theology								
+work_736	#subject_theology								
+work_789	#subject_theology								
+work_792	#subject_theology								
+work_791	#subject_theology								
+work_793	#subject_theology								
+work_5805	#subject_theology								
+work_6147	#subject_theology								
+work_794	#subject_theology								
+work_5802	#subject_theology								
+work_801	#subject_theology								
+work_6363	#subject_theology								
+work_737	#subject_theology								
+work_5840	#subject_theology								
+work_797	#subject_theology								
+work_800	#subject_theology								
+work_802	#subject_theology								
+work_5778	#subject_theology								
+work_803	#subject_theology								
+work_804	#subject_theology								
+work_806	#subject_theology								
+work_807	#subject_theology								
+work_6284	#subject_sermons								
+work_808	#subject_theology								
+work_809	#subject_theology								
+work_6274	#subject_sermons								
+work_7358	#subject_sermons								
+work_810	#subject_theology								
+work_811	#subject_theology								
+work_7380	#subject_sermons								
+work_812	#subject_theology								
+work_5806	#subject_theology								
+work_5786	#subject_theology								
+work_5788	#subject_theology								
+work_815	#subject_theology								
+work_816	#subject_theology								
+work_5775	#subject_theology								
+work_818	#subject_theology								
+work_820	#subject_theology								
+work_821	#subject_theology								
+work_822	#subject_theology								
+work_824	#subject_theology								
+work_839	#subject_christian_literature								
+work_837	#subject_bible								
+work_285	#subject_bible								
+work_6270	#subject_bible								
+work_6271	#subject_bible								
+work_7362	#subject_bible								
+work_7072	#subject_theology	#subject_politics_and_government							
+work_838	#subject_theology								
+work_10426	#subject_literature								
+work_841	#subject_literature								
+work_5754	#subject_bible								
+work_3574	#subject_theology	#subject_bible							
+work_3575	#subject_bible								
+work_843	#subject_literature								
+work_7424	#subject_literature								
+work_10427	#subject_documents								
+work_10428	#subject_literature	#subject_theology	#subject_theology						
+work_844	#subject_natural_history								
+work_488	#subject_bible								
+work_489	#subject_theology								
+work_7091	#subject_sermons								
+work_845	#subject_philosophy								
+work_10429	#subject_theology	#subject_theology							
+work_7252	#subject_philosophy								
+work_846	#subject_philosophy								
+work_848	#subject_philosophy								
+work_7250	#subject_philosophy								
+work_7251	#subject_philosophy								
+work_7352	#subject_science								
+work_847	#subject_philosophy								
+work_849	#subject_philosophy								
+work_850	#subject_philosophy								
+work_851	#subject_philosophy								
+work_852	#subject_philosophy								
+work_853	#subject_philosophy								
+work_854	#subject_classical_literature								
+work_855	#subject_philosophy								
+work_856	#subject_medicine								
+work_857	#subject_philosophy								
+work_858	#subject_philosophy								
+work_859	#subject_medicine								
+work_860	#subject_medicine								
+work_7253	#subject_philosophy								
+work_861	#subject_philosophy								
+work_862	#subject_philosophy								
+work_3918	#subject_philosophy								
+work_3919	#subject_philosophy								
+work_3920	#subject_philosophy								
+work_10431	#subject_literature								
+work_4873	#subject_sermons								
+work_710	#subject_science								
+work_711	#subject_science								
+work_712	#subject_science								
+work_713	#subject_science								
+work_863	#subject_law								
+work_864	#subject_law								
+work_3118	#subject_medicine								
+work_10432	#subject_literature	#subject_literature							
+work_867	#subject_monasticism_and_religious_orders								
+work_4437	#subject_philosophy								
+work_4424	#subject_philosophy								
+work_5670	#subject_science								
+work_4425	#subject_philosophy								
+work_4426	#subject_science								
+work_4427	#subject_science								
+work_4438	#subject_science								
+work_4428	#subject_philosophy								
+work_4439	#subject_science								
+work_4429	#subject_science								
+work_7174	#subject_philosophy								
+work_7385	#subject_medicine								
+work_4430	#subject_philosophy	#subject_theology	#subject_science						
+work_4431	#subject_philosophy	#subject_theology	#subject_science						
+work_4432	#subject_philosophy	#subject_theology	#subject_science						
+work_4433	#subject_science								
+work_4434	#subject_philosophy								
+work_4435	#subject_philosophy								
+work_4422	#subject_bible								
+work_4436	#subject_philosophy								
+work_4107	#subject_theology								
+work_4108	#subject_philosophy								
+work_4109	#subject_philosophy								
+work_4110	#subject_philosophy								
+work_4111	#subject_science								
+work_4112	#subject_philosophy								
+work_2541	#subject_heraldry								
+work_2540	#subject_heraldry								
+work_1672	#subject_history								
+work_2542	#subject_grammar								
+work_868	#subject_science								
+work_869	#subject_literature								
+work_871	#subject_liturgy	#subject_theology	#subject_clergy						
+work_872	#subject_sermons								
+work_2621	#subject_monasticism_and_religious_orders								
+work_10434	#subject_documents								
+work_873	#subject_theology								
+work_10435	#subject_documents								
+work_1475	#subject_science								
+work_1545	#subject_conduct								
+work_3017	#subject_monasticism_and_religious_orders								
+work_10436	#subject_literature								
+work_1762	#subject_history								
+work_2182	#subject_christian_literature								
+work_10437	#subject_literature								
+work_875	#subject_medicine								
+work_3676	#subject_conduct								
+work_876	#subject_theology								
+work_891	#subject_medicine								
+work_892	#subject_medicine								
+work_884	#subject_christian_literature								
+work_877	#subject_natural_history								
+work_878	#subject_natural_history								
+work_879	#subject_science								
+work_886	#subject_theology								
+work_901	#subject_medicine								
+work_894	#subject_medicine								
+work_13224	#subject_medicine								
+work_899	#subject_hagiography								
+work_888	#subject_hagiography								
+work_897	#subject_theology								
+work_898	#subject_theology								
+work_887	#subject_magic								
+work_889	#subject_christian_literature	#subject_classical_literature							
+work_893	#subject_theology	#subject_law							
+work_890	#subject_theology	#subject_law							
+work_904	#subject_law								
+work_911	#subject_law								
+work_912	#subject_law								
+work_910	#subject_law								
+work_913	#subject_law								
+work_903	#subject_law								
+work_905	#subject_heraldry								
+work_914	#subject_law								
+work_915	#subject_law								
+work_909	#subject_history								
+work_2622	#subject_theology								
+work_995	#subject_law								
+work_1233	#subject_grammar								
+work_1630	#subject_grammar								
+work_1631	#subject_grammar								
+work_1633	#subject_literature								
+work_1637	#subject_rhetoric								
+work_1638	#subject_rhetoric								
+work_1632	#subject_literature								
+work_1635	#subject_rhetoric								
+work_5794	#subject_sermons								
+work_6084	#subject_theology								
+work_924	#subject_theology								
+work_3921	#subject_theology								
+work_5869	#subject_sermons								
+work_916	#subject_theology								
+work_917	#subject_theology								
+work_931	#subject_theology								
+work_938	#subject_theology								
+work_4590	#subject_bible								
+work_918	#subject_theology								
+work_925	#subject_theology								
+work_33	#subject_theology								
+work_6217	#subject_theology								
+work_939	#subject_theology								
+work_51	#subject_theology	#subject_monasticism_and_religious_orders							
+work_919	#subject_theology	#subject_monasticism_and_religious_orders							
+work_940	#subject_theology								
+work_926	#subject_theology								
+work_941	#subject_theology								
+work_67	#subject_theology								
+work_920	#subject_theology								
+work_6218	#subject_sermons								
+work_6160	#subject_sermons								
+work_5929	#subject_sermons								
+work_921	#subject_sermons								
+work_6222	#subject_sermons								
+work_930	#subject_sermons								
+work_929	#subject_sermons								
+work_928	#subject_sermons								
+work_5725	#subject_theology								
+work_932	#subject_theology								
+work_922	#subject_theology								
+work_933	#subject_liturgy								
+work_6167	#subject_monasticism_and_religious_orders								
+work_5787	#subject_sermons								
+work_935	#subject_theology								
+work_936	#subject_theology								
+work_942	#subject_theology								
+work_943	#subject_theology								
+work_944	#subject_literature	#subject_science							
+work_945	#subject_literature								
+work_946	#subject_literature								
+work_947	#subject_literature								
+work_948	#subject_literature								
+work_1966	#subject_science								
+work_1967	#subject_science								
+work_576	#subject_literature								
+work_1653	#subject_literature								
+work_10439	#subject_documents	#subject_clergy							
+work_6603	#subject_theology								
+work_6131	#subject_bible								
+work_6068	#subject_science								
+work_7513	#subject_theology								
+work_5842	#subject_theology								
+work_3922	#subject_geography								
+work_5604	#subject_bible								
+work_3923	#subject_sermons								
+work_7511	#subject_theology								
+work_3924	#subject_theology								
+work_949	#subject_history								
+work_950	#subject_bible								
+work_951	#subject_bible								
+work_952	#subject_bible								
+work_953	#subject_bible								
+work_954	#subject_bible								
+work_955	#subject_bible								
+work_956	#subject_bible								
+work_957	#subject_bible								
+work_958	#subject_bible								
+work_959	#subject_grammar								
+work_7510	#subject_theology								
+work_6144	#subject_geography								
+work_960	#subject_natural_history								
+work_961	#subject_grammar								
+work_962	#subject_rhetoric								
+work_963	#subject_theology	#subject_bible							
+work_964	#subject_theology	#subject_bible							
+work_965	#subject_science								
+work_966	#subject_science								
+work_5835	#subject_theology								
+work_5837	#subject_theology								
+work_5839	#subject_theology								
+work_5836	#subject_theology								
+work_5834	#subject_history								
+work_5838	#subject_liturgy								
+work_967	#subject_history	#subject_monasticism_and_religious_orders							
+work_968	#subject_history								
+work_969	#subject_history								
+work_970	#subject_sermons								
+work_971	#subject_sermons								
+work_972	#subject_bible								
+work_973	#subject_hagiography								
+work_974	#subject_geography	#subject_bible							
+work_7090	#subject_bible								
+work_977	#subject_hagiography								
+work_976	#subject_hagiography								
+work_10440	#subject_bible								
+work_4930	#subject_natural_history	#subject_science							
+work_1527	#subject_hagiography								
+work_2623	#subject_clergy								
+work_983	#subject_science								
+work_2304	#subject_law								
+work_985	#subject_rhetoric								
+work_993	#subject_hagiography								
+work_990	#subject_law								
+work_991	#subject_monasticism_and_religious_orders								
+work_992	#subject_law	#subject_monasticism_and_religious_orders							
+work_10441	#subject_monasticism_and_religious_orders								
+work_10442	#subject_monasticism_and_religious_orders								
+work_16332	#subject_monasticism_and_religious_orders								
+work_10443	#subject_liturgy								
+work_10444	#subject_science								
+work_996	#subject_literature								
+work_1001	#subject_medicine								
+work_1002	#subject_history								
+work_1003	#subject_literature								
+work_999	#subject_literature								
+work_1000	#subject_literature								
+work_998	#subject_history								
+work_2159	#subject_medicine								
+work_4885	#subject_law								
+work_1005	#subject_theology								
+work_1007	#subject_bible								
+work_3956	#subject_law								
+work_1076	#subject_science								
+work_1073	#subject_natural_history								
+work_1074	#subject_philosophy	#subject_natural_history							
+work_6229	#subject_philosophy								
+work_1075	#subject_philosophy								
+work_1014	#subject_philosophy								
+work_1015	#subject_philosophy								
+work_5819	#subject_medicine								
+work_1016	#subject_medicine								
+work_1017	#subject_medicine								
+work_1018	#subject_medicine								
+work_1059	#subject_medicine								
+work_1019	#subject_medicine								
+work_7163	#subject_medicine								
+work_1020	#subject_medicine								
+work_1072	#subject_monasticism_and_religious_orders								
+work_3930	#subject_theology								
+work_3943	#subject_christian_literature	#subject_theology							
+work_13324	#subject_christian_literature	#subject_theology							
+work_3910	#subject_christian_literature	#subject_theology							
+work_3944	#subject_christian_literature	#subject_theology							
+work_3926	#subject_theology								
+work_3928	#subject_theology								
+work_3945	#subject_theology								
+work_3946	#subject_theology								
+work_3929	#subject_theology								
+work_3931	#subject_theology								
+work_3932	#subject_liturgy								
+work_5928	#subject_theology								
+work_3933	#subject_theology								
+work_3948	#subject_theology								
+work_3949	#subject_christian_literature	#subject_theology							
+work_3950	#subject_christian_literature	#subject_theology							
+work_3934	#subject_theology								
+work_3935	#subject_theology	#subject_conduct							
+work_3951	#subject_theology	#subject_conduct							
+work_5820	#subject_sermons								
+work_3936	#subject_christian_literature	#subject_theology							
+work_3952	#subject_christian_literature	#subject_theology							
+work_3953	#subject_liturgy								
+work_3938	#subject_theology								
+work_3939	#subject_theology								
+work_3954	#subject_theology								
+work_3941	#subject_bible								
+work_3942	#subject_sermons								
+work_3955	#subject_theology								
+work_1021	#subject_theology								
+work_1022	#subject_theology								
+work_1023	#subject_theology								
+work_1024	#subject_theology								
+work_1025	#subject_theology								
+work_1026	#subject_theology								
+work_1027	#subject_theology								
+work_1028	#subject_theology								
+work_1029	#subject_theology								
+work_1030	#subject_theology								
+work_1031	#subject_theology								
+work_1032	#subject_theology								
+work_1033	#subject_theology								
+work_1034	#subject_theology								
+work_1035	#subject_theology								
+work_1036	#subject_theology								
+work_1008	#subject_theology								
+work_1037	#subject_theology								
+work_1038	#subject_theology								
+work_6293	#subject_theology								
+work_5784	#subject_theology								
+work_1041	#subject_theology								
+work_6430	#subject_theology								
+work_1040	#subject_sermons								
+work_1043	#subject_theology								
+work_1044	#subject_sermons								
+work_1045	#subject_sermons								
+work_1046	#subject_sermons								
+work_1048	#subject_sermons								
+work_1049	#subject_sermons								
+work_1050	#subject_sermons								
+work_1054	#subject_sermons								
+work_1051	#subject_sermons								
+work_1052	#subject_sermons								
+work_1053	#subject_sermons								
+work_1056	#subject_hagiography								
+work_1057	#subject_theology								
+work_1058	#subject_law								
+work_6244	#subject_hagiography								
+work_1067	#subject_monasticism_and_religious_orders								
+work_1065	#subject_law								
+work_1066	#subject_law								
+work_1063	#subject_theology								
+work_1068	#subject_sermons								
+work_1069	#subject_theology								
+work_1077	#subject_literature								
+work_7346	#subject_rhetoric								
+work_3967	#subject_monasticism_and_religious_orders								
+work_1011	#subject_history								
+work_1012	#subject_history								
+work_1013	#subject_theology								
+work_6176	#subject_medicine								
+work_1009	#subject_monasticism_and_religious_orders	#subject_theology							
+work_1010	#subject_monasticism_and_religious_orders								
+work_1071	#subject_medicine								
+work_1079	#subject_philosophy								
+work_1060	#subject_rhetoric								
+work_5904	#subject_science								
+work_2882	#subject_recreation								
+work_1080	#subject_sermons								
+work_7305	#subject_classical_literature								
+work_3577	#subject_natural_history	#subject_bible	#subject_classical_literature						
+work_3430	#subject_bible								
+work_1081	#subject_sermons								
+work_2968	#subject_medicine								
+work_1083	#subject_sermons								
+work_6170	#subject_sermons								
+work_6342	#subject_sermons								
+work_1082	#subject_law								
+work_1084	#subject_theology								
+work_10445	#subject_natural_history								
+work_10447	#subject_natural_history								
+work_10448	#subject_natural_history								
+work_10449	#subject_literature								
+work_1764	#subject_science								
+work_2457	#subject_science								
+work_2458	#subject_science								
+work_10458	#subject_bible								
+work_10451	#subject_bible								
+work_15496	#subject_bible								
+work_10452	#subject_bible								
+work_10454	#subject_bible								
+work_10455	#subject_bible								
+work_10456	#subject_bible	#subject_liturgy							
+work_10460	#subject_bible								
+work_10462	#subject_bible								
+work_10094	#subject_bible								
+work_10232	#subject_bible								
+work_10233	#subject_bible								
+work_10242	#subject_bible								
+work_10244	#subject_bible								
+work_10245	#subject_bible								
+work_10756	#subject_bible								
+work_10757	#subject_bible								
+work_10461	#subject_bible								
+work_12444	#subject_bible								
+work_13313	#subject_bible								
+work_13434	#subject_bible								
+work_13435	#subject_bible								
+work_13437	#subject_bible								
+work_13438	#subject_bible								
+work_13439	#subject_bible								
+work_13440	#subject_bible								
+work_13441	#subject_bible								
+work_13442	#subject_bible								
+work_13443	#subject_bible								
+work_13448	#subject_bible								
+work_13444	#subject_bible	#subject_liturgy							
+work_10097	#subject_bible								
+work_10100	#subject_bible								
+work_10098	#subject_bible								
+work_10099	#subject_bible								
+work_10092	#subject_bible								
+work_10095	#subject_bible								
+work_10093	#subject_bible								
+work_10101	#subject_bible								
+work_10096	#subject_bible								
+work_10223	#subject_bible								
+work_10228	#subject_bible								
+work_10224	#subject_bible								
+work_16201	#subject_bible								
+work_10226	#subject_bible								
+work_10227	#subject_bible								
+work_10229	#subject_bible								
+work_10225	#subject_bible								
+work_10238	#subject_bible								
+work_10239	#subject_bible								
+work_10235	#subject_bible								
+work_10237	#subject_bible								
+work_10230	#subject_bible								
+work_10482	#subject_bible	#subject_bible							
+work_12088	#subject_bible								
+work_12089	#subject_bible								
+work_14054	#subject_bible	#subject_bible							
+work_10257	#subject_bible								
+work_10850	#subject_bible								
+work_11994	#subject_bible								
+work_10851	#subject_bible								
+work_10738	#subject_bible								
+work_11995	#subject_bible								
+work_10740	#subject_bible								
+work_11996	#subject_bible								
+work_10741	#subject_bible								
+work_11702	#subject_bible								
+work_17082	#subject_bible								
+work_10852	#subject_bible								
+work_13445	#subject_bible								
+work_13447	#subject_bible								
+work_12060	#subject_bible								
+work_12090	#subject_bible								
+work_12118	#subject_bible								
+work_12091	#subject_bible								
+work_12092	#subject_bible								
+work_12099	#subject_bible								
+work_12108	#subject_bible								
+work_11886	#subject_bible								
+work_12094	#subject_bible								
+work_12096	#subject_bible								
+work_12098	#subject_bible								
+work_12095	#subject_bible								
+work_12100	#subject_bible								
+work_12102	#subject_bible								
+work_12106	#subject_bible								
+work_12103	#subject_bible								
+work_12104	#subject_bible								
+work_12076	#subject_bible								
+work_14694	#subject_bible								
+work_12074	#subject_bible								
+work_14696	#subject_bible								
+work_12075	#subject_bible								
+work_12078	#subject_bible								
+work_14697	#subject_bible								
+work_12111	#subject_bible								
+work_12079	#subject_bible								
+work_13133	#subject_bible								
+work_12080	#subject_bible								
+work_12113	#subject_bible								
+work_13134	#subject_bible								
+work_14701	#subject_bible								
+work_12082	#subject_bible								
+work_12083	#subject_bible								
+work_14699	#subject_bible								
+work_12110	#subject_bible								
+work_12115	#subject_bible								
+work_12086	#subject_bible								
+work_12085	#subject_bible								
+work_12117	#subject_bible								
+work_12105	#subject_bible								
+work_12077	#subject_bible								
+work_13744	#subject_bible								
+work_13751	#subject_bible								
+work_14703	#subject_bible								
+work_13745	#subject_bible								
+work_13746	#subject_bible								
+work_11706	#subject_bible								
+work_11705	#subject_bible								
+work_11703	#subject_bible								
+work_13752	#subject_bible								
+work_14445	#subject_bible								
+work_13747	#subject_bible								
+work_13748	#subject_bible								
+work_13749	#subject_bible								
+work_13750	#subject_bible								
+work_13452	#subject_bible								
+work_15600	#subject_bible								
+work_13606	#subject_bible								
+work_13607	#subject_bible								
+work_13608	#subject_bible								
+work_13609	#subject_bible								
+work_13610	#subject_bible								
+work_13611	#subject_bible								
+work_13612	#subject_bible								
+work_13619	#subject_bible								
+work_10438	#subject_bible								
+work_11008	#subject_bible								
+work_11009	#subject_bible								
+work_16023	#subject_bible								
+work_16052	#subject_bible	#subject_bible							
+work_11428	#subject_bible								
+work_11510	#subject_bible								
+work_11512	#subject_bible								
+work_11511	#subject_bible								
+work_11678	#subject_bible								
+work_16004	#subject_bible								
+work_16202	#subject_bible								
+work_17119	#subject_bible								
+work_11686	#subject_bible								
+work_11006	#subject_bible								
+work_12216	#subject_bible								
+work_11765	#subject_bible								
+work_11766	#subject_bible								
+work_16051	#subject_bible	#subject_bible							
+work_11767	#subject_bible								
+work_11798	#subject_bible								
+work_11799	#subject_bible								
+work_11800	#subject_bible								
+work_11801	#subject_bible								
+work_11999	#subject_bible								
+work_12000	#subject_bible								
+work_12001	#subject_bible								
+work_16050	#subject_bible	#subject_bible							
+work_10459	#subject_bible								
+work_13613	#subject_bible								
+work_12002	#subject_bible								
+work_12192	#subject_bible								
+work_12427	#subject_bible								
+work_12428	#subject_bible								
+work_12434	#subject_bible								
+work_12437	#subject_bible								
+work_12438	#subject_bible								
+work_12441	#subject_bible								
+work_12442	#subject_bible								
+work_12443	#subject_bible								
+work_12445	#subject_bible								
+work_12447	#subject_bible								
+work_12446	#subject_bible								
+work_12449	#subject_bible								
+work_12453	#subject_bible								
+work_12454	#subject_bible								
+work_12465	#subject_bible								
+work_10598	#subject_bible								
+work_12464	#subject_bible								
+work_12486	#subject_bible								
+work_12487	#subject_bible								
+work_16246	#subject_bible								
+work_12772	#subject_bible								
+work_13092	#subject_bible								
+work_13093	#subject_bible								
+work_13618	#subject_bible	#subject_literature							
+work_13312	#subject_bible								
+work_16024	#subject_bible								
+work_13550	#subject_bible								
+work_13556	#subject_bible								
+work_13557	#subject_bible								
+work_13559	#subject_bible								
+work_13766	#subject_bible								
+work_13768	#subject_bible								
+work_13769	#subject_bible								
+work_13771	#subject_bible								
+work_14044	#subject_bible								
+work_14066	#subject_bible								
+work_13620	#subject_bible								
+work_14068	#subject_bible								
+work_14069	#subject_bible								
+work_14070	#subject_bible								
+work_14071	#subject_bible								
+work_16003	#subject_bible								
+work_14080	#subject_bible								
+work_14082	#subject_bible								
+work_14085	#subject_bible								
+work_14088	#subject_bible								
+work_14083	#subject_bible								
+work_14084	#subject_bible	#subject_bible							
+work_14077	#subject_bible								
+work_14078	#subject_bible								
+work_14079	#subject_literature	#subject_bible							
+work_14090	#subject_bible								
+work_10605	#subject_bible								
+work_14466	#subject_bible								
+work_14657	#subject_bible								
+work_14655	#subject_bible								
+work_14658	#subject_bible								
+work_14656	#subject_literature	#subject_bible							
+work_14662	#subject_bible								
+work_14660	#subject_bible								
+work_10606	#subject_bible								
+work_16085	#subject_bible								
+work_15353	#subject_bible								
+work_15354	#subject_bible								
+work_15522	#subject_bible								
+work_15523	#subject_bible								
+work_15524	#subject_bible								
+work_16005	#subject_bible								
+work_13622	#subject_bible								
+work_15570	#subject_bible								
+work_13754	#subject_bible								
+work_10463	#subject_bible								
+work_14659	#subject_bible								
+work_10464	#subject_bible								
+work_10469	#subject_bible								
+work_10470	#subject_bible								
+work_10471	#subject_bible								
+work_10472	#subject_bible								
+work_10473	#subject_bible								
+work_10474	#subject_history	#subject_bible							
+work_10476	#subject_indexes	#subject_bible							
+work_10477	#subject_bible								
+work_10478	#subject_bible								
+work_10479	#subject_bible								
+work_10480	#subject_bible								
+work_10481	#subject_bible								
+work_10483	#subject_christian_literature	#subject_theology							
+work_4309	#subject_philosophy								
+work_10484	#subject_documents								
+work_1733	#subject_bible								
+work_1758	#subject_music								
+work_1086	#subject_bible								
+work_1529	#subject_history								
+work_980	#subject_medicine								
+work_981	#subject_conduct								
+work_982	#subject_conduct								
+work_3123	#subject_theology								
+work_3137	#subject_theology	#subject_liturgy							
+work_5653	#subject_law								
+work_3124	#subject_law								
+work_10487	#subject_liturgy								
+work_1095	#subject_literature								
+work_1096	#subject_literature								
+work_1097	#subject_literature								
+work_1765	#subject_literature								
+work_1098	#subject_literature								
+work_1766	#subject_literature								
+work_1767	#subject_geography								
+work_1100	#subject_literature								
+work_1101	#subject_literature								
+work_1102	#subject_literature								
+work_1103	#subject_literature								
+work_1104	#subject_literature								
+work_1105	#subject_literature								
+work_1115	#subject_literature								
+work_7306	#subject_literature								
+work_1106	#subject_literature								
+work_1107	#subject_literature								
+work_1768	#subject_literature								
+work_1109	#subject_christian_literature								
+work_1111	#subject_literature								
+work_1116	#subject_literature								
+work_1112	#subject_literature								
+work_1113	#subject_literature								
+work_1114	#subject_literature								
+work_2459	#subject_history								
+work_4180	#subject_hagiography								
+work_6429	#subject_philosophy								
+work_7323	#subject_philosophy	#subject_classical_literature							
+work_5500	#subject_philosophy	#subject_theology							
+work_5502	#subject_philosophy	#subject_theology							
+work_1118	#subject_philosophy	#subject_theology							
+work_1122	#subject_philosophy	#subject_theology							
+work_1117	#subject_philosophy	#subject_theology							
+work_1123	#subject_philosophy	#subject_theology							
+work_1119	#subject_philosophy	#subject_theology							
+work_1120	#subject_philosophy	#subject_theology							
+work_1121	#subject_philosophy	#subject_theology							
+work_1124	#subject_philosophy								
+work_1125	#subject_philosophy								
+work_1126	#subject_theology								
+work_1127	#subject_science								
+work_1128	#subject_music								
+work_6428	#subject_philosophy								
+work_6426	#subject_philosophy								
+work_1130	#subject_theology								
+work_7202	#subject_philosophy								
+work_1132	#subject_philosophy	#subject_theology							
+work_7302	#subject_philosophy								
+work_3958	#subject_science								
+work_3121	#subject_literature								
+work_10489	#subject_documents								
+work_2460	#subject_science								
+work_1134	#subject_law								
+work_1135	#subject_law								
+work_3962	#subject_christian_literature								
+work_3963	#subject_christian_literature								
+work_3269	#subject_christian_literature	#subject_theology							
+work_3964	#subject_christian_literature								
+work_3965	#subject_christian_literature								
+work_6434	#subject_theology								
+work_3959	#subject_theology								
+work_6292	#subject_christian_literature								
+work_3960	#subject_christian_literature								
+work_7021	#subject_theology	#subject_conduct							
+work_6291	#subject_christian_literature								
+work_3961	#subject_christian_literature								
+work_1136	#subject_theology								
+work_1137	#subject_bible								
+work_1138	#subject_theology								
+work_1139	#subject_theology								
+work_1140	#subject_christian_literature								
+work_1141	#subject_theology								
+work_1143	#subject_christian_literature								
+work_1144	#subject_hagiography								
+work_1146	#subject_christian_literature								
+work_1145	#subject_christian_literature								
+work_1147	#subject_liturgy								
+work_4591	#subject_christian_literature								
+work_1148	#subject_christian_literature								
+work_1149	#subject_theology								
+work_2091	#subject_politics_and_government								
+work_2090	#subject_politics_and_government								
+work_3321	#subject_philosophy								
+work_7121	#subject_natural_history	#subject_theology							
+work_1150	#subject_law								
+work_7507	#subject_literature								
+work_1151	#subject_clergy	#subject_law							
+work_1152	#subject_law								
+work_1153	#subject_law								
+work_1154	#subject_theology								
+work_2926	#subject_science								
+work_1155	#subject_law								
+work_3373	#subject_classical_literature								
+work_3380	#subject_grammar								
+work_1157	#subject_christian_literature								
+work_1158	#subject_christian_literature								
+work_1159	#subject_science								
+work_1160	#subject_conduct								
+work_10491	#subject_liturgy								
+work_10493	#subject_monasticism_and_religious_orders								
+work_10494	#subject_history								
+work_10496	#subject_liturgy								
+work_10497	#subject_liturgy								
+work_10498	#subject_liturgy								
+work_10499	#subject_liturgy								
+work_10508	#subject_liturgy								
+work_10509	#subject_liturgy								
+work_10502	#subject_liturgy								
+work_10500	#subject_liturgy								
+work_10503	#subject_liturgy								
+work_10505	#subject_liturgy								
+work_10506	#subject_liturgy								
+work_10504	#subject_liturgy								
+work_10507	#subject_liturgy								
+work_10510	#subject_liturgy								
+work_10511	#subject_liturgy	#subject_bible							
+work_10513	#subject_liturgy								
+work_10515	#subject_liturgy								
+work_10516	#subject_liturgy								
+work_10514	#subject_liturgy								
+work_10517	#subject_liturgy								
+work_10518	#subject_liturgy								
+work_10520	#subject_liturgy								
+work_10521	#subject_liturgy								
+work_10522	#subject_liturgy								
+work_10523	#subject_liturgy								
+work_10525	#subject_liturgy								
+work_10526	#subject_liturgy								
+work_10527	#subject_liturgy								
+work_10528	#subject_liturgy								
+work_10529	#subject_liturgy								
+work_10530	#subject_liturgy								
+work_10531	#subject_liturgy								
+work_10532	#subject_liturgy								
+work_10534	#subject_liturgy								
+work_10533	#subject_liturgy								
+work_10535	#subject_liturgy								
+work_10536	#subject_liturgy								
+work_10537	#subject_liturgy								
+work_10538	#subject_liturgy								
+work_10594	#subject_liturgy								
+work_10540	#subject_liturgy								
+work_10541	#subject_liturgy								
+work_10543	#subject_liturgy								
+work_10545	#subject_liturgy								
+work_10546	#subject_liturgy								
+work_10544	#subject_liturgy								
+work_10547	#subject_liturgy								
+work_10548	#subject_liturgy								
+work_10549	#subject_liturgy								
+work_10550	#subject_liturgy								
+work_10551	#subject_liturgy								
+work_10553	#subject_liturgy								
+work_10554	#subject_liturgy								
+work_10555	#subject_liturgy								
+work_10556	#subject_liturgy								
+work_10557	#subject_liturgy								
+work_10558	#subject_liturgy								
+work_10559	#subject_liturgy								
+work_10560	#subject_liturgy								
+work_10563	#subject_liturgy								
+work_10561	#subject_liturgy								
+work_10562	#subject_liturgy								
+work_10565	#subject_liturgy								
+work_10566	#subject_liturgy								
+work_10567	#subject_liturgy								
+work_10568	#subject_liturgy								
+work_10570	#subject_liturgy								
+work_10571	#subject_liturgy								
+work_10572	#subject_liturgy								
+work_10573	#subject_liturgy								
+work_10575	#subject_liturgy								
+work_10576	#subject_liturgy								
+work_10577	#subject_liturgy								
+work_10579	#subject_liturgy								
+work_10580	#subject_liturgy								
+work_10581	#subject_liturgy								
+work_10584	#subject_liturgy								
+work_10582	#subject_liturgy								
+work_10585	#subject_liturgy								
+work_10587	#subject_liturgy								
+work_10586	#subject_liturgy								
+work_10588	#subject_liturgy								
+work_10589	#subject_liturgy								
+work_10590	#subject_liturgy								
+work_10591	#subject_liturgy								
+work_10593	#subject_liturgy								
+work_10596	#subject_liturgy								
+work_10597	#subject_liturgy								
+work_10599	#subject_natural_history								
+work_10600	#subject_documents								
+work_10601	#subject_christian_literature								
+work_10602	#subject_christian_literature	#subject_theology	#subject_christian_literature						
+work_10608	#subject_christian_literature	#subject_theology							
+work_10609	#subject_bibliography								
+work_1532	#subject_classical_literature								
+work_2543	#subject_theology								
+work_4931	#subject_christian_literature								
+work_1061	#subject_law								
+work_1062	#subject_law								
+work_1226	#subject_literature								
+work_2361	#subject_law								
+work_1156	#subject_theology								
+work_10612	#subject_documents								
+work_3259	#subject_christian_literature								
+work_3260	#subject_conduct								
+work_2344	#subject_literature								
+work_3739	#subject_literature								
+work_3726	#subject_literature								
+work_3727	#subject_literature								
+work_3728	#subject_geography								
+work_3729	#subject_literature	#subject_politics_and_government							
+work_3730	#subject_politics_and_government								
+work_3731	#subject_literature								
+work_3733	#subject_literature								
+work_3734	#subject_literature								
+work_3740	#subject_literature								
+work_1999	#subject_law								
+work_4788	#subject_theology								
+work_4789	#subject_science								
+work_4790	#subject_science								
+work_7095	#subject_sermons								
+work_4545	#subject_science								
+work_4546	#subject_science								
+work_4547	#subject_science								
+work_4548	#subject_science								
+work_4549	#subject_medicine								
+work_10613	#subject_law								
+work_2346	#subject_history	#subject_literature							
+work_10614	#subject_law								
+work_10615	#subject_music								
+work_10616	#subject_history								
+work_10617	#subject_medicine								
+work_10618	#subject_bible								
+work_16255	#subject_geography								
+work_10619	#subject_liturgy								
+work_10620	#subject_liturgy								
+work_10621	#subject_liturgy								
+work_10622	#subject_liturgy								
+work_10623	#subject_liturgy								
+work_10624	#subject_liturgy								
+work_10625	#subject_liturgy								
+work_10626	#subject_liturgy								
+work_10627	#subject_liturgy								
+work_10628	#subject_liturgy								
+work_10629	#subject_liturgy								
+work_10630	#subject_liturgy								
+work_10631	#subject_liturgy								
+work_10632	#subject_liturgy								
+work_10633	#subject_liturgy								
+work_10634	#subject_liturgy								
+work_10647	#subject_liturgy								
+work_10636	#subject_liturgy								
+work_10637	#subject_liturgy								
+work_10638	#subject_liturgy								
+work_10639	#subject_liturgy								
+work_10641	#subject_liturgy								
+work_10645	#subject_liturgy								
+work_10649	#subject_liturgy								
+work_10648	#subject_liturgy								
+work_13594	#subject_liturgy								
+work_10646	#subject_liturgy								
+work_10650	#subject_liturgy								
+work_10652	#subject_liturgy								
+work_10655	#subject_liturgy								
+work_10656	#subject_liturgy								
+work_10657	#subject_liturgy								
+work_10658	#subject_liturgy								
+work_10659	#subject_liturgy								
+work_10660	#subject_liturgy								
+work_10661	#subject_liturgy								
+work_10662	#subject_liturgy								
+work_10663	#subject_liturgy								
+work_10664	#subject_liturgy								
+work_10665	#subject_liturgy								
+work_10651	#subject_liturgy								
+work_10654	#subject_liturgy								
+work_10666	#subject_liturgy								
+work_10667	#subject_liturgy								
+work_2625	#subject_rhetoric								
+work_7139	#subject_christian_literature								
+work_1087	#subject_christian_literature								
+work_4592	#subject_christian_literature								
+work_4593	#subject_christian_literature								
+work_1161	#subject_christian_literature								
+work_7138	#subject_christian_literature								
+work_10669	#subject_theology								
+work_4869	#subject_grammar								
+work_10670	#subject_law								
+work_2626	#subject_theology								
+work_2463	#subject_sermons								
+work_10671	#subject_history								
+work_2949	#subject_rhetoric								
+work_2950	#subject_rhetoric								
+work_2951	#subject_philosophy								
+work_2952	#subject_history								
+work_2953	#subject_history								
+work_2954	#subject_history								
+work_2955	#subject_literature								
+work_2956	#subject_history								
+work_2958	#subject_literature								
+work_2960	#subject_history								
+work_2961	#subject_rhetoric								
+work_2962	#subject_rhetoric								
+work_2963	#subject_history								
+work_2964	#subject_literature								
+work_6178	#subject_literature								
+work_1166	#subject_bible								
+work_1165	#subject_bible								
+work_1172	#subject_medicine								
+work_1173	#subject_medicine								
+work_6189	#subject_theology								
+work_6188	#subject_bible								
+work_1171	#subject_bible								
+work_1167	#subject_bible								
+work_1169	#subject_bible								
+work_1170	#subject_liturgy	#subject_theology	#subject_clergy						
+work_1168	#subject_theology	#subject_sermons							
+work_3971	#subject_classical_literature								
+work_3034	#subject_classical_literature								
+work_4937	#subject_science								
+work_3107	#subject_theology								
+work_7074	#subject_theology								
+work_1175	#subject_politics_and_government								
+work_1133	#subject_politics_and_government								
+work_1234	#subject_geography								
+work_1176	#subject_geography								
+work_1177	#subject_theology								
+work_988	#subject_conduct								
+work_2362	#subject_philosophy								
+work_2363	#subject_philosophy								
+work_2629	#subject_philosophy								
+work_2628	#subject_philosophy								
+work_7241	#subject_science								
+work_4938	#subject_philosophy								
+work_4939	#subject_philosophy								
+work_7258	#subject_philosophy								
+work_7297	#subject_philosophy								
+work_4940	#subject_philosophy								
+work_4941	#subject_philosophy								
+work_4942	#subject_philosophy								
+work_5682	#subject_philosophy								
+work_5680	#subject_philosophy								
+work_4943	#subject_philosophy								
+work_5677	#subject_philosophy								
+work_4945	#subject_philosophy								
+work_4946	#subject_philosophy								
+work_4947	#subject_philosophy								
+work_5681	#subject_philosophy								
+work_5679	#subject_philosophy								
+work_5683	#subject_philosophy								
+work_4948	#subject_philosophy								
+work_4949	#subject_science								
+work_4950	#subject_philosophy								
+work_4951	#subject_philosophy								
+work_4952	#subject_philosophy								
+work_4954	#subject_philosophy								
+work_5684	#subject_philosophy								
+work_4139	#subject_philosophy								
+work_4304	#subject_bibliography								
+work_6379	#subject_sermons								
+work_7361	#subject_bible	#subject_theology							
+work_585	#subject_law								
+work_604	#subject_clergy	#subject_law							
+work_1178	#subject_science								
+work_5656	#subject_theology								
+work_3262	#subject_liturgy								
+work_5935	#subject_theology								
+work_5934	#subject_hagiography								
+work_5936	#subject_liturgy								
+work_3352	#subject_theology								
+work_10673	#subject_theology								
+work_1180	#subject_classical_literature								
+work_1181	#subject_classical_literature								
+work_1182	#subject_classical_literature								
+work_1183	#subject_classical_literature								
+work_1184	#subject_classical_literature								
+work_3972	#subject_theology								
+work_6073	#subject_law								
+work_6074	#subject_sermons								
+work_1185	#subject_sermons								
+work_1186	#subject_bible								
+work_5773	#subject_sermons								
+work_7114	#subject_sermons								
+work_5813	#subject_sermons								
+work_7115	#subject_sermons								
+work_5923	#subject_sermons								
+work_1188	#subject_sermons								
+work_7116	#subject_sermons								
+work_7117	#subject_sermons								
+work_1189	#subject_sermons	#subject_monasticism_and_religious_orders							
+work_1190	#subject_sermons								
+work_1192	#subject_hagiography								
+work_4752	#subject_monasticism_and_religious_orders								
+work_4751	#subject_hagiography								
+work_4851	#subject_hagiography								
+work_1194	#subject_philosophy								
+work_10674	#subject_science								
+work_1772	#subject_politics_and_government	#subject_geography							
+work_1773	#subject_geography								
+work_1774	#subject_theology								
+work_6365	#subject_theology								
+work_1769	#subject_theology								
+work_1770	#subject_law								
+work_10675	#subject_science	#subject_liturgy							
+work_10676	#subject_liturgy								
+work_10677	#subject_liturgy								
+work_10678	#subject_science								
+work_10679	#subject_science	#subject_liturgy							
+work_10681	#subject_science								
+work_10680	#subject_science								
+work_10682	#subject_liturgy								
+work_10683	#subject_liturgy	#subject_science							
+work_10684	#subject_science								
+work_10685	#subject_science	#subject_liturgy							
+work_10687	#subject_liturgy	#subject_science							
+work_10689	#subject_science	#subject_science	#subject_liturgy						
+work_10690	#subject_science	#subject_liturgy							
+work_10691	#subject_liturgy	#subject_science	#subject_christian_literature						
+work_10693	#subject_liturgy								
+work_10694	#subject_liturgy								
+work_10695	#subject_documents	#subject_history							
+work_10696	#subject_documents								
+work_10697	#subject_documents								
+work_10704	#subject_history	#subject_liturgy	#subject_science						
+work_10705	#subject_science	#subject_history							
+work_10688	#subject_science	#subject_liturgy	#subject_grammar	#subject_christian_literature					
+work_10692	#subject_liturgy	#subject_science							
+work_10698	#subject_science								
+work_10699	#subject_liturgy	#subject_science							
+work_10700	#subject_science	#subject_liturgy							
+work_10701	#subject_science	#subject_liturgy							
+work_10702	#subject_liturgy								
+work_10703	#subject_liturgy								
+work_10706	#subject_law	#subject_indexes							
+work_10707	#subject_science	#subject_science							
+work_10708	#subject_science	#subject_science							
+work_10709	#subject_science	#subject_science							
+work_10711	#subject_science								
+work_10712	#subject_science								
+work_10713	#subject_science	#subject_liturgy							
+work_10714	#subject_science	#subject_liturgy							
+work_10716	#subject_science	#subject_liturgy							
+work_10717	#subject_science	#subject_liturgy							
+work_10718	#subject_science	#subject_liturgy							
+work_10719	#subject_science								
+work_10720	#subject_science								
+work_10721	#subject_science								
+work_10722	#subject_science								
+work_10724	#subject_science								
+work_10725	#subject_literature								
+work_1195	#subject_literature								
+work_1196	#subject_literature								
+work_1197	#subject_literature								
+work_4143	#subject_classical_literature								
+work_6268	#subject_monasticism_and_religious_orders								
+work_6378	#subject_classical_literature								
+work_1198	#subject_science								
+work_1199	#subject_science								
+work_1200	#subject_science								
+work_1201	#subject_science								
+work_1202	#subject_science								
+work_10726	#subject_science								
+work_14973	#subject_law								
+work_10727	#subject_law								
+work_10736	#subject_theology								
+work_16215	#subject_law								
+work_10744	#subject_law								
+work_10743	#subject_law								
+work_16092	#subject_law								
+work_10745	#subject_law								
+work_10746	#subject_clergy	#subject_law							
+work_10747	#subject_clergy	#subject_law							
+work_10749	#subject_clergy								
+work_10750	#subject_law								
+work_16221	#subject_law								
+work_16225	#subject_law								
+work_16214	#subject_law								
+work_16222	#subject_law								
+work_10752	#subject_clergy								
+work_16220	#subject_law								
+work_16224	#subject_law								
+work_16219	#subject_law								
+work_17108	#subject_law								
+work_10753	#subject_law	#subject_clergy							
+work_17109	#subject_law								
+work_17112	#subject_law								
+work_17111	#subject_law								
+work_10754	#subject_law								
+work_16245	#subject_clergy	#subject_law							
+work_10755	#subject_science								
+work_1203	#subject_literature								
+work_1204	#subject_literature								
+work_5605	#subject_history								
+work_2630	#subject_bible								
+work_2631	#subject_hagiography								
+work_2632	#subject_geography								
+work_2546	#subject_medicine								
+work_2547	#subject_medicine								
+work_3432	#subject_medicine								
+work_10758	#subject_liturgy								
+work_1412	#subject_clergy								
+work_3207	#subject_theology								
+work_605	#subject_theology								
+work_3677	#subject_hagiography								
+work_10760	#subject_monasticism_and_religious_orders								
+work_17020	#subject_literature								
+work_10761	#subject_literature	#subject_law							
+work_16302	#subject_clergy								
+work_10762	#subject_literature								
+work_10763	#subject_literature								
+work_16035	#subject_monasticism_and_religious_orders								
+work_10764	#subject_literature	#subject_christian_literature							
+work_10765	#subject_documents								
+work_10766	#subject_documents	#subject_law							
+work_446	#subject_politics_and_government								
+work_10768	#subject_monasticism_and_religious_orders	#subject_documents							
+work_10769	#subject_law	#subject_monasticism_and_religious_orders							
+work_10770	#subject_monasticism_and_religious_orders	#subject_documents	#subject_law						
+work_10771	#subject_monasticism_and_religious_orders	#subject_documents							
+work_10779	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10780	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10781	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10784	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10785	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10786	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10787	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10788	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10789	#subject_documents								
+work_10790	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10791	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10792	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10793	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10796	#subject_documents								
+work_10797	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10901	#subject_documents								
+work_10800	#subject_monasticism_and_religious_orders	#subject_documents							
+work_10801	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10802	#subject_documents	#subject_monasticism_and_religious_orders							
+work_16002	#subject_monasticism_and_religious_orders	#subject_documents							
+work_10809	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10810	#subject_documents								
+work_10811	#subject_documents								
+work_10812	#subject_documents								
+work_10815	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10813	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10814	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10816	#subject_documents								
+work_10817	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10818	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10819	#subject_monasticism_and_religious_orders	#subject_documents							
+work_10820	#subject_documents								
+work_10772	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10773	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10774	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10775	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10776	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10899	#subject_documents	#subject_clergy							
+work_10777	#subject_documents	#subject_clergy							
+work_10778	#subject_documents								
+work_10782	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10783	#subject_documents								
+work_17152	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10900	#subject_documents								
+work_10794	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10795	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10798	#subject_documents								
+work_10799	#subject_documents								
+work_10803	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10902	#subject_documents								
+work_10804	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10805	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10806	#subject_monasticism_and_religious_orders	#subject_documents							
+work_10807	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10808	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10821	#subject_documents	#subject_monasticism_and_religious_orders							
+work_5001	#subject_literature								
+work_902	#subject_christian_literature								
+work_10822	#subject_law								
+work_1206	#subject_theology								
+work_2633	#subject_theology	#subject_monasticism_and_religious_orders							
+work_2635	#subject_monasticism_and_religious_orders								
+work_2636	#subject_monasticism_and_religious_orders								
+work_2637	#subject_monasticism_and_religious_orders								
+work_2638	#subject_monasticism_and_religious_orders								
+work_1212	#subject_history								
+work_1208	#subject_bible								
+work_1209	#subject_bible								
+work_1210	#subject_theology								
+work_1211	#subject_monasticism_and_religious_orders								
+work_1213	#subject_politics_and_government	#subject_literature							
+work_2392	#subject_christian_literature								
+work_10823	#subject_grammar								
+work_3473	#subject_law								
+work_16362	#subject_law								
+work_16361	#subject_law								
+work_10824	#subject_law								
+work_10825	#subject_documents								
+work_10826	#subject_geography								
+work_10827	#subject_history								
+work_10828	#subject_monasticism_and_religious_orders	#subject_bibliography							
+work_10829	#subject_indexes								
+work_10830	#subject_documents								
+work_10834	#subject_bible								
+work_10835	#subject_bible								
+work_10837	#subject_bible								
+work_10839	#subject_bible								
+work_10843	#subject_bible								
+work_16226	#subject_bible								
+work_10848	#subject_bible								
+work_10844	#subject_bible								
+work_10833	#subject_bible								
+work_10842	#subject_bible								
+work_10847	#subject_bible								
+work_10849	#subject_literature								
+work_5931	#subject_christian_literature								
+work_1216	#subject_christian_literature								
+work_6279	#subject_christian_literature								
+work_1214	#subject_christian_literature								
+work_1215	#subject_christian_literature								
+work_10853	#subject_grammar								
+work_1217	#subject_classical_literature								
+work_1218	#subject_classical_literature								
+work_10854	#subject_monasticism_and_religious_orders								
+work_1413	#subject_christian_literature								
+work_1414	#subject_christian_literature								
+work_1415	#subject_medicine								
+work_1416	#subject_christian_literature								
+work_1417	#subject_christian_literature								
+work_1687	#subject_history								
+work_1219	#subject_literature	#subject_science							
+work_209	#subject_medicine								
+work_1222	#subject_classical_literature	#subject_science							
+work_10855	#subject_documents								
+work_10857	#subject_documents								
+work_10858	#subject_bible								
+work_16376	#subject_literature	#subject_monasticism_and_religious_orders							
+work_1223	#subject_classical_literature								
+work_10859	#subject_liturgy								
+work_10861	#subject_documents								
+work_10862	#subject_documents								
+work_10860	#subject_documents								
+work_10863	#subject_documents								
+work_2918	#subject_history								
+work_2639	#subject_science								
+work_10864	#subject_literature								
+work_10865	#subject_literature								
+work_10867	#subject_monasticism_and_religious_orders								
+work_10868	#subject_law								
+work_10869	#subject_philosophy								
+work_10870	#subject_history								
+work_5002	#subject_bibliography								
+work_5003	#subject_documents								
+work_1224	#subject_law								
+work_1225	#subject_law								
+work_10872	#subject_medicine	#subject_magic							
+work_10875	#subject_magic								
+work_10873	#subject_magic								
+work_10874	#subject_magic								
+work_1683	#subject_politics_and_government								
+work_1684	#subject_politics_and_government								
+work_1685	#subject_politics_and_government								
+work_1686	#subject_politics_and_government								
+work_17120	#subject_documents								
+work_10876	#subject_documents								
+work_10878	#subject_documents								
+work_10880	#subject_documents								
+work_10881	#subject_documents	#subject_law							
+work_10882	#subject_documents								
+work_10877	#subject_christian_literature	#subject_theology							
+work_16198	#subject_theology								
+work_10884	#subject_documents								
+work_10885	#subject_documents								
+work_10879	#subject_documents								
+work_10883	#subject_documents								
+work_10887	#subject_documents								
+work_10888	#subject_documents								
+work_10890	#subject_documents	#subject_monasticism_and_religious_orders							
+work_10891	#subject_documents								
+work_10889	#subject_documents								
+work_10892	#subject_documents								
+work_10893	#subject_law	#subject_documents							
+work_10894	#subject_monasticism_and_religious_orders	#subject_documents							
+work_10896	#subject_documents								
+work_10897	#subject_documents								
+work_10895	#subject_documents								
+work_10898	#subject_documents								
+work_10886	#subject_documents								
+work_296	#subject_politics_and_government								
+work_297	#subject_politics_and_government								
+work_298	#subject_politics_and_government								
+work_299	#subject_politics_and_government								
+work_300	#subject_politics_and_government								
+work_301	#subject_politics_and_government								
+work_302	#subject_politics_and_government								
+work_303	#subject_politics_and_government								
+work_304	#subject_politics_and_government								
+work_6332	#subject_literature								
+work_6334	#subject_christian_literature								
+work_1661	#subject_literature								
+work_1662	#subject_literature								
+work_6333	#subject_literature								
+work_6330	#subject_literature								
+work_1227	#subject_literature								
+work_6328	#subject_literature								
+work_1663	#subject_literature								
+work_6331	#subject_literature								
+work_6329	#subject_literature								
+work_1664	#subject_literature								
+work_1665	#subject_literature								
+work_1228	#subject_science								
+work_1666	#subject_literature								
+work_3144	#subject_hagiography								
+work_10905	#subject_science								
+work_10906	#subject_history								
+work_1697	#subject_rhetoric								
+work_1698	#subject_law								
+work_1699	#subject_rhetoric								
+work_1700	#subject_rhetoric								
+work_10907	#subject_liturgy								
+work_10909	#subject_liturgy								
+work_10910	#subject_liturgy	#subject_music							
+work_10911	#subject_liturgy								
+work_10913	#subject_liturgy	#subject_music							
+work_3251	#subject_theology								
+work_5645	#subject_literature								
+work_10914	#subject_bible								
+work_1230	#subject_literature	#subject_politics_and_government							
+work_1231	#subject_politics_and_government	#subject_conduct							
+work_1232	#subject_politics_and_government								
+work_5730	#subject_sermons								
+work_1236	#subject_philosophy								
+work_1237	#subject_philosophy								
+work_7128	#subject_liturgy	#subject_hagiography							
+work_6103	#subject_sermons								
+work_10916	#subject_history								
+work_10917	#subject_history								
+work_10918	#subject_history								
+work_10919	#subject_history								
+work_10921	#subject_history								
+work_10926	#subject_history								
+work_10929	#subject_history								
+work_10932	#subject_history								
+work_10933	#subject_history								
+work_10934	#subject_history								
+work_10935	#subject_history								
+work_10940	#subject_history								
+work_10941	#subject_history								
+work_10672	#subject_history								
+work_10939	#subject_history								
+work_10942	#subject_history								
+work_10943	#subject_history								
+work_10944	#subject_history								
+work_10945	#subject_history								
+work_10946	#subject_history								
+work_10927	#subject_history								
+work_10956	#subject_history								
+work_10957	#subject_history								
+work_10949	#subject_history								
+work_10951	#subject_history								
+work_10952	#subject_history								
+work_10958	#subject_history								
+work_10963	#subject_history								
+work_10964	#subject_history								
+work_10965	#subject_history	#subject_literature							
+work_10966	#subject_history								
+work_10967	#subject_history								
+work_10969	#subject_history								
+work_10970	#subject_history								
+work_10971	#subject_history								
+work_10972	#subject_history								
+work_10973	#subject_history								
+work_10974	#subject_history								
+work_10975	#subject_history								
+work_10976	#subject_history								
+work_10977	#subject_history								
+work_10948	#subject_history								
+work_10950	#subject_history								
+work_10953	#subject_history								
+work_10954	#subject_history								
+work_10955	#subject_history								
+work_10959	#subject_history								
+work_10960	#subject_history								
+work_10961	#subject_history								
+work_10962	#subject_history								
+work_10979	#subject_history								
+work_10978	#subject_history								
+work_10980	#subject_history								
+work_10981	#subject_history								
+work_10988	#subject_history								
+work_10987	#subject_history								
+work_10989	#subject_history	#subject_bible							
+work_10991	#subject_history	#subject_clergy							
+work_10992	#subject_history	#subject_clergy							
+work_16243	#subject_history	#subject_clergy							
+work_10993	#subject_history								
+work_10994	#subject_history								
+work_1278	#subject_history								
+work_10995	#subject_history								
+work_10920	#subject_history								
+work_10923	#subject_history	#subject_clergy							
+work_10922	#subject_history	#subject_clergy							
+work_10924	#subject_history	#subject_clergy							
+work_10925	#subject_history								
+work_10982	#subject_history								
+work_10984	#subject_history	#subject_literature							
+work_10985	#subject_history								
+work_10983	#subject_history								
+work_10986	#subject_history								
+work_10990	#subject_history								
+work_10997	#subject_history								
+work_10996	#subject_history								
+work_10998	#subject_history								
+work_10999	#subject_history								
+work_11000	#subject_history								
+work_11001	#subject_history								
+work_11002	#subject_history								
+work_11003	#subject_history								
+work_11004	#subject_history								
+work_11005	#subject_history								
+work_11010	#subject_history								
+work_11011	#subject_history								
+work_11012	#subject_history								
+work_11013	#subject_history								
+work_11014	#subject_history								
+work_11015	#subject_history								
+work_11016	#subject_history								
+work_16323	#subject_history								
+work_11017	#subject_history	#subject_science							
+work_11018	#subject_history								
+work_11019	#subject_history								
+work_11020	#subject_history								
+work_11021	#subject_history								
+work_3057	#subject_literature								
+work_3054	#subject_grammar								
+work_3055	#subject_grammar								
+work_3056	#subject_grammar								
+work_11027	#subject_clergy	#subject_law							
+work_11028	#subject_clergy								
+work_11029	#subject_clergy	#subject_documents							
+work_3233	#subject_liturgy								
+work_1238	#subject_philosophy	#subject_classical_literature							
+work_1239	#subject_rhetoric	#subject_classical_literature							
+work_1241	#subject_philosophy	#subject_classical_literature							
+work_1242	#subject_classical_literature								
+work_5912	#subject_classical_literature								
+work_5913	#subject_classical_literature								
+work_1243	#subject_philosophy	#subject_classical_literature							
+work_1244	#subject_rhetoric	#subject_classical_literature							
+work_5914	#subject_classical_literature								
+work_1245	#subject_philosophy	#subject_classical_literature							
+work_1246	#subject_philosophy	#subject_classical_literature							
+work_1247	#subject_rhetoric	#subject_classical_literature							
+work_1248	#subject_rhetoric	#subject_classical_literature							
+work_1249	#subject_philosophy	#subject_classical_literature							
+work_1250	#subject_philosophy	#subject_classical_literature							
+work_1251	#subject_philosophy	#subject_classical_literature							
+work_1252	#subject_classical_literature								
+work_1253	#subject_classical_literature								
+work_1254	#subject_classical_literature								
+work_1255	#subject_classical_literature								
+work_1256	#subject_classical_literature	#subject_rhetoric							
+work_1257	#subject_classical_literature								
+work_1258	#subject_rhetoric	#subject_classical_literature							
+work_1259	#subject_rhetoric	#subject_classical_literature							
+work_1260	#subject_rhetoric	#subject_classical_literature							
+work_1261	#subject_rhetoric	#subject_classical_literature							
+work_1262	#subject_rhetoric	#subject_classical_literature							
+work_1263	#subject_philosophy	#subject_classical_literature							
+work_1264	#subject_rhetoric	#subject_classical_literature							
+work_1266	#subject_rhetoric	#subject_classical_literature							
+work_1267	#subject_rhetoric	#subject_classical_literature							
+work_1268	#subject_rhetoric	#subject_classical_literature							
+work_1269	#subject_rhetoric	#subject_classical_literature							
+work_1270	#subject_philosophy	#subject_classical_literature							
+work_1271	#subject_philosophy	#subject_classical_literature							
+work_1272	#subject_rhetoric	#subject_classical_literature							
+work_1273	#subject_philosophy	#subject_classical_literature							
+work_1274	#subject_rhetoric	#subject_classical_literature							
+work_1276	#subject_classical_literature								
+work_3819	#subject_rhetoric								
+work_6338	#subject_grammar								
+work_3973	#subject_classical_literature								
+work_3975	#subject_rhetoric								
+work_3976	#subject_rhetoric								
+work_3977	#subject_rhetoric								
+work_895	#subject_law								
+work_286	#subject_grammar								
+work_11030	#subject_documents								
+work_1277	#subject_literature								
+work_11032	#subject_monasticism_and_religious_orders	#subject_law							
+work_11033	#subject_monasticism_and_religious_orders								
+work_11034	#subject_monasticism_and_religious_orders	#subject_law							
+work_11035	#subject_monasticism_and_religious_orders	#subject_law							
+work_11036	#subject_law								
+work_2683	#subject_literature								
+work_2682	#subject_literature								
+work_1279	#subject_law								
+work_11037	#subject_bible	#subject_literature							
+work_11038	#subject_literature								
+work_11039	#subject_literature								
+work_11040	#subject_literature								
+work_11041	#subject_literature								
+work_11042	#subject_literature								
+work_11043	#subject_literature								
+work_1280	#subject_literature								
+work_1281	#subject_classical_literature								
+work_1282	#subject_classical_literature								
+work_1283	#subject_classical_literature								
+work_1284	#subject_classical_literature								
+work_6258	#subject_theology								
+work_6422	#subject_sermons								
+work_3978	#subject_law								
+work_3979	#subject_law								
+work_5661	#subject_hagiography								
+work_1289	#subject_theology								
+work_1290	#subject_theology								
+work_1292	#subject_bible								
+work_1293	#subject_bible								
+work_1286	#subject_law								
+work_1287	#subject_law	#subject_monasticism_and_religious_orders							
+work_1288	#subject_monasticism_and_religious_orders								
+work_1557	#subject_literature								
+work_1294	#subject_science								
+work_6182	#subject_music	#subject_classical_literature							
+work_3980	#subject_medicine								
+work_1546	#subject_theology								
+work_11047	#subject_christian_literature	#subject_theology							
+work_11050	#subject_heraldry								
+work_11051	#subject_heraldry								
+work_11049	#subject_heraldry								
+work_1701	#subject_politics_and_government								
+work_3188	#subject_science								
+work_11056	#subject_literature								
+work_11058	#subject_grammar								
+work_11059	#subject_history	#subject_geography	#subject_liturgy	#subject_bible					
+work_11060	#subject_liturgy								
+work_11061	#subject_liturgy								
+work_11062	#subject_liturgy								
+work_11063	#subject_liturgy								
+work_11064	#subject_liturgy								
+work_11065	#subject_liturgy								
+work_16217	#subject_law								
+work_10731	#subject_law								
+work_16213	#subject_law								
+work_10730	#subject_law								
+work_11066	#subject_law								
+work_16025	#subject_law								
+work_16292	#subject_sermons								
+work_16273	#subject_sermons								
+work_17014	#subject_law								
+work_11068	#subject_law								
+work_11069	#subject_heraldry								
+work_11070	#subject_documents	#subject_law							
+work_11071	#subject_theology	#subject_sermons							
+work_11072	#subject_science								
+work_11074	#subject_law								
+work_11075	#subject_law								
+work_11076	#subject_law								
+work_11077	#subject_history	#subject_literature							
+work_11078	#subject_sermons								
+work_11079	#subject_monasticism_and_religious_orders								
+work_11081	#subject_theology	#subject_geography							
+work_11082	#subject_law								
+work_11083	#subject_documents								
+work_11084	#subject_literature								
+work_11085	#subject_law								
+work_11086	#subject_literature								
+work_11087	#subject_christian_literature								
+work_11088	#subject_monasticism_and_religious_orders								
+work_11089	#subject_theology								
+work_11090	#subject_literature								
+work_11091	#subject_documents								
+work_11092	#subject_theology								
+work_11093	#subject_theology								
+work_11094	#subject_theology								
+work_11095	#subject_literature								
+work_11096	#subject_literature								
+work_11097	#subject_law	#subject_clergy							
+work_3440	#subject_literature								
+work_11098	#subject_grammar								
+work_1907	#subject_history								
+work_1908	#subject_history								
+work_7509	#subject_christian_literature								
+work_4594	#subject_monasticism_and_religious_orders								
+work_1298	#subject_classical_literature								
+work_11099	#subject_literature								
+work_11100	#subject_literature	#subject_literature							
+work_11101	#subject_literature								
+work_11102	#subject_liturgy	#subject_christian_literature							
+work_11103	#subject_liturgy								
+work_11105	#subject_bible								
+work_11107	#subject_law								
+work_11108	#subject_philosophy								
+work_11109	#subject_philosophy								
+work_11110	#subject_philosophy	#subject_natural_history							
+work_11111	#subject_philosophy	#subject_science							
+work_11113	#subject_bible								
+work_11114	#subject_literature								
+work_11116	#subject_grammar								
+work_11117	#subject_bible								
+work_11118	#subject_medicine								
+work_11119	#subject_law								
+work_11121	#subject_liturgy								
+work_11122	#subject_liturgy								
+work_11123	#subject_philosophy								
+work_11124	#subject_bible								
+work_11125	#subject_literature								
+work_11126	#subject_grammar								
+work_11128	#subject_bible								
+work_11112	#subject_bible								
+work_11127	#subject_bible								
+work_11129	#subject_theology								
+work_11130	#subject_law								
+work_11172	#subject_christian_literature								
+work_16366	#subject_bible								
+work_17123	#subject_bible								
+work_17133	#subject_bible								
+work_17135	#subject_bible								
+work_17122	#subject_bible								
+work_17134	#subject_bible								
+work_17136	#subject_bible								
+work_11132	#subject_grammar								
+work_11133	#subject_medicine								
+work_11134	#subject_philosophy								
+work_16303	#subject_bible								
+work_16336	#subject_law								
+work_16232	#subject_medicine								
+work_16308	#subject_science								
+work_16270	#subject_grammar								
+work_11135	#subject_grammar								
+work_15602	#subject_bible								
+work_11137	#subject_bible								
+work_11140	#subject_philosophy								
+work_11141	#subject_philosophy								
+work_11142	#subject_philosophy								
+work_17049	#subject_philosophy								
+work_11143	#subject_philosophy								
+work_11146	#subject_rhetoric								
+work_11147	#subject_philosophy	#subject_science							
+work_11148	#subject_science								
+work_11149	#subject_philosophy								
+work_11150	#subject_philosophy								
+work_11164	#subject_philosophy								
+work_11152	#subject_philosophy								
+work_11153	#subject_science								
+work_11155	#subject_natural_history								
+work_11157	#subject_science								
+work_11158	#subject_philosophy								
+work_11159	#subject_philosophy								
+work_11160	#subject_philosophy								
+work_11162	#subject_philosophy								
+work_11163	#subject_philosophy								
+work_11168	#subject_theology								
+work_11169	#subject_monasticism_and_religious_orders								
+work_16283	#subject_bible								
+work_11171	#subject_christian_literature								
+work_11174	#subject_philosophy								
+work_11175	#subject_philosophy								
+work_11176	#subject_science								
+work_11177	#subject_music								
+work_11182	#subject_bible								
+work_11184	#subject_philosophy								
+work_11185	#subject_literature								
+work_11186	#subject_literature								
+work_17132	#subject_bible								
+work_11190	#subject_theology								
+work_11191	#subject_bible								
+work_11192	#subject_literature								
+work_11195	#subject_law								
+work_11197	#subject_grammar								
+work_11198	#subject_conduct								
+work_16298	#subject_bible								
+work_11199	#subject_bible								
+work_16031	#subject_science								
+work_11200	#subject_grammar								
+work_17081	#subject_bible								
+work_11201	#subject_bible								
+work_11203	#subject_medicine								
+work_16034	#subject_bible								
+work_11204	#subject_bible								
+work_17051	#subject_theology								
+work_11206	#subject_bible								
+work_11207	#subject_bible	#subject_liturgy							
+work_11208	#subject_bible	#subject_liturgy							
+work_11209	#subject_bible	#subject_liturgy							
+work_11210	#subject_law								
+work_11211	#subject_liturgy								
+work_11212	#subject_law								
+work_17138	#subject_bible								
+work_3126	#subject_rhetoric								
+work_16231	#subject_medicine								
+work_11213	#subject_medicine								
+work_11214	#subject_medicine								
+work_11215	#subject_literature								
+work_11225	#subject_bible								
+work_11217	#subject_bible								
+work_11216	#subject_bible								
+work_15608	#subject_bible								
+work_11219	#subject_bible								
+work_15610	#subject_bible								
+work_11218	#subject_bible								
+work_11220	#subject_science								
+work_11221	#subject_medicine								
+work_11222	#subject_bible								
+work_11289	#subject_bible								
+work_11223	#subject_law								
+work_16253	#subject_bible								
+work_11196	#subject_law								
+work_11224	#subject_literature								
+work_17096	#subject_bible								
+work_11226	#subject_philosophy								
+work_11229	#subject_literature								
+work_11230	#subject_literature								
+work_11232	#subject_bible								
+work_11233	#subject_theology	#subject_bible							
+work_17077	#subject_bible								
+work_11234	#subject_geography	#subject_science							
+work_17080	#subject_bible								
+work_16088	#subject_bible								
+work_11239	#subject_bible								
+work_11240	#subject_bible								
+work_11242	#subject_literature								
+work_11243	#subject_literature								
+work_11245	#subject_bible								
+work_11250	#subject_theology								
+work_11255	#subject_theology								
+work_11257	#subject_medicine								
+work_17137	#subject_bible								
+work_17124	#subject_bible								
+work_11258	#subject_theology								
+work_11259	#subject_philosophy								
+work_11260	#subject_literature								
+work_11261	#subject_philosophy								
+work_11262	#subject_grammar								
+work_16352	#subject_bible								
+work_11263	#subject_bible								
+work_11264	#subject_science								
+work_11265	#subject_science								
+work_11266	#subject_science								
+work_11267	#subject_philosophy								
+work_11268	#subject_rhetoric								
+work_11269	#subject_theology								
+work_11270	#subject_bible								
+work_11272	#subject_bible								
+work_11274	#subject_bible								
+work_11271	#subject_bible								
+work_11276	#subject_bible								
+work_11104	#subject_bible								
+work_11278	#subject_science								
+work_11279	#subject_monasticism_and_religious_orders								
+work_11280	#subject_monasticism_and_religious_orders								
+work_17079	#subject_bible								
+work_11281	#subject_law								
+work_11282	#subject_liturgy								
+work_11283	#subject_liturgy								
+work_11284	#subject_rhetoric	#subject_literature							
+work_11285	#subject_law								
+work_11286	#subject_literature								
+work_16282	#subject_bible								
+work_17102	#subject_bible								
+work_11288	#subject_bible								
+work_11290	#subject_bible								
+work_11292	#subject_bible								
+work_11236	#subject_bible								
+work_11293	#subject_bible								
+work_11296	#subject_theology								
+work_11136	#subject_science								
+work_11138	#subject_theology								
+work_11139	#subject_theology								
+work_11166	#subject_theology								
+work_11167	#subject_theology								
+work_11170	#subject_bible								
+work_15606	#subject_literature	#subject_bible							
+work_11180	#subject_bible								
+work_11183	#subject_bible								
+work_17083	#subject_law								
+work_11188	#subject_theology								
+work_11189	#subject_theology								
+work_11193	#subject_theology								
+work_11194	#subject_theology								
+work_17003	#subject_law								
+work_11202	#subject_monasticism_and_religious_orders								
+work_16081	#subject_bible								
+work_16076	#subject_theology								
+work_16174	#subject_theology								
+work_16077	#subject_theology								
+work_11227	#subject_theology								
+work_11228	#subject_theology	#subject_theology							
+work_11231	#subject_bible								
+work_11235	#subject_theology								
+work_11237	#subject_bible								
+work_11238	#subject_bible								
+work_11241	#subject_bible								
+work_11244	#subject_theology								
+work_11247	#subject_bible								
+work_11248	#subject_bible								
+work_11249	#subject_bible								
+work_16281	#subject_bible								
+work_17011	#subject_bible								
+work_17033	#subject_bible								
+work_11273	#subject_bible								
+work_11287	#subject_bible								
+work_11294	#subject_clergy								
+work_11295	#subject_theology								
+work_11297	#subject_theology								
+work_11298	#subject_medicine								
+work_11299	#subject_theology								
+work_11300	#subject_literature								
+work_11301	#subject_literature								
+work_11302	#subject_philosophy								
+work_16230	#subject_classical_literature								
+work_11307	#subject_documents								
+work_11308	#subject_documents								
+work_11310	#subject_documents								
+work_11312	#subject_literature								
+work_11313	#subject_literature								
+work_11314	#subject_literature								
+work_11315	#subject_literature								
+work_11316	#subject_medicine	#subject_literature	#subject_law	#subject_magic	#subject_documents	#subject_history			
+work_11318	#subject_history								
+work_16326	#subject_monasticism_and_religious_orders								
+work_11319	#subject_literature								
+work_11320	#subject_medicine								
+work_16319	#subject_literature								
+work_11321	#subject_documents								
+work_11322	#subject_literature	#subject_science							
+work_11325	#subject_science								
+work_11326	#subject_documents								
+work_11328	#subject_science								
+work_11329	#subject_science	#subject_science							
+work_11330	#subject_science	#subject_science							
+work_11331	#subject_science								
+work_11332	#subject_science								
+work_11333	#subject_science								
+work_11334	#subject_science								
+work_11335	#subject_theology								
+work_17095	#subject_indexes								
+work_17055	#subject_indexes								
+work_17056	#subject_indexes								
+work_10468	#subject_bible								
+work_11336	#subject_indexes								
+work_17053	#subject_philosophy	#subject_indexes							
+work_11337	#subject_bible								
+work_11338	#subject_bible								
+work_16374	#subject_bible								
+work_11339	#subject_documents	#subject_monasticism_and_religious_orders							
+work_11340	#subject_documents	#subject_monasticism_and_religious_orders							
+work_4994	#subject_medicine								
+work_7410	#subject_law								
+work_1309	#subject_sermons								
+work_1310	#subject_theology								
+work_1302	#subject_sermons								
+work_1311	#subject_theology								
+work_1299	#subject_sermons								
+work_1300	#subject_christian_literature								
+work_1303	#subject_christian_literature								
+work_1304	#subject_christian_literature	#subject_theology							
+work_1305	#subject_christian_literature	#subject_theology							
+work_1306	#subject_christian_literature	#subject_theology							
+work_16327	#subject_theology								
+work_1317	#subject_history								
+work_1329	#subject_politics_and_government								
+work_1318	#subject_medicine								
+work_1319	#subject_medicine								
+work_5743	#subject_medicine								
+work_7151	#subject_medicine								
+work_1320	#subject_medicine								
+work_7243	#subject_philosophy								
+work_7153	#subject_medicine								
+work_7152	#subject_medicine								
+work_1321	#subject_medicine								
+work_1322	#subject_medicine								
+work_1323	#subject_medicine								
+work_1324	#subject_medicine								
+work_1325	#subject_medicine								
+work_1331	#subject_sermons								
+work_5927	#subject_sermons								
+work_5659	#subject_law								
+work_1327	#subject_hagiography								
+work_11341	#subject_law								
+work_11342	#subject_clergy	#subject_liturgy							
+work_11343	#subject_law								
+work_11345	#subject_law	#subject_clergy							
+work_11346	#subject_clergy	#subject_law							
+work_11347	#subject_law	#subject_clergy							
+work_11348	#subject_law								
+work_11349	#subject_law								
+work_11356	#subject_clergy	#subject_law							
+work_11351	#subject_law	#subject_clergy							
+work_11352	#subject_law	#subject_clergy							
+work_11353	#subject_clergy								
+work_11354	#subject_clergy	#subject_law							
+work_11355	#subject_clergy	#subject_law							
+work_11358	#subject_law	#subject_monasticism_and_religious_orders							
+work_11359	#subject_law								
+work_11360	#subject_clergy	#subject_law							
+work_11361	#subject_clergy	#subject_law							
+work_11362	#subject_clergy	#subject_law							
+work_11363	#subject_clergy	#subject_law							
+work_11364	#subject_clergy	#subject_law							
+work_11365	#subject_clergy	#subject_law							
+work_11366	#subject_clergy	#subject_law							
+work_11367	#subject_law	#subject_clergy							
+work_11350	#subject_clergy	#subject_law							
+work_11357	#subject_monasticism_and_religious_orders	#subject_law							
+work_17015	#subject_law								
+work_11368	#subject_liturgy								
+work_11369	#subject_liturgy								
+work_2190	#subject_theology								
+work_1732	#subject_science								
+work_11370	#subject_christian_literature								
+work_1798	#subject_literature								
+work_3339	#subject_science								
+work_11371	#subject_theology								
+work_11372	#subject_documents								
+work_11373	#subject_documents								
+work_11374	#subject_documents								
+work_11375	#subject_documents								
+work_11376	#subject_documents								
+work_11377	#subject_documents								
+work_11378	#subject_documents								
+work_11379	#subject_documents								
+work_11380	#subject_documents								
+work_11381	#subject_documents								
+work_11382	#subject_documents								
+work_11383	#subject_documents								
+work_11384	#subject_documents								
+work_11385	#subject_documents								
+work_11386	#subject_documents								
+work_11387	#subject_documents								
+work_11389	#subject_science								
+work_7404	#subject_medicine								
+work_1332	#subject_medicine								
+work_7155	#subject_medicine								
+work_11390	#subject_documents	#subject_monasticism_and_religious_orders							
+work_11391	#subject_documents								
+work_11392	#subject_documents								
+work_11393	#subject_documents	#subject_monasticism_and_religious_orders							
+work_11394	#subject_documents								
+work_11395	#subject_grammar								
+work_16301	#subject_theology								
+work_11396	#subject_bible								
+work_11397	#subject_documents								
+work_578	#subject_literature								
+work_579	#subject_hagiography								
+work_11398	#subject_literature								
+work_11399	#subject_liturgy								
+work_3234	#subject_literature								
+work_11400	#subject_documents								
+work_590	#subject_law								
+work_3120	#subject_medicine								
+work_1335	#subject_law								
+work_2899	#subject_hagiography								
+work_16055	#subject_geography								
+work_1337	#subject_literature								
+work_11401	#subject_clergy	#subject_law							
+work_6139	#subject_sermons								
+work_11402	#subject_documents								
+work_11403	#subject_documents								
+work_11404	#subject_documents								
+work_11405	#subject_documents								
+work_11406	#subject_documents								
+work_7017	#subject_theology								
+work_5607	#subject_sermons								
+work_1338	#subject_classical_literature								
+work_10419	#subject_theology								
+work_3670	#subject_literature								
+work_3617	#subject_literature								
+work_1339	#subject_law								
+work_3021	#subject_history								
+work_7429	#subject_sermons								
+work_11408	#subject_hagiography								
+work_11409	#subject_science								
+work_11410	#subject_science								
+work_11411	#subject_science								
+work_5759	#subject_bible								
+work_1340	#subject_theology	#subject_theology							
+work_16250	#subject_bible								
+work_14465	#subject_law								
+work_11412	#subject_history								
+work_4162	#subject_history								
+work_4156	#subject_history								
+work_2296	#subject_science								
+work_11415	#subject_liturgy	#subject_monasticism_and_religious_orders							
+work_11414	#subject_liturgy	#subject_monasticism_and_religious_orders							
+work_13033	#subject_law	#subject_liturgy							
+work_11416	#subject_liturgy								
+work_11417	#subject_law								
+work_11418	#subject_law								
+work_11419	#subject_documents	#subject_law							
+work_11420	#subject_documents								
+work_11421	#subject_documents								
+work_11422	#subject_documents								
+work_1341	#subject_history								
+work_1344	#subject_theology								
+work_6300	#subject_theology								
+work_6294	#subject_theology								
+work_6303	#subject_theology								
+work_7119	#subject_christian_literature	#subject_clergy							
+work_6304	#subject_theology								
+work_6301	#subject_theology								
+work_6297	#subject_theology								
+work_1342	#subject_theology								
+work_6295	#subject_theology								
+work_6296	#subject_theology								
+work_6298	#subject_theology								
+work_6299	#subject_theology								
+work_6302	#subject_theology								
+work_1343	#subject_christian_literature								
+work_6306	#subject_theology								
+work_6307	#subject_theology								
+work_6308	#subject_theology								
+work_6305	#subject_theology								
+work_1345	#subject_hagiography								
+work_1346	#subject_magic								
+work_11427	#subject_science								
+work_3982	#subject_hagiography								
+work_3983	#subject_hagiography								
+work_5639	#subject_sermons								
+work_1352	#subject_theology								
+work_5933	#subject_hagiography								
+work_5143	#subject_history								
+work_1351	#subject_grammar								
+work_1347	#subject_bible								
+work_1348	#subject_bible								
+work_1349	#subject_theology								
+work_5997	#subject_sermons								
+work_1350	#subject_theology								
+work_5995	#subject_bible								
+work_5877	#subject_sermons								
+work_5996	#subject_theology								
+work_1353	#subject_rhetoric								
+work_1355	#subject_philosophy	#subject_classical_literature							
+work_1356	#subject_philosophy	#subject_classical_literature							
+work_3986	#subject_law								
+work_1358	#subject_law								
+work_1359	#subject_law								
+work_1360	#subject_law								
+work_1357	#subject_law								
+work_1361	#subject_natural_history								
+work_511	#subject_history								
+work_504	#subject_history								
+work_5634	#subject_christian_literature								
+work_1993	#subject_medicine								
+work_1362	#subject_hagiography								
+work_1363	#subject_hagiography								
+work_1364	#subject_christian_literature								
+work_1365	#subject_christian_literature								
+work_1366	#subject_christian_literature								
+work_1367	#subject_christian_literature								
+work_1368	#subject_christian_literature								
+work_6239	#subject_philosophy								
+work_1369	#subject_christian_literature								
+work_1370	#subject_christian_literature								
+work_1371	#subject_christian_literature								
+work_2684	#subject_philosophy								
+work_2685	#subject_philosophy								
+work_2686	#subject_philosophy								
+work_2687	#subject_theology								
+work_836	#subject_philosophy								
+work_1374	#subject_conduct	#subject_monasticism_and_religious_orders							
+work_1375	#subject_monasticism_and_religious_orders								
+work_226	#subject_politics_and_government								
+work_11429	#subject_documents								
+work_16083	#subject_hagiography	#subject_hagiography							
+work_11431	#subject_law								
+work_11432	#subject_grammar								
+work_11433	#subject_history	#subject_geography							
+work_11434	#subject_law								
+work_11435	#subject_bible								
+work_16373	#subject_theology								
+work_16371	#subject_science								
+work_16367	#subject_rhetoric								
+work_11436	#subject_law								
+work_17086	#subject_bible								
+work_11437	#subject_literature	#subject_theology							
+work_17028	#subject_medicine								
+work_11438	#subject_hagiography								
+work_11439	#subject_literature								
+work_11440	#subject_literature								
+work_16310	#subject_science								
+work_17036	#subject_philosophy								
+work_11441	#subject_theology								
+work_16328	#subject_theology								
+work_17084	#subject_liturgy								
+work_11442	#subject_science	#subject_science							
+work_16262	#subject_theology								
+work_16252	#subject_bible								
+work_11443	#subject_bible								
+work_11444	#subject_history	#subject_theology							
+work_16060	#subject_law								
+work_11445	#subject_medicine								
+work_16346	#subject_law								
+work_11446	#subject_bible								
+work_11447	#subject_medicine								
+work_16347	#subject_law								
+work_16251	#subject_bible								
+work_17106	#subject_literature	#subject_natural_history							
+work_17045	#subject_philosophy								
+work_11448	#subject_geography								
+work_17035	#subject_grammar								
+work_17044	#subject_philosophy								
+work_16069	#subject_theology								
+work_17029	#subject_medicine								
+work_17060	#subject_grammar	#subject_rhetoric							
+work_16084	#subject_hagiography	#subject_hagiography							
+work_15087	#subject_science								
+work_16309	#subject_science								
+work_11449	#subject_geography	#subject_history							
+work_11450	#subject_theology								
+work_17101	#subject_theology								
+work_16350	#subject_theology								
+work_16355	#subject_history								
+work_17008	#subject_theology								
+work_17041	#subject_theology	#subject_theology	#subject_theology						
+work_17070	#subject_medicine								
+work_16053	#subject_medicine								
+work_16256	#subject_science								
+work_11451	#subject_medicine								
+work_17073	#subject_medicine								
+work_11452	#subject_politics_and_government								
+work_16212	#subject_science								
+work_11453	#subject_politics_and_government								
+work_11455	#subject_hagiography								
+work_17009	#subject_liturgy	#subject_theology	#subject_clergy						
+work_11456	#subject_medicine								
+work_11457	#subject_science								
+work_16079	#subject_science								
+work_11458	#subject_grammar								
+work_11459	#subject_hagiography								
+work_11460	#subject_hagiography								
+work_11461	#subject_history								
+work_17105	#subject_medicine								
+work_17153	#subject_medicine								
+work_17025	#subject_medicine								
+work_11462	#subject_science								
+work_16271	#subject_theology								
+work_11463	#subject_classical_literature								
+work_16351	#subject_history	#subject_bible							
+work_1807	#subject_theology								
+work_11464	#subject_literature	#subject_literature							
+work_3667	#subject_grammar								
+work_3668	#subject_history								
+work_11465	#subject_documents								
+work_11466	#subject_documents								
+work_11467	#subject_documents								
+work_11468	#subject_law	#subject_documents							
+work_11469	#subject_monasticism_and_religious_orders	#subject_clergy							
+work_11470	#subject_law	#subject_clergy							
+work_11473	#subject_law	#subject_monasticism_and_religious_orders							
+work_11475	#subject_clergy	#subject_law							
+work_11471	#subject_law	#subject_clergy							
+work_11472	#subject_law	#subject_clergy							
+work_11474	#subject_law	#subject_clergy							
+work_11476	#subject_law								
+work_11477	#subject_law								
+work_11478	#subject_law								
+work_16257	#subject_law								
+work_11479	#subject_law								
+work_17039	#subject_law								
+work_11482	#subject_documents								
+work_11483	#subject_documents								
+work_11484	#subject_documents								
+work_11485	#subject_documents								
+work_11486	#subject_documents								
+work_11487	#subject_documents								
+work_11480	#subject_documents								
+work_11481	#subject_documents								
+work_11488	#subject_documents								
+work_11489	#subject_documents								
+work_11490	#subject_documents								
+work_11491	#subject_monasticism_and_religious_orders	#subject_documents							
+work_11492	#subject_documents								
+work_11493	#subject_documents								
+work_11494	#subject_theology								
+work_1376	#subject_christian_literature								
+work_3631	#subject_clergy	#subject_law							
+work_3683	#subject_theology								
+work_11495	#subject_hagiography								
+work_3216	#subject_history								
+work_16059	#subject_geography								
+work_6216	#subject_sermons	#subject_hagiography							
+work_1377	#subject_theology								
+work_1378	#subject_classical_literature	#subject_rhetoric							
+work_1379	#subject_classical_literature	#subject_rhetoric							
+work_1380	#subject_classical_literature	#subject_rhetoric							
+work_1381	#subject_classical_literature	#subject_rhetoric							
+work_11496	#subject_documents								
+work_11497	#subject_history	#subject_documents							
+work_11498	#subject_documents	#subject_law							
+work_11499	#subject_documents								
+work_13055	#subject_hagiography								
+work_16297	#subject_geography								
+work_11501	#subject_geography								
+work_11502	#subject_geography								
+work_11503	#subject_geography								
+work_11504	#subject_medicine								
+work_11505	#subject_theology	#subject_geography							
+work_11506	#subject_geography								
+work_11500	#subject_bible								
+work_11507	#subject_geography								
+work_11509	#subject_clergy								
+work_17010	#subject_theology								
+work_1385	#subject_christian_literature								
+work_7087	#subject_theology								
+work_11513	#subject_christian_literature								
+work_11514	#subject_christian_literature								
+work_11515	#subject_christian_literature								
+work_11517	#subject_christian_literature								
+work_11516	#subject_christian_literature								
+work_11518	#subject_christian_literature	#subject_christian_literature							
+work_11519	#subject_christian_literature								
+work_11520	#subject_christian_literature								
+work_11521	#subject_christian_literature	#subject_literature							
+work_11526	#subject_christian_literature								
+work_11523	#subject_christian_literature								
+work_11524	#subject_christian_literature								
+work_11522	#subject_christian_literature								
+work_11525	#subject_christian_literature								
+work_11527	#subject_sermons	#subject_christian_literature							
+work_11528	#subject_literature	#subject_christian_literature							
+work_11529	#subject_christian_literature								
+work_11530	#subject_christian_literature								
+work_11531	#subject_christian_literature								
+work_11532	#subject_christian_literature	#subject_hagiography							
+work_1386	#subject_philosophy								
+work_5850	#subject_theology								
+work_1387	#subject_theology								
+work_1388	#subject_theology								
+work_11533	#subject_theology								
+work_11534	#subject_theology								
+work_11536	#subject_hagiography	#subject_theology							
+work_11535	#subject_medicine	#subject_law							
+work_11537	#subject_clergy	#subject_liturgy							
+work_11538	#subject_theology								
+work_17503	#subject_medicine								
+work_4187	#subject_history								
+work_11539	#subject_philosophy	#subject_literature							
+work_11541	#subject_grammar								
+work_11542	#subject_grammar								
+work_11543	#subject_law								
+work_1389	#subject_history								
+work_1390	#subject_geography								
+work_11544	#subject_medicine								
+work_11545	#subject_literature	#subject_medicine							
+work_4684	#subject_hagiography								
+work_11546	#subject_grammar	#subject_rhetoric							
+work_1392	#subject_classical_literature	#subject_rhetoric							
+work_11548	#subject_geography								
+work_1394	#subject_medicine								
+work_1395	#subject_medicine								
+work_1393	#subject_law								
+work_1396	#subject_medicine								
+work_1397	#subject_history								
+work_3987	#subject_philosophy	#subject_classical_literature							
+work_5156	#subject_literature								
+work_6324	#subject_grammar								
+work_1406	#subject_classical_literature								
+work_6172	#subject_theology								
+work_1400	#subject_law								
+work_152	#subject_grammar								
+work_1405	#subject_grammar								
+work_157	#subject_grammar	#subject_rhetoric							
+work_158	#subject_grammar								
+work_1382	#subject_christian_literature								
+work_1383	#subject_theology								
+work_1399	#subject_christian_literature								
+work_12601	#subject_hagiography								
+work_1408	#subject_history								
+work_1409	#subject_classical_literature								
+work_1401	#subject_grammar								
+work_1410	#subject_rhetoric								
+work_1403	#subject_geography								
+work_1404	#subject_geography								
+work_6052	#subject_theology								
+work_6051	#subject_theology								
+work_3989	#subject_theology								
+work_7001	#subject_theology								
+work_3991	#subject_theology								
+work_6053	#subject_theology								
+work_7003	#subject_theology								
+work_7002	#subject_theology								
+work_6054	#subject_theology								
+work_7000	#subject_theology								
+work_3992	#subject_theology								
+work_6055	#subject_theology								
+work_3988	#subject_theology								
+work_6049	#subject_theology								
+work_6050	#subject_theology								
+work_3993	#subject_theology								
+work_3990	#subject_theology								
+work_1411	#subject_medicine								
+work_3994	#subject_medicine								
+work_11549	#subject_christian_literature	#subject_theology							
+work_11551	#subject_theology								
+work_11552	#subject_literature								
+work_11553	#subject_theology								
+work_11554	#subject_theology								
+work_11555	#subject_theology								
+work_11556	#subject_theology	#subject_christian_literature							
+work_17076	#subject_philosophy								
+work_11558	#subject_grammar								
+work_11559	#subject_grammar								
+work_11560	#subject_grammar								
+work_11561	#subject_grammar								
+work_11562	#subject_grammar								
+work_11563	#subject_grammar								
+work_11564	#subject_theology								
+work_16263	#subject_law								
+work_11567	#subject_theology								
+work_11565	#subject_bible	#subject_theology							
+work_11566	#subject_theology								
+work_16274	#subject_theology	#subject_theology	#subject_bible						
+work_11568	#subject_theology	#subject_theology	#subject_bible						
+work_11569	#subject_liturgy								
+work_11574	#subject_liturgy								
+work_11570	#subject_liturgy								
+work_11575	#subject_liturgy								
+work_11576	#subject_liturgy								
+work_11572	#subject_liturgy								
+work_11573	#subject_liturgy								
+work_11577	#subject_liturgy								
+work_11578	#subject_theology								
+work_16047	#subject_history								
+work_11579	#subject_documents	#subject_law							
+work_11580	#subject_theology								
+work_16227	#subject_theology	#subject_literature							
+work_11581	#subject_documents								
+work_11582	#subject_documents								
+work_11583	#subject_documents	#subject_documents							
+work_11584	#subject_documents								
+work_11585	#subject_documents								
+work_11586	#subject_documents								
+work_11588	#subject_documents								
+work_11589	#subject_documents								
+work_11590	#subject_documents								
+work_11591	#subject_documents	#subject_monasticism_and_religious_orders							
+work_11592	#subject_documents	#subject_law							
+work_11593	#subject_documents								
+work_11594	#subject_documents								
+work_11596	#subject_documents								
+work_11597	#subject_documents								
+work_11599	#subject_documents								
+work_11595	#subject_documents								
+work_11598	#subject_documents								
+work_11600	#subject_documents								
+work_11601	#subject_documents								
+work_11602	#subject_documents								
+work_11587	#subject_documents								
+work_11603	#subject_documents								
+work_11604	#subject_documents								
+work_11605	#subject_documents								
+work_11606	#subject_documents								
+work_11607	#subject_documents								
+work_11608	#subject_documents								
+work_11609	#subject_documents								
+work_11610	#subject_documents								
+work_11611	#subject_documents								
+work_11612	#subject_monasticism_and_religious_orders	#subject_documents							
+work_11613	#subject_documents								
+work_11614	#subject_documents								
+work_11615	#subject_law								
+work_11616	#subject_documents								
+work_11617	#subject_documents								
+work_11618	#subject_documents								
+work_11619	#subject_documents								
+work_11620	#subject_documents								
+work_11621	#subject_documents								
+work_11622	#subject_geography	#subject_history							
+work_11623	#subject_clergy								
+work_11624	#subject_documents								
+work_11625	#subject_history	#subject_documents							
+work_11626	#subject_documents								
+work_11628	#subject_clergy								
+work_11629	#subject_documents								
+work_11630	#subject_documents								
+work_11631	#subject_documents								
+work_11632	#subject_documents								
+work_11633	#subject_documents								
+work_11635	#subject_clergy								
+work_11636	#subject_clergy								
+work_11638	#subject_documents								
+work_11641	#subject_documents								
+work_11642	#subject_documents								
+work_11645	#subject_documents	#subject_clergy							
+work_11647	#subject_documents								
+work_11648	#subject_documents								
+work_11653	#subject_documents								
+work_11654	#subject_documents								
+work_11655	#subject_documents								
+work_11656	#subject_documents								
+work_11634	#subject_documents								
+work_11637	#subject_documents	#subject_clergy							
+work_11639	#subject_documents								
+work_11640	#subject_documents								
+work_11643	#subject_documents								
+work_11644	#subject_monasticism_and_religious_orders								
+work_11646	#subject_documents								
+work_11649	#subject_documents								
+work_11650	#subject_documents								
+work_11651	#subject_documents								
+work_11652	#subject_documents								
+work_11657	#subject_documents	#subject_hagiography							
+work_11658	#subject_documents								
+work_11659	#subject_documents								
+work_11660	#subject_documents	#subject_theology							
+work_11627	#subject_documents								
+work_11661	#subject_liturgy								
+work_11662	#subject_documents								
+work_11663	#subject_documents								
+work_11303	#subject_documents								
+work_1422	#subject_theology								
+work_1421	#subject_theology								
+work_1423	#subject_sermons								
+work_1419	#subject_grammar								
+work_1776	#subject_christian_literature								
+work_2481	#subject_theology								
+work_2482	#subject_christian_literature								
+work_5618	#subject_philosophy								
+work_5617	#subject_theology								
+work_5619	#subject_philosophy								
+work_3582	#subject_rhetoric								
+work_11664	#subject_theology	#subject_christian_literature	#subject_christian_literature						
+work_1424	#subject_grammar								
+work_1425	#subject_grammar								
+work_258	#subject_classical_literature								
+work_259	#subject_rhetoric								
+work_7079	#subject_classical_literature								
+work_3995	#subject_grammar								
+work_2554	#subject_natural_history								
+work_2555	#subject_natural_history								
+work_2341	#subject_grammar								
+work_514	#subject_classical_literature								
+work_1427	#subject_monasticism_and_religious_orders	#subject_christian_literature							
+work_1430	#subject_christian_literature								
+work_1431	#subject_sermons								
+work_1432	#subject_christian_literature								
+work_1426	#subject_science								
+work_5137	#subject_bible								
+work_1547	#subject_history								
+work_11665	#subject_documents								
+work_11666	#subject_documents								
+work_5629	#subject_christian_literature								
+work_11672	#subject_literature								
+work_11673	#subject_christian_literature								
+work_7244	#subject_philosophy								
+work_4058	#subject_philosophy								
+work_7005	#subject_theology								
+work_7015	#subject_theology								
+work_7014	#subject_theology								
+work_2689	#subject_philosophy								
+work_6202	#subject_philosophy								
+work_5973	#subject_theology								
+work_1434	#subject_theology								
+work_5974	#subject_theology								
+work_5971	#subject_theology								
+work_5972	#subject_theology								
+work_7342	#subject_theology								
+work_7013	#subject_theology	#subject_philosophy							
+work_1435	#subject_philosophy								
+work_2222	#subject_philosophy								
+work_7278	#subject_philosophy								
+work_7200	#subject_philosophy								
+work_2691	#subject_philosophy								
+work_7012	#subject_theology								
+work_1438	#subject_liturgy								
+work_4984	#subject_liturgy								
+work_1437	#subject_conduct								
+work_1439	#subject_theology								
+work_1442	#subject_theology								
+work_5768	#subject_theology								
+work_5767	#subject_theology								
+work_6067	#subject_history								
+work_6586	#subject_hagiography								
+work_11675	#subject_science								
+work_11676	#subject_science								
+work_11677	#subject_science								
+work_227	#subject_hagiography								
+work_4838	#subject_sermons								
+work_11679	#subject_clergy	#subject_law							
+work_11680	#subject_clergy	#subject_law							
+work_11687	#subject_law	#subject_clergy							
+work_11681	#subject_clergy	#subject_law							
+work_11682	#subject_clergy	#subject_documents							
+work_11683	#subject_clergy	#subject_documents							
+work_11684	#subject_law	#subject_clergy	#subject_sermons						
+work_11685	#subject_clergy	#subject_law							
+work_11688	#subject_clergy								
+work_15572	#subject_theology								
+work_2446	#subject_theology								
+work_11689	#subject_law								
+work_2898	#subject_clergy	#subject_monasticism_and_religious_orders							
+work_11690	#subject_documents								
+work_11691	#subject_documents								
+work_1445	#subject_hagiography								
+work_6280	#subject_christian_literature								
+work_6245	#subject_liturgy								
+work_1446	#subject_theology								
+work_1448	#subject_theology								
+work_5969	#subject_theology								
+work_1447	#subject_theology								
+work_1449	#subject_theology	#subject_monasticism_and_religious_orders							
+work_1453	#subject_science								
+work_3996	#subject_clergy								
+work_1451	#subject_politics_and_government								
+work_1454	#subject_recreation								
+work_3997	#subject_theology	#subject_theology							
+work_3998	#subject_theology	#subject_theology							
+work_1444	#subject_theology								
+work_1667	#subject_history								
+work_7409	#subject_law								
+work_1457	#subject_history								
+work_6230	#subject_christian_literature								
+work_6105	#subject_hagiography								
+work_1459	#subject_christian_literature								
+work_1441	#subject_hagiography								
+work_1461	#subject_hagiography								
+work_1460	#subject_christian_literature								
+work_260	#subject_christian_literature								
+work_11693	#subject_science								
+work_11694	#subject_natural_history								
+work_11695	#subject_documents								
+work_11696	#subject_history	#subject_geography							
+work_11697	#subject_clergy	#subject_law							
+work_1463	#subject_christian_literature								
+work_5662	#subject_hagiography								
+work_6164	#subject_monasticism_and_religious_orders								
+work_6030	#subject_theology								
+work_5865	#subject_theology								
+work_6162	#subject_theology								
+work_5868	#subject_theology								
+work_1464	#subject_theology								
+work_6056	#subject_theology								
+work_6163	#subject_theology								
+work_6029	#subject_sermons								
+work_6161	#subject_sermons								
+work_5690	#subject_sermons								
+work_1467	#subject_sermons								
+work_3999	#subject_sermons								
+work_1465	#subject_sermons								
+work_1466	#subject_sermons								
+work_5873	#subject_hagiography								
+work_1468	#subject_theology								
+work_1469	#subject_philosophy	#subject_classical_literature							
+work_11698	#subject_literature								
+work_11699	#subject_literature								
+work_7357	#subject_bible								
+work_6116	#subject_bible								
+work_1470	#subject_hagiography								
+work_1471	#subject_bible								
+work_5144	#subject_sermons								
+work_5702	#subject_sermons								
+work_5644	#subject_sermons								
+work_1473	#subject_bible	#subject_natural_history							
+work_11700	#subject_liturgy								
+work_16033	#subject_bible	#subject_liturgy							
+work_11701	#subject_liturgy								
+work_11709	#subject_literature								
+work_16358	#subject_theology								
+work_11712	#subject_bible								
+work_16126	#subject_bible								
+work_11713	#subject_literature								
+work_11714	#subject_bible								
+work_11715	#subject_bible								
+work_11716	#subject_law								
+work_11717	#subject_liturgy								
+work_11718	#subject_liturgy								
+work_11719	#subject_literature								
+work_11720	#subject_bible	#subject_literature							
+work_17504	#subject_medicine								
+work_11723	#subject_literature								
+work_17062	#subject_literature								
+work_11725	#subject_literature								
+work_11726	#subject_literature								
+work_11727	#subject_literature								
+work_11728	#subject_literature								
+work_16259	#subject_hagiography								
+work_16364	#subject_law								
+work_11729	#subject_literature								
+work_15573	#subject_christian_literature								
+work_1384	#subject_politics_and_government								
+work_1474	#subject_literature								
+work_2692	#subject_history								
+work_2519	#subject_classical_literature								
+work_2520	#subject_natural_history								
+work_1476	#subject_theology								
+work_11731	#subject_literature								
+work_11732	#subject_grammar								
+work_1477	#subject_medicine	#subject_grammar							
+work_2617	#subject_science								
+work_2618	#subject_science								
+work_512	#subject_theology								
+work_2160	#subject_theology								
+work_11733	#subject_grammar								
+work_11735	#subject_bible								
+work_16014	#subject_bible								
+work_11736	#subject_bible								
+work_11737	#subject_bible								
+work_4000	#subject_geography								
+work_1478	#subject_christian_literature								
+work_11739	#subject_liturgy								
+work_4001	#subject_science								
+work_1479	#subject_science	#subject_classical_literature							
+work_7340	#subject_science	#subject_classical_literature							
+work_1480	#subject_science	#subject_classical_literature							
+work_1481	#subject_science	#subject_classical_literature							
+work_1482	#subject_science	#subject_classical_literature							
+work_1483	#subject_classical_literature								
+work_6425	#subject_theology								
+work_6069	#subject_christian_literature								
+work_1484	#subject_law								
+work_6571	#subject_liturgy								
+work_6269	#subject_bible								
+work_6582	#subject_theology	#subject_theology							
+work_6578	#subject_theology								
+work_6583	#subject_history								
+work_6572	#subject_theology								
+work_6573	#subject_bible								
+work_6570	#subject_theology								
+work_6576	#subject_theology								
+work_6574	#subject_theology								
+work_6580	#subject_theology								
+work_6579	#subject_theology								
+work_6577	#subject_bible								
+work_6581	#subject_theology								
+work_6575	#subject_bible								
+work_4002	#subject_geography								
+work_1486	#subject_christian_literature								
+work_1487	#subject_theology								
+work_5666	#subject_hagiography	#subject_monasticism_and_religious_orders							
+work_6097	#subject_literature								
+work_1488	#subject_classical_literature								
+work_1489	#subject_classical_literature								
+work_1490	#subject_classical_literature								
+work_1491	#subject_classical_literature								
+work_1492	#subject_classical_literature								
+work_1493	#subject_classical_literature								
+work_1494	#subject_classical_literature								
+work_4003	#subject_hagiography								
+work_4004	#subject_hagiography								
+work_1501	#subject_sermons	#subject_monasticism_and_religious_orders							
+work_175	#subject_sermons								
+work_5770	#subject_sermons								
+work_176	#subject_sermons								
+work_1502	#subject_sermons								
+work_6041	#subject_sermons								
+work_6028	#subject_sermons								
+work_5641	#subject_sermons								
+work_5138	#subject_history								
+work_1495	#subject_history								
+work_1496	#subject_theology								
+work_1500	#subject_history								
+work_1505	#subject_bible	#subject_geography							
+work_6059	#subject_bible								
+work_1506	#subject_theology								
+work_1507	#subject_history								
+work_1509	#subject_history								
+work_1508	#subject_history								
+work_1497	#subject_theology								
+work_6111	#subject_geography	#subject_bible							
+work_1499	#subject_theology								
+work_6369	#subject_classical_literature								
+work_1510	#subject_classical_literature								
+work_5148	#subject_bible	#subject_history							
+work_1516	#subject_classical_literature	#subject_science							
+work_5632	#subject_hagiography								
+work_1517	#subject_history								
+work_1518	#subject_grammar								
+work_11740	#subject_liturgy								
+work_11741	#subject_liturgy								
+work_11743	#subject_liturgy								
+work_1443	#subject_grammar								
+work_11745	#subject_documents								
+work_11746	#subject_theology								
+work_11747	#subject_theology								
+work_11748	#subject_theology								
+work_11749	#subject_law								
+work_11750	#subject_law								
+work_11752	#subject_theology								
+work_11754	#subject_literature								
+work_11753	#subject_theology								
+work_11755	#subject_theology								
+work_11756	#subject_history								
+work_11757	#subject_music	#subject_science							
+work_11758	#subject_sermons								
+work_11759	#subject_sermons								
+work_11760	#subject_sermons								
+work_11761	#subject_sermons	#subject_theology	#subject_clergy						
+work_11762	#subject_christian_literature								
+work_11763	#subject_christian_literature								
+work_11764	#subject_theology								
+work_17074	#subject_medicine								
+work_11768	#subject_grammar	#subject_liturgy							
+work_11769	#subject_liturgy	#subject_grammar							
+work_11770	#subject_grammar	#subject_liturgy							
+work_16075	#subject_theology								
+work_11774	#subject_theology								
+work_16337	#subject_liturgy								
+work_16068	#subject_bible								
+work_4731	#subject_theology	#subject_theology	#subject_theology						
+work_16248	#subject_theology								
+work_11771	#subject_theology								
+work_11772	#subject_monasticism_and_religious_orders								
+work_11775	#subject_grammar	#subject_liturgy							
+work_11776	#subject_grammar	#subject_liturgy							
+work_11777	#subject_grammar	#subject_liturgy							
+work_11780	#subject_liturgy	#subject_theology	#subject_clergy						
+work_11773	#subject_theology								
+work_11779	#subject_theology								
+work_11781	#subject_liturgy								
+work_11782	#subject_liturgy								
+work_11783	#subject_bible	#subject_liturgy							
+work_11784	#subject_theology								
+work_11785	#subject_liturgy								
+work_11786	#subject_theology								
+work_11787	#subject_literature								
+work_11790	#subject_literature								
+work_11791	#subject_law	#subject_clergy							
+work_11788	#subject_literature	#subject_bible	#subject_theology						
+work_11792	#subject_history								
+work_11793	#subject_literature	#subject_theology							
+work_11794	#subject_theology								
+work_11795	#subject_theology								
+work_11797	#subject_geography								
+work_7036	#subject_law								
+work_16242	#subject_literature								
+work_11803	#subject_literature								
+work_11804	#subject_liturgy	#subject_music							
+work_11805	#subject_grammar								
+work_880	#subject_grammar								
+work_896	#subject_literature								
+work_907	#subject_literature								
+work_881	#subject_grammar								
+work_1592	#subject_medicine								
+work_1589	#subject_medicine								
+work_1590	#subject_medicine								
+work_1591	#subject_medicine								
+work_11806	#subject_literature								
+work_11808	#subject_sermons								
+work_7110	#subject_sermons								
+work_4797	#subject_history								
+work_11809	#subject_literature	#subject_christian_literature							
+work_1525	#subject_literature								
+work_1526	#subject_literature								
+work_11963	#subject_liturgy								
+work_11810	#subject_documents								
+work_11811	#subject_documents								
+work_11812	#subject_documents								
+work_11813	#subject_documents								
+work_513	#subject_history								
+work_508	#subject_history								
+work_11816	#subject_documents								
+work_11817	#subject_liturgy	#subject_bible							
+work_7249	#subject_philosophy								
+work_1781	#subject_medicine								
+work_2508	#subject_law								
+work_7025	#subject_theology								
+work_1968	#subject_politics_and_government								
+work_11818	#subject_christian_literature								
+work_11819	#subject_hagiography								
+work_11820	#subject_sermons								
+work_3749	#subject_grammar								
+work_1688	#subject_law								
+work_2965	#subject_science								
+work_3092	#subject_bible								
+work_3091	#subject_philosophy								
+work_4563	#subject_bible								
+work_4561	#subject_conduct								
+work_4557	#subject_sermons								
+work_16249	#subject_theology								
+work_5134	#subject_literature								
+work_11822	#subject_science								
+work_1559	#subject_literature								
+work_1541	#subject_literature	#subject_rhetoric							
+work_1779	#subject_literature								
+work_1780	#subject_literature								
+work_3635	#subject_medicine								
+work_3634	#subject_medicine								
+work_192	#subject_rhetoric								
+work_3076	#subject_literature								
+work_11823	#subject_documents								
+work_11824	#subject_science	#subject_documents							
+work_11825	#subject_documents								
+work_11826	#subject_history								
+work_11827	#subject_hagiography								
+work_11828	#subject_hagiography								
+work_11829	#subject_hagiography								
+work_2883	#subject_science								
+work_1528	#subject_science								
+work_4308	#subject_politics_and_government								
+work_4255	#subject_monasticism_and_religious_orders								
+work_4253	#subject_monasticism_and_religious_orders								
+work_6273	#subject_clergy	#subject_monasticism_and_religious_orders							
+work_4256	#subject_sermons								
+work_4254	#subject_monasticism_and_religious_orders								
+work_5004	#subject_geography								
+work_5005	#subject_hagiography								
+work_11830	#subject_hagiography								
+work_5006	#subject_christian_literature								
+work_5007	#subject_christian_literature								
+work_4605	#subject_rhetoric								
+work_4606	#subject_rhetoric								
+work_4608	#subject_grammar								
+work_11832	#subject_literature								
+work_11833	#subject_sermons								
+work_11834	#subject_monasticism_and_religious_orders								
+work_7405	#subject_medicine								
+work_11835	#subject_literature								
+work_11836	#subject_literature								
+work_11839	#subject_hagiography								
+work_11840	#subject_monasticism_and_religious_orders								
+work_11841	#subject_theology								
+work_11845	#subject_literature								
+work_11846	#subject_literature								
+work_11796	#subject_literature								
+work_2900	#subject_history								
+work_2901	#subject_history								
+work_1531	#subject_bible								
+work_6171	#subject_theology								
+work_1777	#subject_politics_and_government								
+work_908	#subject_history								
+work_4562	#subject_literature								
+work_11851	#subject_theology								
+work_11853	#subject_literature								
+work_11854	#subject_theology								
+work_11855	#subject_theology								
+work_11856	#subject_clergy	#subject_documents							
+work_11858	#subject_documents	#subject_law							
+work_4550	#subject_science								
+work_4551	#subject_science								
+work_4552	#subject_medicine								
+work_4553	#subject_medicine								
+work_11859	#subject_theology								
+work_11860	#subject_clergy	#subject_law							
+work_11861	#subject_clergy	#subject_law							
+work_11863	#subject_law	#subject_documents							
+work_11864	#subject_liturgy								
+work_11865	#subject_literature								
+work_11867	#subject_literature								
+work_11869	#subject_literature								
+work_11870	#subject_literature								
+work_11871	#subject_law	#subject_clergy	#subject_documents						
+work_11872	#subject_law	#subject_literature	#subject_documents						
+work_11873	#subject_law	#subject_documents							
+work_11874	#subject_literature								
+work_16345	#subject_law								
+work_11875	#subject_rhetoric								
+work_11877	#subject_law	#subject_documents							
+work_11879	#subject_documents	#subject_literature							
+work_11878	#subject_law	#subject_literature	#subject_documents						
+work_11880	#subject_documents								
+work_11881	#subject_documents								
+work_11882	#subject_law	#subject_documents							
+work_2696	#subject_philosophy	#subject_law							
+work_2697	#subject_philosophy								
+work_2698	#subject_philosophy								
+work_2699	#subject_philosophy								
+work_1229	#subject_rhetoric								
+work_6173	#subject_theology								
+work_6109	#subject_hagiography								
+work_4901	#subject_christian_literature	#subject_literature							
+work_4903	#subject_hagiography								
+work_4902	#subject_hagiography								
+work_6106	#subject_hagiography								
+work_1581	#subject_history								
+work_11883	#subject_monasticism_and_religious_orders	#subject_history							
+work_11884	#subject_history	#subject_monasticism_and_religious_orders							
+work_11887	#subject_hagiography								
+work_11888	#subject_clergy	#subject_law							
+work_11889	#subject_sermons								
+work_11890	#subject_documents								
+work_11891	#subject_medicine								
+work_11897	#subject_documents	#subject_law							
+work_11899	#subject_liturgy								
+work_11902	#subject_documents	#subject_law							
+work_11903	#subject_documents	#subject_law							
+work_11927	#subject_liturgy								
+work_11929	#subject_documents								
+work_11933	#subject_documents								
+work_11935	#subject_medicine	#subject_theology	#subject_grammar						
+work_11928	#subject_history								
+work_11937	#subject_theology	#subject_liturgy							
+work_11942	#subject_liturgy								
+work_11944	#subject_philosophy								
+work_1542	#subject_grammar								
+work_1565	#subject_grammar	#subject_rhetoric							
+work_1566	#subject_rhetoric								
+work_1543	#subject_rhetoric								
+work_1538	#subject_history								
+work_1549	#subject_christian_literature								
+work_6594	#subject_monasticism_and_religious_orders								
+work_11945	#subject_monasticism_and_religious_orders								
+work_11946	#subject_monasticism_and_religious_orders	#subject_law							
+work_11947	#subject_monasticism_and_religious_orders	#subject_law							
+work_11948	#subject_monasticism_and_religious_orders	#subject_law							
+work_11949	#subject_liturgy								
+work_11950	#subject_law	#subject_monasticism_and_religious_orders							
+work_11953	#subject_monasticism_and_religious_orders	#subject_law							
+work_11954	#subject_monasticism_and_religious_orders								
+work_1551	#subject_grammar								
+work_6433	#subject_sermons								
+work_6361	#subject_theology								
+work_1567	#subject_theology								
+work_7183	#subject_theology	#subject_monasticism_and_religious_orders							
+work_1553	#subject_theology								
+work_7199	#subject_natural_history								
+work_1554	#subject_philosophy								
+work_7182	#subject_theology								
+work_1576	#subject_theology								
+work_1555	#subject_theology								
+work_7122	#subject_theology								
+work_7123	#subject_theology								
+work_1569	#subject_philosophy								
+work_1573	#subject_theology								
+work_1574	#subject_music								
+work_1006	#subject_law								
+work_1004	#subject_theology	#subject_theology							
+work_6183	#subject_geography								
+work_1524	#subject_christian_literature								
+work_11955	#subject_literature	#subject_monasticism_and_religious_orders							
+work_1577	#subject_recreation								
+work_1552	#subject_medicine								
+work_11956	#subject_law	#subject_theology							
+work_2364	#subject_history								
+work_1579	#subject_classical_literature								
+work_11957	#subject_liturgy								
+work_11958	#subject_literature								
+work_11959	#subject_law								
+work_11960	#subject_law								
+work_4006	#subject_sermons								
+work_1580	#subject_hagiography								
+work_1584	#subject_sermons								
+work_1583	#subject_classical_literature								
+work_6101	#subject_sermons								
+work_1585	#subject_theology								
+work_6142	#subject_theology								
+work_6102	#subject_theology								
+work_1588	#subject_theology								
+work_5922	#subject_theology								
+work_1586	#subject_theology								
+work_6141	#subject_theology								
+work_6143	#subject_theology								
+work_11961	#subject_rhetoric								
+work_11962	#subject_documents								
+work_1641	#subject_science								
+work_1594	#subject_medicine								
+work_7166	#subject_medicine								
+work_1595	#subject_medicine								
+work_1596	#subject_medicine								
+work_7157	#subject_medicine								
+work_7156	#subject_medicine								
+work_7158	#subject_medicine								
+work_1597	#subject_medicine								
+work_1598	#subject_medicine								
+work_7142	#subject_medicine								
+work_1599	#subject_medicine								
+work_1600	#subject_medicine								
+work_6187	#subject_medicine								
+work_1601	#subject_medicine								
+work_1602	#subject_medicine								
+work_1603	#subject_medicine								
+work_1604	#subject_medicine								
+work_6186	#subject_medicine								
+work_1605	#subject_medicine								
+work_1606	#subject_medicine								
+work_1607	#subject_medicine								
+work_7146	#subject_medicine								
+work_1608	#subject_medicine								
+work_7143	#subject_medicine								
+work_1610	#subject_medicine								
+work_7145	#subject_medicine								
+work_1611	#subject_medicine								
+work_1612	#subject_medicine								
+work_1613	#subject_medicine								
+work_1614	#subject_medicine								
+work_7173	#subject_medicine								
+work_7144	#subject_medicine								
+work_1615	#subject_medicine								
+work_7147	#subject_medicine								
+work_1616	#subject_medicine								
+work_1617	#subject_medicine								
+work_1618	#subject_medicine								
+work_1619	#subject_medicine								
+work_7514	#subject_medicine								
+work_1620	#subject_medicine								
+work_1621	#subject_medicine								
+work_1622	#subject_medicine								
+work_7209	#subject_philosophy								
+work_7210	#subject_philosophy								
+work_7213	#subject_philosophy								
+work_7211	#subject_philosophy								
+work_7212	#subject_philosophy								
+work_7208	#subject_philosophy								
+work_1640	#subject_history	#subject_geography							
+work_4007	#subject_theology	#subject_theology							
+work_1623	#subject_science								
+work_1624	#subject_science								
+work_11964	#subject_music								
+work_2365	#subject_christian_literature								
+work_1625	#subject_literature								
+work_11965	#subject_literature								
+work_351	#subject_law								
+work_5685	#subject_medicine								
+work_4799	#subject_history								
+work_204	#subject_history								
+work_1626	#subject_medicine								
+work_1724	#subject_science								
+work_1627	#subject_science								
+work_1628	#subject_bible								
+work_1639	#subject_hagiography								
+work_7349	#subject_theology								
+work_6604	#subject_theology								
+work_4977	#subject_liturgy								
+work_4978	#subject_music	#subject_liturgy							
+work_6249	#subject_sermons								
+work_4685	#subject_grammar								
+work_4704	#subject_grammar								
+work_591	#subject_science								
+work_592	#subject_science								
+work_6060	#subject_science								
+work_4008	#subject_science								
+work_11966	#subject_liturgy								
+work_840	#subject_classical_literature								
+work_1642	#subject_philosophy								
+work_1703	#subject_philosophy								
+work_1643	#subject_philosophy								
+work_1644	#subject_philosophy								
+work_1702	#subject_philosophy								
+work_11967	#subject_history	#subject_heraldry							
+work_11969	#subject_history								
+work_11968	#subject_history								
+work_11983	#subject_history								
+work_11970	#subject_history								
+work_11972	#subject_history								
+work_11971	#subject_history								
+work_11973	#subject_history	#subject_hagiography							
+work_11974	#subject_history								
+work_11975	#subject_history								
+work_11976	#subject_history	#subject_hagiography							
+work_11977	#subject_history								
+work_11978	#subject_history								
+work_11979	#subject_history								
+work_11980	#subject_history								
+work_11981	#subject_history								
+work_11982	#subject_history								
+work_11984	#subject_history								
+work_11985	#subject_history								
+work_11986	#subject_history								
+work_11987	#subject_history								
+work_11988	#subject_history								
+work_11989	#subject_history								
+work_11990	#subject_history								
+work_11991	#subject_history								
+work_11992	#subject_history								
+work_11993	#subject_monasticism_and_religious_orders	#subject_law							
+work_1651	#subject_theology								
+work_1645	#subject_theology								
+work_1647	#subject_theology								
+work_1707	#subject_theology								
+work_1646	#subject_theology								
+work_1650	#subject_christian_literature								
+work_1649	#subject_theology								
+work_1708	#subject_theology								
+work_6108	#subject_hagiography								
+work_1652	#subject_history								
+work_1648	#subject_theology								
+work_1654	#subject_medicine								
+work_7161	#subject_medicine								
+work_7387	#subject_medicine								
+work_1655	#subject_medicine								
+work_1656	#subject_medicine								
+work_1657	#subject_medicine								
+work_1658	#subject_medicine								
+work_1668	#subject_monasticism_and_religious_orders	#subject_clergy							
+work_1669	#subject_sermons								
+work_1673	#subject_theology								
+work_1674	#subject_history								
+work_1675	#subject_hagiography								
+work_1677	#subject_history								
+work_1679	#subject_literature								
+work_1680	#subject_rhetoric								
+work_1676	#subject_natural_history								
+work_1659	#subject_bible								
+work_1660	#subject_sermons								
+work_1681	#subject_history								
+work_12003	#subject_geography	#subject_history							
+work_12004	#subject_geography								
+work_12005	#subject_geography								
+work_12006	#subject_geography								
+work_12007	#subject_geography								
+work_12008	#subject_geography								
+work_12009	#subject_geography								
+work_12010	#subject_history								
+work_12011	#subject_science	#subject_science							
+work_12012	#subject_science								
+work_12013	#subject_science								
+work_1709	#subject_science								
+work_1710	#subject_grammar								
+work_1696	#subject_hagiography								
+work_1704	#subject_history								
+work_16038	#subject_hagiography	#subject_hagiography							
+work_6451	#subject_theology								
+work_1706	#subject_christian_literature								
+work_6212	#subject_history								
+work_6085	#subject_theology								
+work_5849	#subject_hagiography								
+work_5792	#subject_hagiography								
+work_580	#subject_literature								
+work_12014	#subject_literature								
+work_1715	#subject_medicine								
+work_1716	#subject_medicine								
+work_1791	#subject_medicine								
+work_7203	#subject_philosophy								
+work_7077	#subject_theology								
+work_1719	#subject_medicine								
+work_1720	#subject_medicine								
+work_1717	#subject_christian_literature								
+work_1714	#subject_christian_literature								
+work_1718	#subject_christian_literature								
+work_1537	#subject_christian_literature								
+work_1544	#subject_literature								
+work_6448	#subject_sermons								
+work_5863	#subject_sermons								
+work_1725	#subject_hagiography								
+work_12015	#subject_monasticism_and_religious_orders								
+work_2366	#subject_theology								
+work_2367	#subject_theology								
+work_2368	#subject_theology								
+work_2370	#subject_theology								
+work_2371	#subject_theology								
+work_2372	#subject_philosophy								
+work_2373	#subject_theology								
+work_2374	#subject_theology								
+work_2700	#subject_theology								
+work_2375	#subject_theology								
+work_2376	#subject_theology								
+work_2377	#subject_theology								
+work_4033	#subject_theology								
+work_1726	#subject_geography								
+work_1728	#subject_history	#subject_geography	#subject_natural_history						
+work_12016	#subject_history								
+work_12017	#subject_history								
+work_12018	#subject_bible	#subject_literature							
+work_12019	#subject_history	#subject_monasticism_and_religious_orders							
+work_12020	#subject_history								
+work_12021	#subject_literature	#subject_sermons							
+work_12022	#subject_literature	#subject_sermons							
+work_12023	#subject_literature	#subject_sermons							
+work_12024	#subject_literature								
+work_7430	#subject_sermons	#subject_music							
+work_6345	#subject_theology								
+work_1712	#subject_science								
+work_1713	#subject_science								
+work_1711	#subject_science								
+work_681	#subject_christian_literature								
+work_1731	#subject_christian_literature								
+work_2870	#subject_theology								
+work_1735	#subject_theology								
+work_486	#subject_law								
+work_1738	#subject_bible								
+work_1739	#subject_bible								
+work_1737	#subject_bible								
+work_1740	#subject_christian_literature								
+work_1742	#subject_bible	#subject_sermons							
+work_1743	#subject_bible	#subject_sermons							
+work_1744	#subject_theology								
+work_12025	#subject_monasticism_and_religious_orders								
+work_7160	#subject_medicine								
+work_6322	#subject_medicine								
+work_1746	#subject_medicine								
+work_1749	#subject_natural_history								
+work_1750	#subject_science								
+work_1752	#subject_theology								
+work_1906	#subject_philosophy								
+work_1753	#subject_philosophy								
+work_1754	#subject_philosophy								
+work_7315	#subject_philosophy								
+work_7317	#subject_philosophy								
+work_7277	#subject_philosophy								
+work_1755	#subject_philosophy								
+work_244	#subject_bible								
+work_246	#subject_theology								
+work_7055	#subject_theology								
+work_1756	#subject_theology								
+work_7056	#subject_theology								
+work_7061	#subject_philosophy								
+work_1757	#subject_theology								
+work_7057	#subject_theology								
+work_247	#subject_theology								
+work_1456	#subject_theology								
+work_248	#subject_theology								
+work_5844	#subject_theology								
+work_7058	#subject_theology								
+work_7053	#subject_theology								
+work_7059	#subject_theology								
+work_7060	#subject_theology								
+work_7316	#subject_theology								
+work_245	#subject_theology								
+work_7054	#subject_philosophy								
+work_5818	#subject_theology								
+work_12026	#subject_hagiography								
+work_1778	#subject_documents								
+work_6157	#subject_sermons								
+work_1760	#subject_sermons								
+work_1763	#subject_christian_literature								
+work_11344	#subject_law								
+work_2219	#subject_law								
+work_2449	#subject_law								
+work_6241	#subject_clergy	#subject_law							
+work_2450	#subject_law								
+work_2451	#subject_law								
+work_2452	#subject_law								
+work_1788	#subject_law								
+work_1790	#subject_rhetoric								
+work_2606	#subject_classical_literature								
+work_6376	#subject_monasticism_and_religious_orders	#subject_theology							
+work_2226	#subject_theology								
+work_2227	#subject_theology								
+work_2610	#subject_history	#subject_geography							
+work_2840	#subject_law								
+work_1792	#subject_geography								
+work_1793	#subject_history								
+work_1794	#subject_geography								
+work_3046	#subject_clergy								
+work_874	#subject_conduct								
+work_2966	#subject_literature								
+work_2701	#subject_science								
+work_4215	#subject_law								
+work_16368	#subject_rhetoric								
+work_12027	#subject_grammar								
+work_12028	#subject_law								
+work_12029	#subject_grammar								
+work_12030	#subject_grammar								
+work_12031	#subject_grammar								
+work_15591	#subject_grammar								
+work_16254	#subject_grammar								
+work_12032	#subject_grammar								
+work_12033	#subject_grammar								
+work_12034	#subject_grammar								
+work_12035	#subject_grammar								
+work_12036	#subject_grammar								
+work_12037	#subject_grammar								
+work_12038	#subject_grammar	#subject_bible							
+work_12039	#subject_grammar								
+work_12040	#subject_medicine								
+work_12041	#subject_medicine								
+work_12042	#subject_bible	#subject_grammar							
+work_12043	#subject_science								
+work_12044	#subject_bible								
+work_17151	#subject_grammar	#subject_theology							
+work_16240	#subject_grammar								
+work_12045	#subject_bible								
+work_12046	#subject_bible								
+work_12049	#subject_literature								
+work_12050	#subject_bible								
+work_12051	#subject_literature								
+work_12047	#subject_law								
+work_12048	#subject_bible								
+work_12052	#subject_literature								
+work_12053	#subject_bible								
+work_12054	#subject_literature								
+work_12055	#subject_bible								
+work_4351	#subject_history								
+work_3189	#subject_history								
+work_12056	#subject_literature								
+work_5970	#subject_christian_literature								
+work_2378	#subject_christian_literature								
+work_7062	#subject_theology								
+work_1800	#subject_history								
+work_1801	#subject_literature								
+work_12057	#subject_science								
+work_1802	#subject_christian_literature								
+work_1803	#subject_law								
+work_12058	#subject_christian_literature								
+work_2703	#subject_bible								
+work_12059	#subject_literature	#subject_literature							
+work_1804	#subject_philosophy								
+work_1805	#subject_hagiography								
+work_12062	#subject_liturgy	#subject_bible							
+work_12063	#subject_bible								
+work_12187	#subject_bible								
+work_12064	#subject_bible								
+work_12188	#subject_bible								
+work_12065	#subject_liturgy								
+work_12066	#subject_liturgy								
+work_12067	#subject_liturgy	#subject_bible							
+work_12068	#subject_liturgy	#subject_bible							
+work_12069	#subject_liturgy								
+work_12070	#subject_liturgy								
+work_12071	#subject_liturgy	#subject_bible							
+work_12072	#subject_bible	#subject_liturgy							
+work_12073	#subject_liturgy	#subject_bible							
+work_16032	#subject_bible	#subject_liturgy							
+work_2704	#subject_literature								
+work_2705	#subject_history								
+work_2706	#subject_literature								
+work_2707	#subject_literature								
+work_2708	#subject_literature								
+work_2709	#subject_literature								
+work_4874	#subject_christian_literature	#subject_literature							
+work_12120	#subject_liturgy								
+work_12121	#subject_liturgy								
+work_12122	#subject_liturgy								
+work_12123	#subject_liturgy								
+work_12124	#subject_liturgy								
+work_12125	#subject_liturgy								
+work_12127	#subject_liturgy								
+work_12128	#subject_liturgy	#subject_music							
+work_12131	#subject_documents								
+work_12132	#subject_documents								
+work_12133	#subject_grammar								
+work_12134	#subject_grammar	#subject_science							
+work_12135	#subject_grammar								
+work_12136	#subject_grammar	#subject_literature							
+work_12137	#subject_grammar	#subject_rhetoric							
+work_12138	#subject_grammar								
+work_15535	#subject_grammar	#subject_literature							
+work_12140	#subject_grammar								
+work_12142	#subject_grammar								
+work_12143	#subject_grammar								
+work_12144	#subject_grammar								
+work_12145	#subject_grammar	#subject_literature							
+work_12147	#subject_grammar	#subject_literature							
+work_12151	#subject_grammar								
+work_12150	#subject_grammar								
+work_12153	#subject_grammar								
+work_16026	#subject_grammar								
+work_12148	#subject_grammar								
+work_12149	#subject_grammar								
+work_12152	#subject_grammar								
+work_12154	#subject_grammar								
+work_12155	#subject_grammar								
+work_12156	#subject_grammar								
+work_12157	#subject_grammar								
+work_12158	#subject_literature	#subject_grammar							
+work_12159	#subject_grammar								
+work_12141	#subject_grammar	#subject_philosophy	#subject_music						
+work_12146	#subject_grammar	#subject_rhetoric	#subject_theology						
+work_12161	#subject_documents								
+work_12162	#subject_law								
+work_12163	#subject_history								
+work_2710	#subject_hagiography								
+work_12164	#subject_documents								
+work_12165	#subject_documents								
+work_12166	#subject_documents								
+work_12167	#subject_documents								
+work_4801	#subject_indexes								
+work_12168	#subject_documents	#subject_monasticism_and_religious_orders							
+work_5620	#subject_philosophy								
+work_5621	#subject_philosophy								
+work_1806	#subject_law								
+work_5909	#subject_hagiography								
+work_4257	#subject_clergy								
+work_12169	#subject_grammar								
+work_12170	#subject_literature								
+work_12171	#subject_grammar								
+work_6179	#subject_science								
+work_5601	#subject_grammar								
+work_3246	#subject_grammar								
+work_3247	#subject_history								
+work_3248	#subject_philosophy								
+work_1808	#subject_theology								
+work_5793	#subject_sermons								
+work_1824	#subject_hagiography								
+work_1826	#subject_christian_literature	#subject_literature							
+work_5745	#subject_theology								
+work_1816	#subject_theology								
+work_2	#subject_theology								
+work_3	#subject_theology								
+work_106	#subject_theology								
+work_5	#subject_theology								
+work_6	#subject_theology								
+work_7	#subject_theology								
+work_8	#subject_theology								
+work_9	#subject_theology								
+work_1831	#subject_theology								
+work_16	#subject_theology								
+work_17	#subject_theology								
+work_1838	#subject_literature								
+work_1832	#subject_theology								
+work_37	#subject_theology								
+work_44	#subject_theology								
+work_103	#subject_theology								
+work_52	#subject_theology								
+work_1845	#subject_history								
+work_1812	#subject_theology								
+work_72	#subject_sermons								
+work_73	#subject_sermons								
+work_74	#subject_sermons								
+work_76	#subject_sermons								
+work_1833	#subject_sermons								
+work_1834	#subject_sermons								
+work_1846	#subject_sermons								
+work_1835	#subject_sermons								
+work_82	#subject_sermons								
+work_107	#subject_sermons								
+work_114	#subject_sermons								
+work_108	#subject_sermons								
+work_102	#subject_sermons								
+work_86	#subject_sermons								
+work_88	#subject_philosophy								
+work_104	#subject_sermons								
+work_115	#subject_sermons								
+work_105	#subject_sermons								
+work_112	#subject_sermons								
+work_110	#subject_sermons								
+work_111	#subject_sermons								
+work_116	#subject_sermons								
+work_1814	#subject_sermons								
+work_92	#subject_sermons								
+work_93	#subject_sermons								
+work_109	#subject_sermons								
+work_1840	#subject_liturgy								
+work_1847	#subject_sermons								
+work_1844	#subject_sermons								
+work_123	#subject_sermons								
+work_129	#subject_sermons								
+work_130	#subject_sermons								
+work_113	#subject_sermons								
+work_134	#subject_sermons								
+work_135	#subject_sermons								
+work_136	#subject_sermons								
+work_137	#subject_sermons								
+work_138	#subject_sermons								
+work_1839	#subject_theology								
+work_1818	#subject_theology								
+work_1823	#subject_theology								
+work_6210	#subject_hagiography								
+work_1859	#subject_history								
+work_1860	#subject_hagiography								
+work_6209	#subject_hagiography								
+work_1874	#subject_theology								
+work_1862	#subject_theology								
+work_1877	#subject_theology								
+work_1863	#subject_theology								
+work_6027	#subject_theology								
+work_1864	#subject_theology								
+work_1865	#subject_theology								
+work_1867	#subject_theology								
+work_1868	#subject_sermons								
+work_1869	#subject_sermons								
+work_1871	#subject_sermons								
+work_1870	#subject_sermons								
+work_1872	#subject_sermons								
+work_1876	#subject_theology								
+work_1875	#subject_theology								
+work_1878	#subject_theology								
+work_1880	#subject_theology								
+work_1829	#subject_monasticism_and_religious_orders								
+work_1830	#subject_law								
+work_6132	#subject_theology								
+work_6133	#subject_theology								
+work_6220	#subject_theology								
+work_6219	#subject_sermons								
+work_6221	#subject_sermons								
+work_1848	#subject_theology								
+work_1849	#subject_bible								
+work_36	#subject_theology								
+work_41	#subject_theology								
+work_1827	#subject_theology								
+work_1820	#subject_theology								
+work_1850	#subject_theology								
+work_1851	#subject_theology								
+work_47	#subject_theology								
+work_1852	#subject_theology								
+work_1853	#subject_theology								
+work_5660	#subject_hagiography								
+work_1821	#subject_theology								
+work_1828	#subject_theology								
+work_1854	#subject_sermons								
+work_5943	#subject_bible								
+work_1855	#subject_theology								
+work_1856	#subject_theology								
+work_5848	#subject_theology								
+work_1822	#subject_theology								
+work_1858	#subject_theology								
+work_178	#subject_hagiography								
+work_5906	#subject_theology								
+work_1842	#subject_law								
+work_193	#subject_grammar								
+work_6596	#subject_theology	#subject_theology							
+work_4388	#subject_theology								
+work_4389	#subject_natural_history								
+work_4354	#subject_theology	#subject_conduct	#subject_literature						
+work_4353	#subject_theology	#subject_conduct							
+work_4355	#subject_philosophy								
+work_7245	#subject_philosophy								
+work_7298	#subject_philosophy								
+work_4357	#subject_theology								
+work_4356	#subject_theology								
+work_4358	#subject_theology								
+work_4390	#subject_philosophy								
+work_4359	#subject_theology								
+work_4360	#subject_science								
+work_4362	#subject_sermons								
+work_4361	#subject_sermons								
+work_4364	#subject_theology								
+work_4371	#subject_science								
+work_4365	#subject_science								
+work_7382	#subject_theology								
+work_4366	#subject_science								
+work_4368	#subject_science								
+work_4369	#subject_theology	#subject_conduct							
+work_7299	#subject_theology	#subject_conduct							
+work_4370	#subject_theology								
+work_4373	#subject_natural_history								
+work_4374	#subject_science								
+work_7381	#subject_theology								
+work_4375	#subject_theology	#subject_philosophy							
+work_7042	#subject_theology								
+work_4363	#subject_theology	#subject_conduct							
+work_4376	#subject_christian_literature								
+work_4377	#subject_theology								
+work_5951	#subject_philosophy								
+work_7383	#subject_theology								
+work_4379	#subject_politics_and_government								
+work_4380	#subject_politics_and_government								
+work_4381	#subject_sermons								
+work_4384	#subject_sermons								
+work_4385	#subject_sermons								
+work_4386	#subject_conduct								
+work_5950	#subject_philosophy								
+work_4387	#subject_theology	#subject_conduct							
+work_4367	#subject_grammar								
+work_7433	#subject_theology								
+work_4104	#subject_theology								
+work_4106	#subject_science								
+work_7369	#subject_sermons								
+work_7324	#subject_philosophy								
+work_2161	#subject_theology								
+work_1898	#subject_medicine								
+work_593	#subject_science								
+work_594	#subject_medicine								
+work_595	#subject_medicine								
+work_596	#subject_medicine								
+work_12172	#subject_documents								
+work_12173	#subject_literature								
+work_12534	#subject_literature								
+work_12174	#subject_literature								
+work_12175	#subject_literature								
+work_12176	#subject_literature								
+work_12177	#subject_literature								
+work_12178	#subject_literature								
+work_12179	#subject_literature								
+work_12180	#subject_liturgy	#subject_literature							
+work_12181	#subject_liturgy	#subject_literature							
+work_12182	#subject_literature								
+work_12183	#subject_music	#subject_literature							
+work_1887	#subject_grammar								
+work_1884	#subject_classical_literature								
+work_1897	#subject_classical_literature								
+work_1892	#subject_rhetoric								
+work_1888	#subject_grammar								
+work_1883	#subject_literature								
+work_1894	#subject_literature								
+work_1890	#subject_literature								
+work_1895	#subject_grammar								
+work_1896	#subject_literature								
+work_1891	#subject_classical_literature								
+work_1882	#subject_literature								
+work_505	#subject_grammar								
+work_1899	#subject_sermons								
+work_5059	#subject_medicine								
+work_4996	#subject_medicine								
+work_4997	#subject_medicine								
+work_5096	#subject_medicine								
+work_5097	#subject_medicine								
+work_1925	#subject_medicine								
+work_1934	#subject_medicine								
+work_1900	#subject_literature								
+work_1901	#subject_sermons								
+work_1745	#subject_sermons								
+work_6288	#subject_rhetoric								
+work_1902	#subject_history								
+work_1903	#subject_law								
+work_1905	#subject_law								
+work_1910	#subject_clergy								
+work_1936	#subject_sermons								
+work_1937	#subject_sermons								
+work_5789	#subject_christian_literature								
+work_1911	#subject_hagiography								
+work_1912	#subject_christian_literature								
+work_1913	#subject_monasticism_and_religious_orders								
+work_1914	#subject_monasticism_and_religious_orders								
+work_4986	#subject_politics_and_government								
+work_4991	#subject_sermons								
+work_4988	#subject_sermons								
+work_4989	#subject_sermons								
+work_4990	#subject_sermons								
+work_7304	#subject_natural_history								
+work_4998	#subject_philosophy								
+work_4999	#subject_philosophy								
+work_4993	#subject_bible								
+work_4541	#subject_history								
+work_1931	#subject_law								
+work_1932	#subject_law								
+work_5069	#subject_medicine								
+work_5036	#subject_medicine								
+work_5037	#subject_sermons								
+work_1933	#subject_philosophy								
+work_5077	#subject_philosophy								
+work_5078	#subject_philosophy								
+work_5079	#subject_philosophy								
+work_5088	#subject_bible	#subject_theology							
+work_5031	#subject_theology								
+work_7120	#subject_theology								
+work_5032	#subject_theology								
+work_5033	#subject_liturgy	#subject_theology	#subject_clergy						
+work_5034	#subject_theology								
+work_5015	#subject_medicine								
+work_5022	#subject_philosophy								
+work_5023	#subject_philosophy								
+work_5024	#subject_indexes								
+work_7359	#subject_indexes	#subject_law							
+work_5103	#subject_christian_literature								
+work_1915	#subject_christian_literature								
+work_1918	#subject_christian_literature								
+work_1916	#subject_christian_literature								
+work_1919	#subject_literature								
+work_6148	#subject_theology								
+work_5092	#subject_monasticism_and_religious_orders								
+work_6277	#subject_monasticism_and_religious_orders								
+work_5093	#subject_monasticism_and_religious_orders								
+work_1920	#subject_philosophy								
+work_1921	#subject_natural_history								
+work_5105	#subject_bible								
+work_5000	#subject_bible								
+work_7365	#subject_bible								
+work_4983	#subject_bible								
+work_5058	#subject_theology								
+work_1928	#subject_theology								
+work_4995	#subject_liturgy	#subject_theology	#subject_clergy						
+work_5075	#subject_law								
+work_5076	#subject_law								
+work_1420	#subject_philosophy								
+work_5843	#subject_theology								
+work_7175	#subject_science								
+work_5672	#subject_philosophy								
+work_6323	#subject_medicine								
+work_1935	#subject_medicine								
+work_2348	#subject_history								
+work_1941	#subject_medicine								
+work_1940	#subject_philosophy								
+work_2564	#subject_theology								
+work_2565	#subject_bible								
+work_6373	#subject_bible								
+work_6372	#subject_bible								
+work_2566	#subject_bible								
+work_2567	#subject_sermons								
+work_2568	#subject_christian_literature								
+work_12184	#subject_hagiography								
+work_12185	#subject_hagiography								
+work_1943	#subject_law								
+work_4011	#subject_bible								
+work_5132	#subject_sermons								
+work_1946	#subject_bible								
+work_7101	#subject_bible								
+work_1944	#subject_bible								
+work_1958	#subject_bible								
+work_7356	#subject_sermons								
+work_2712	#subject_politics_and_government								
+work_12186	#subject_theology								
+work_1952	#subject_law								
+work_1954	#subject_medicine								
+work_16333	#subject_theology								
+work_3298	#subject_bible								
+work_3322	#subject_sermons								
+work_3283	#subject_sermons								
+work_3284	#subject_sermons								
+work_2715	#subject_history								
+work_696	#subject_geography								
+work_1312	#subject_theology								
+work_1235	#subject_literature								
+work_4803	#subject_liturgy								
+work_12189	#subject_literature								
+work_1949	#subject_bible								
+work_1950	#subject_christian_literature								
+work_1959	#subject_liturgy								
+work_1948	#subject_liturgy								
+work_7325	#subject_history								
+work_1978	#subject_theology								
+work_6340	#subject_liturgy	#subject_bible							
+work_1977	#subject_law								
+work_1982	#subject_theology								
+work_1979	#subject_theology								
+work_1980	#subject_theology								
+work_1983	#subject_bible								
+work_2004	#subject_theology								
+work_5831	#subject_christian_literature								
+work_6344	#subject_sermons								
+work_1960	#subject_sermons								
+work_1961	#subject_christian_literature								
+work_6343	#subject_monasticism_and_religious_orders								
+work_2005	#subject_theology								
+work_1985	#subject_theology								
+work_1989	#subject_philosophy								
+work_12190	#subject_liturgy								
+work_12191	#subject_liturgy	#subject_music							
+work_1962	#subject_law	#subject_clergy							
+work_1963	#subject_hagiography								
+work_3583	#subject_grammar								
+work_2181	#subject_literature								
+work_1964	#subject_grammar								
+work_1965	#subject_science								
+work_5009	#subject_law								
+work_4183	#subject_law								
+work_4184	#subject_law								
+work_4185	#subject_law								
+work_4181	#subject_law								
+work_4182	#subject_law								
+work_4971	#subject_politics_and_government								
+work_4972	#subject_politics_and_government								
+work_7235	#subject_philosophy								
+work_6418	#subject_law								
+work_14181	#subject_theology								
+work_1988	#subject_rhetoric								
+work_7345	#subject_rhetoric								
+work_707	#subject_christian_literature								
+work_1992	#subject_bible								
+work_1987	#subject_law								
+work_1986	#subject_law								
+work_2006	#subject_law								
+work_7322	#subject_literature								
+work_4013	#subject_medicine								
+work_2007	#subject_philosophy								
+work_2002	#subject_grammar								
+work_2001	#subject_hagiography								
+work_6588	#subject_hagiography								
+work_6587	#subject_hagiography								
+work_7030	#subject_theology								
+work_7031	#subject_theology								
+work_6310	#subject_history								
+work_2003	#subject_history								
+work_1942	#subject_christian_literature								
+work_2008	#subject_grammar								
+work_16029	#subject_law								
+work_2009	#subject_classical_literature								
+work_2011	#subject_law								
+work_12193	#subject_history	#subject_heraldry							
+work_12194	#subject_heraldry								
+work_15058	#subject_heraldry								
+work_12196	#subject_heraldry								
+work_12197	#subject_heraldry								
+work_12198	#subject_heraldry								
+work_12199	#subject_heraldry								
+work_12200	#subject_heraldry								
+work_12201	#subject_heraldry								
+work_16314	#subject_medicine								
+work_12203	#subject_medicine								
+work_12204	#subject_medicine								
+work_12205	#subject_medicine								
+work_12206	#subject_medicine								
+work_12207	#subject_medicine								
+work_12208	#subject_medicine								
+work_12209	#subject_medicine								
+work_12210	#subject_medicine								
+work_12211	#subject_medicine								
+work_12212	#subject_medicine								
+work_12214	#subject_medicine								
+work_12215	#subject_medicine								
+work_7373	#subject_hagiography								
+work_3330	#subject_sermons								
+work_2015	#subject_hagiography								
+work_7326	#subject_theology								
+work_2016	#subject_science								
+work_2018	#subject_science								
+work_2019	#subject_science								
+work_2014	#subject_science								
+work_6255	#subject_christian_literature								
+work_2020	#subject_christian_literature								
+work_179	#subject_science								
+work_180	#subject_science								
+work_181	#subject_science								
+work_182	#subject_science								
+work_183	#subject_science								
+work_184	#subject_philosophy								
+work_4014	#subject_philosophy								
+work_2021	#subject_science								
+work_6118	#subject_classical_literature	#subject_rhetoric							
+work_6120	#subject_classical_literature	#subject_rhetoric							
+work_6119	#subject_classical_literature	#subject_rhetoric							
+work_2023	#subject_rhetoric								
+work_2024	#subject_classical_literature								
+work_2026	#subject_classical_literature								
+work_6091	#subject_science								
+work_2027	#subject_classical_literature								
+work_2025	#subject_classical_literature								
+work_2028	#subject_classical_literature								
+work_2029	#subject_classical_literature								
+work_2031	#subject_grammar								
+work_5602	#subject_grammar								
+work_2032	#subject_grammar								
+work_2033	#subject_history								
+work_6347	#subject_theology								
+work_2490	#subject_sermons								
+work_2491	#subject_sermons								
+work_2492	#subject_sermons								
+work_2030	#subject_politics_and_government								
+work_2034	#subject_theology								
+work_7073	#subject_politics_and_government								
+work_2035	#subject_theology								
+work_2036	#subject_theology								
+work_2037	#subject_bible								
+work_2038	#subject_classical_literature								
+work_2039	#subject_classical_literature								
+work_2040	#subject_classical_literature								
+work_5796	#subject_sermons								
+work_2645	#subject_bible								
+work_2042	#subject_bible								
+work_6024	#subject_sermons								
+work_12217	#subject_literature	#subject_bible							
+work_5010	#subject_philosophy								
+work_5011	#subject_philosophy								
+work_5066	#subject_philosophy								
+work_5012	#subject_philosophy								
+work_5067	#subject_philosophy								
+work_5013	#subject_philosophy								
+work_5014	#subject_philosophy								
+work_4213	#subject_sermons								
+work_4212	#subject_history								
+work_4214	#subject_history								
+work_2048	#subject_liturgy								
+work_6325	#subject_theology								
+work_2049	#subject_bible								
+work_2050	#subject_theology								
+work_2051	#subject_bible								
+work_2052	#subject_christian_literature								
+work_2053	#subject_theology								
+work_2054	#subject_theology								
+work_2058	#subject_christian_literature								
+work_2055	#subject_christian_literature								
+work_2056	#subject_christian_literature	#subject_literature							
+work_6590	#subject_sermons								
+work_2057	#subject_hagiography								
+work_4015	#subject_history								
+work_2060	#subject_christian_literature	#subject_theology							
+work_2061	#subject_theology	#subject_monasticism_and_religious_orders							
+work_12819	#subject_hagiography								
+work_2062	#subject_hagiography								
+work_5967	#subject_bible								
+work_5968	#subject_bible								
+work_4955	#subject_christian_literature								
+work_5953	#subject_theology								
+work_4956	#subject_christian_literature								
+work_4957	#subject_monasticism_and_religious_orders								
+work_4958	#subject_christian_literature								
+work_4959	#subject_christian_literature								
+work_4960	#subject_christian_literature								
+work_4961	#subject_christian_literature								
+work_2063	#subject_theology								
+work_2064	#subject_natural_history								
+work_4016	#subject_science								
+work_6319	#subject_science								
+work_7204	#subject_medicine								
+work_7384	#subject_medicine								
+work_5149	#subject_medicine								
+work_6318	#subject_medicine								
+work_6096	#subject_medicine								
+work_2068	#subject_medicine								
+work_4018	#subject_classical_literature								
+work_2071	#subject_medicine								
+work_7339	#subject_medicine								
+work_6093	#subject_medicine								
+work_2065	#subject_medicine								
+work_2066	#subject_medicine								
+work_6388	#subject_medicine								
+work_6402	#subject_medicine								
+work_6386	#subject_medicine								
+work_6387	#subject_medicine								
+work_6400	#subject_medicine								
+work_6399	#subject_medicine								
+work_6405	#subject_medicine								
+work_6391	#subject_medicine								
+work_6408	#subject_medicine								
+work_6385	#subject_medicine								
+work_6393	#subject_medicine								
+work_6401	#subject_medicine								
+work_6398	#subject_medicine								
+work_6396	#subject_medicine								
+work_6397	#subject_medicine								
+work_6389	#subject_medicine								
+work_6406	#subject_medicine								
+work_6390	#subject_medicine								
+work_6404	#subject_medicine								
+work_6392	#subject_medicine								
+work_6395	#subject_medicine								
+work_6384	#subject_medicine								
+work_6394	#subject_medicine								
+work_6407	#subject_medicine								
+work_7333	#subject_medicine								
+work_6403	#subject_medicine								
+work_7338	#subject_medicine								
+work_2069	#subject_medicine								
+work_6382	#subject_medicine								
+work_2070	#subject_medicine								
+work_6383	#subject_medicine								
+work_6409	#subject_medicine								
+work_2072	#subject_medicine								
+work_2074	#subject_history								
+work_6165	#subject_bible								
+work_5139	#subject_bible								
+work_2073	#subject_history								
+work_7320	#subject_classical_literature	#subject_history							
+work_12219	#subject_history								
+work_12220	#subject_literature								
+work_12221	#subject_literature								
+work_12222	#subject_literature								
+work_12223	#subject_history								
+work_12224	#subject_history								
+work_12225	#subject_literature	#subject_history							
+work_12226	#subject_literature								
+work_12227	#subject_hagiography								
+work_12228	#subject_history								
+work_12229	#subject_literature								
+work_12230	#subject_monasticism_and_religious_orders								
+work_12231	#subject_monasticism_and_religious_orders								
+work_12232	#subject_hagiography								
+work_12233	#subject_history	#subject_geography							
+work_12234	#subject_history	#subject_law							
+work_12235	#subject_history								
+work_12236	#subject_history								
+work_12237	#subject_history								
+work_12238	#subject_history	#subject_christian_literature							
+work_12239	#subject_history								
+work_12240	#subject_history								
+work_12241	#subject_history								
+work_12242	#subject_history								
+work_12244	#subject_history								
+work_12245	#subject_history								
+work_12246	#subject_history								
+work_12249	#subject_history								
+work_12248	#subject_history								
+work_12250	#subject_history								
+work_12252	#subject_history								
+work_12247	#subject_history								
+work_12255	#subject_history								
+work_12254	#subject_history								
+work_12253	#subject_history								
+work_12256	#subject_history								
+work_12257	#subject_history								
+work_12258	#subject_history								
+work_12260	#subject_history								
+work_12261	#subject_history								
+work_12262	#subject_history	#subject_literature							
+work_12243	#subject_history	#subject_theology	#subject_literature						
+work_12259	#subject_theology	#subject_history	#subject_clergy	#subject_law	#subject_science	#subject_magic			
+work_12263	#subject_bible								
+work_12269	#subject_history								
+work_12270	#subject_history								
+work_12271	#subject_bible								
+work_12272	#subject_bible								
+work_12274	#subject_history	#subject_monasticism_and_religious_orders	#subject_documents						
+work_12264	#subject_history								
+work_12265	#subject_history	#subject_clergy							
+work_12266	#subject_history	#subject_clergy							
+work_12267	#subject_history	#subject_clergy							
+work_12268	#subject_bible								
+work_12273	#subject_history								
+work_12276	#subject_history								
+work_12275	#subject_history								
+work_5610	#subject_literature								
+work_4804	#subject_literature								
+work_4805	#subject_literature								
+work_4806	#subject_politics_and_government	#subject_literature							
+work_4807	#subject_literature								
+work_4808	#subject_literature								
+work_4809	#subject_literature								
+work_4810	#subject_literature								
+work_4811	#subject_literature								
+work_4392	#subject_bible								
+work_4391	#subject_bible								
+work_5944	#subject_sermons								
+work_4393	#subject_theology								
+work_7037	#subject_theology								
+work_4394	#subject_science								
+work_4021	#subject_classical_literature								
+work_4022	#subject_classical_literature								
+work_2076	#subject_classical_literature								
+work_2077	#subject_classical_literature								
+work_2078	#subject_classical_literature								
+work_12277	#subject_sermons	#subject_hagiography							
+work_12278	#subject_sermons	#subject_monasticism_and_religious_orders							
+work_12279	#subject_sermons	#subject_liturgy							
+work_12280	#subject_sermons	#subject_liturgy							
+work_12281	#subject_sermons	#subject_liturgy							
+work_12282	#subject_sermons	#subject_liturgy							
+work_12283	#subject_sermons								
+work_12284	#subject_sermons								
+work_12285	#subject_sermons								
+work_12286	#subject_sermons								
+work_16329	#subject_sermons								
+work_12287	#subject_sermons	#subject_liturgy	#subject_hagiography						
+work_12288	#subject_sermons	#subject_hagiography	#subject_liturgy						
+work_12289	#subject_sermons	#subject_liturgy							
+work_12290	#subject_sermons	#subject_liturgy							
+work_12291	#subject_sermons	#subject_liturgy							
+work_12292	#subject_sermons								
+work_12293	#subject_sermons	#subject_bible	#subject_liturgy						
+work_12294	#subject_sermons								
+work_12295	#subject_sermons								
+work_12296	#subject_sermons								
+work_12297	#subject_sermons								
+work_12299	#subject_sermons								
+work_16013	#subject_sermons	#subject_hagiography							
+work_12298	#subject_sermons								
+work_12300	#subject_sermons								
+work_12301	#subject_sermons								
+work_4531	#subject_law								
+work_2079	#subject_bible								
+work_2080	#subject_theology								
+work_2081	#subject_conduct								
+work_2082	#subject_theology								
+work_2083	#subject_theology								
+work_2089	#subject_theology								
+work_2084	#subject_theology	#subject_liturgy							
+work_2085	#subject_geography	#subject_history	#subject_natural_history						
+work_2086	#subject_theology								
+work_2087	#subject_bible	#subject_liturgy							
+work_6452	#subject_theology								
+work_2088	#subject_theology								
+work_1994	#subject_literature								
+work_2092	#subject_classical_literature								
+work_2097	#subject_classical_literature								
+work_2094	#subject_classical_literature								
+work_2095	#subject_classical_literature								
+work_2096	#subject_classical_literature								
+work_2099	#subject_sermons								
+work_2100	#subject_classical_literature								
+work_4985	#subject_law								
+work_12302	#subject_liturgy								
+work_12303	#subject_liturgy								
+work_16211	#subject_science	#subject_science							
+work_12305	#subject_science								
+work_12308	#subject_liturgy								
+work_12306	#subject_liturgy								
+work_12307	#subject_liturgy								
+work_12309	#subject_liturgy	#subject_christian_literature							
+work_12310	#subject_liturgy								
+work_12311	#subject_documents								
+work_12312	#subject_documents								
+work_12313	#subject_documents								
+work_12314	#subject_documents								
+work_12315	#subject_documents								
+work_12316	#subject_documents								
+work_12317	#subject_documents								
+work_12318	#subject_documents								
+work_12319	#subject_documents								
+work_2838	#subject_christian_literature								
+work_2839	#subject_christian_literature								
+work_4023	#subject_hagiography								
+work_2107	#subject_hagiography								
+work_2108	#subject_literature								
+work_1433	#subject_medicine								
+work_7393	#subject_medicine								
+work_4024	#subject_bible								
+work_4028	#subject_theology								
+work_4029	#subject_natural_history								
+work_4026	#subject_theology								
+work_4027	#subject_theology								
+work_2167	#subject_theology								
+work_2110	#subject_hagiography								
+work_2112	#subject_natural_history								
+work_2168	#subject_natural_history								
+work_2169	#subject_monasticism_and_religious_orders								
+work_2113	#subject_medicine								
+work_2114	#subject_monasticism_and_religious_orders								
+work_2115	#subject_monasticism_and_religious_orders								
+work_2170	#subject_monasticism_and_religious_orders								
+work_7412	#subject_sermons								
+work_7423	#subject_theology								
+work_2116	#subject_liturgy	#subject_clergy							
+work_2117	#subject_bible								
+work_2142	#subject_sermons								
+work_2133	#subject_monasticism_and_religious_orders								
+work_2123	#subject_monasticism_and_religious_orders								
+work_2128	#subject_bible								
+work_2118	#subject_history								
+work_2130	#subject_philosophy								
+work_2144	#subject_christian_literature								
+work_2145	#subject_christian_literature								
+work_2131	#subject_christian_literature								
+work_6591	#subject_hagiography								
+work_2147	#subject_christian_literature								
+work_2148	#subject_christian_literature								
+work_2149	#subject_christian_literature	#subject_monasticism_and_religious_orders							
+work_2121	#subject_christian_literature								
+work_5921	#subject_christian_literature								
+work_5919	#subject_christian_literature								
+work_5846	#subject_christian_literature								
+work_5845	#subject_christian_literature								
+work_2150	#subject_christian_literature								
+work_5920	#subject_christian_literature								
+work_2151	#subject_liturgy	#subject_theology	#subject_clergy						
+work_5916	#subject_liturgy	#subject_theology	#subject_clergy						
+work_2152	#subject_christian_literature								
+work_5918	#subject_christian_literature								
+work_2153	#subject_christian_literature								
+work_5915	#subject_christian_literature								
+work_2154	#subject_christian_literature								
+work_7185	#subject_christian_literature								
+work_7184	#subject_christian_literature								
+work_2132	#subject_christian_literature								
+work_2134	#subject_sermons								
+work_5917	#subject_christian_literature								
+work_2155	#subject_theology								
+work_2125	#subject_christian_literature								
+work_2158	#subject_theology								
+work_2163	#subject_theology								
+work_2164	#subject_theology								
+work_2171	#subject_sermons								
+work_2172	#subject_sermons								
+work_2111	#subject_history								
+work_2165	#subject_philosophy								
+work_2126	#subject_science								
+work_2174	#subject_music								
+work_185	#subject_medicine								
+work_2178	#subject_theology								
+work_3047	#subject_monasticism_and_religious_orders								
+work_7353	#subject_sermons								
+work_2177	#subject_christian_literature								
+work_2179	#subject_christian_literature								
+work_7503	#subject_literature								
+work_2180	#subject_classical_literature	#subject_science							
+work_17501	#subject_literature	#subject_liturgy							
+work_12320	#subject_liturgy								
+work_12321	#subject_liturgy								
+work_12322	#subject_liturgy								
+work_12323	#subject_liturgy								
+work_12324	#subject_liturgy	#subject_hagiography							
+work_16317	#subject_liturgy								
+work_12325	#subject_liturgy								
+work_12326	#subject_liturgy								
+work_12327	#subject_liturgy								
+work_12328	#subject_liturgy								
+work_12329	#subject_liturgy								
+work_12330	#subject_liturgy								
+work_12331	#subject_liturgy								
+work_12332	#subject_liturgy								
+work_12333	#subject_liturgy								
+work_12334	#subject_liturgy								
+work_12335	#subject_liturgy								
+work_12336	#subject_liturgy	#subject_christian_literature							
+work_12337	#subject_christian_literature	#subject_monasticism_and_religious_orders	#subject_liturgy						
+work_12338	#subject_theology	#subject_christian_literature	#subject_liturgy						
+work_12339	#subject_liturgy	#subject_literature							
+work_12341	#subject_liturgy	#subject_music							
+work_12342	#subject_liturgy	#subject_hagiography							
+work_12343	#subject_liturgy	#subject_music							
+work_12340	#subject_liturgy	#subject_music							
+work_12345	#subject_liturgy								
+work_16137	#subject_hagiography								
+work_16150	#subject_hagiography								
+work_16148	#subject_hagiography								
+work_16167	#subject_hagiography								
+work_16153	#subject_hagiography								
+work_16152	#subject_hagiography								
+work_16154	#subject_hagiography								
+work_12346	#subject_literature								
+work_12347	#subject_law								
+work_7159	#subject_medicine								
+work_1957	#subject_science								
+work_2186	#subject_philosophy	#subject_classical_literature							
+work_2187	#subject_classical_literature								
+work_1955	#subject_science								
+work_1956	#subject_science								
+work_358	#subject_science								
+work_7167	#subject_medicine								
+work_490	#subject_science								
+work_289	#subject_science								
+work_3504	#subject_conduct								
+work_12348	#subject_theology	#subject_christian_literature							
+work_12349	#subject_theology	#subject_theology							
+work_12350	#subject_literature								
+work_12351	#subject_literature								
+work_6287	#subject_hagiography								
+work_2188	#subject_theology								
+work_12352	#subject_literature								
+work_12353	#subject_liturgy	#subject_bible							
+work_12354	#subject_magic	#subject_christian_literature							
+work_12355	#subject_documents								
+work_12356	#subject_documents								
+work_12357	#subject_documents								
+work_12358	#subject_documents								
+work_17092	#subject_indexes								
+work_12359	#subject_bible								
+work_12360	#subject_indexes								
+work_12361	#subject_theology	#subject_indexes							
+work_12362	#subject_indexes								
+work_12363	#subject_theology	#subject_indexes							
+work_17048	#subject_indexes								
+work_12364	#subject_indexes	#subject_bible							
+work_17064	#subject_indexes								
+work_17063	#subject_indexes								
+work_12365	#subject_indexes								
+work_17100	#subject_liturgy	#subject_theology	#subject_clergy						
+work_12368	#subject_bible	#subject_indexes							
+work_12369	#subject_indexes								
+work_17054	#subject_indexes								
+work_17058	#subject_indexes								
+work_17057	#subject_indexes								
+work_12370	#subject_indexes								
+work_17017	#subject_indexes								
+work_12372	#subject_indexes								
+work_17059	#subject_indexes								
+work_12366	#subject_bible	#subject_indexes							
+work_17037	#subject_law								
+work_12367	#subject_indexes								
+work_17016	#subject_indexes								
+work_12373	#subject_law								
+work_17090	#subject_indexes								
+work_12374	#subject_theology	#subject_indexes							
+work_17118	#subject_indexes								
+work_12375	#subject_law								
+work_12376	#subject_indexes								
+work_12377	#subject_indexes								
+work_12378	#subject_christian_literature								
+work_12379	#subject_documents								
+work_2191	#subject_christian_literature								
+work_2192	#subject_theology								
+work_2193	#subject_liturgy	#subject_theology	#subject_clergy						
+work_2194	#subject_sermons								
+work_2195	#subject_bible								
+work_6135	#subject_law								
+work_2196	#subject_law								
+work_2197	#subject_law								
+work_2200	#subject_christian_literature								
+work_2198	#subject_christian_literature								
+work_2199	#subject_law								
+work_2201	#subject_theology								
+work_3542	#subject_bible								
+work_2202	#subject_literature								
+work_12380	#subject_law								
+work_12381	#subject_documents								
+work_12382	#subject_documents								
+work_12383	#subject_documents								
+work_12384	#subject_documents								
+work_12385	#subject_history								
+work_12389	#subject_history								
+work_12392	#subject_history								
+work_12387	#subject_history								
+work_12393	#subject_history								
+work_12394	#subject_monasticism_and_religious_orders								
+work_12395	#subject_law								
+work_12397	#subject_christian_literature								
+work_12398	#subject_documents								
+work_12399	#subject_bible								
+work_12400	#subject_bible								
+work_16078	#subject_bible								
+work_12402	#subject_history								
+work_12401	#subject_bible								
+work_12404	#subject_literature								
+work_12405	#subject_documents								
+work_12406	#subject_documents								
+work_16007	#subject_documents								
+work_12407	#subject_documents								
+work_12409	#subject_documents	#subject_liturgy							
+work_12410	#subject_documents								
+work_12408	#subject_documents								
+work_12411	#subject_documents								
+work_12412	#subject_documents								
+work_12413	#subject_documents								
+work_12414	#subject_liturgy	#subject_christian_literature							
+work_12415	#subject_liturgy	#subject_christian_literature							
+work_2439	#subject_bible								
+work_2440	#subject_sermons	#subject_hagiography							
+work_2441	#subject_literature								
+work_165	#subject_literature								
+work_166	#subject_literature								
+work_167	#subject_literature								
+work_151	#subject_literature								
+work_156	#subject_literature								
+work_7354	#subject_philosophy								
+work_2864	#subject_politics_and_government								
+work_12416	#subject_literature								
+work_12417	#subject_literature								
+work_12418	#subject_history								
+work_12419	#subject_history								
+work_12421	#subject_history	#subject_hagiography							
+work_12422	#subject_history								
+work_12423	#subject_history	#subject_geography	#subject_hagiography						
+work_12424	#subject_history								
+work_12425	#subject_history								
+work_6154	#subject_law								
+work_2243	#subject_christian_literature								
+work_2244	#subject_christian_literature								
+work_2242	#subject_christian_literature								
+work_2245	#subject_christian_literature								
+work_2246	#subject_sermons								
+work_6592	#subject_theology								
+work_12426	#subject_medicine								
+work_2248	#subject_christian_literature								
+work_6155	#subject_law								
+work_4031	#subject_law								
+work_2274	#subject_christian_literature								
+work_2272	#subject_theology								
+work_7164	#subject_theology								
+work_4032	#subject_theology	#subject_natural_history	#subject_science						
+work_2259	#subject_bible								
+work_2260	#subject_history								
+work_2249	#subject_bible								
+work_2262	#subject_bible								
+work_2250	#subject_theology								
+work_2263	#subject_liturgy								
+work_2251	#subject_theology								
+work_2265	#subject_natural_history								
+work_2252	#subject_bible								
+work_2254	#subject_bible								
+work_2271	#subject_theology								
+work_2256	#subject_history								
+work_6200	#subject_christian_literature								
+work_2257	#subject_theology								
+work_2258	#subject_bible								
+work_2266	#subject_grammar								
+work_2268	#subject_theology								
+work_2269	#subject_theology								
+work_2270	#subject_theology								
+work_2275	#subject_classical_literature	#subject_rhetoric							
+work_2276	#subject_classical_literature	#subject_rhetoric							
+work_6250	#subject_classical_literature	#subject_rhetoric							
+work_2278	#subject_classical_literature	#subject_rhetoric							
+work_2280	#subject_classical_literature	#subject_rhetoric							
+work_2279	#subject_classical_literature	#subject_rhetoric							
+work_7515	#subject_christian_literature								
+work_7205	#subject_medicine								
+work_2235	#subject_medicine								
+work_2236	#subject_medicine								
+work_2237	#subject_medicine								
+work_2238	#subject_medicine								
+work_2239	#subject_medicine								
+work_2240	#subject_medicine								
+work_12429	#subject_literature	#subject_history							
+work_12430	#subject_history								
+work_12431	#subject_literature								
+work_12432	#subject_grammar								
+work_16056	#subject_geography								
+work_12433	#subject_geography								
+work_5035	#subject_monasticism_and_religious_orders								
+work_2288	#subject_law								
+work_2289	#subject_liturgy	#subject_theology	#subject_clergy						
+work_7348	#subject_law								
+work_2292	#subject_literature								
+work_2293	#subject_law								
+work_2294	#subject_sermons								
+work_177	#subject_science								
+work_12435	#subject_monasticism_and_religious_orders	#subject_literature							
+work_12436	#subject_bible	#subject_bible							
+work_2299	#subject_law								
+work_2300	#subject_law								
+work_2303	#subject_law								
+work_2305	#subject_philosophy								
+work_2311	#subject_theology								
+work_2317	#subject_christian_literature								
+work_2320	#subject_liturgy								
+work_2322	#subject_philosophy								
+work_2338	#subject_medicine								
+work_186	#subject_medicine								
+work_2301	#subject_natural_history								
+work_2183	#subject_sermons								
+work_2306	#subject_recreation	#subject_conduct							
+work_2307	#subject_recreation	#subject_conduct							
+work_7400	#subject_theology								
+work_7401	#subject_theology								
+work_7402	#subject_theology								
+work_2316	#subject_monasticism_and_religious_orders								
+work_7399	#subject_theology								
+work_2352	#subject_monasticism_and_religious_orders								
+work_2308	#subject_medicine								
+work_7027	#subject_sermons								
+work_2355	#subject_sermons								
+work_2310	#subject_sermons								
+work_2318	#subject_philosophy								
+work_2319	#subject_philosophy								
+work_2184	#subject_theology								
+work_2321	#subject_theology								
+work_2327	#subject_hagiography								
+work_2328	#subject_hagiography								
+work_2329	#subject_hagiography								
+work_2330	#subject_hagiography								
+work_2331	#subject_sermons								
+work_2333	#subject_sermons								
+work_2334	#subject_sermons								
+work_7343	#subject_sermons								
+work_2335	#subject_indexes	#subject_bible	#subject_theology						
+work_2339	#subject_law								
+work_2345	#subject_christian_literature								
+work_2349	#subject_literature								
+work_2323	#subject_sermons								
+work_2350	#subject_history								
+work_2354	#subject_literature								
+work_3968	#subject_christian_literature								
+work_3969	#subject_christian_literature								
+work_2356	#subject_christian_literature								
+work_2357	#subject_christian_literature								
+work_2521	#subject_literature								
+work_2360	#subject_science								
+work_2806	#subject_sermons								
+work_2536	#subject_monasticism_and_religious_orders								
+work_2518	#subject_clergy								
+work_2385	#subject_history								
+work_2393	#subject_bible								
+work_2386	#subject_hagiography								
+work_2388	#subject_history								
+work_2713	#subject_bible								
+work_2714	#subject_sermons								
+work_7043	#subject_history								
+work_2570	#subject_philosophy								
+work_7239	#subject_natural_history								
+work_2563	#subject_philosophy								
+work_7411	#subject_bible								
+work_6346	#subject_bible								
+work_2390	#subject_bible								
+work_2585	#subject_theology								
+work_2584	#subject_bible								
+work_2861	#subject_theology								
+work_2387	#subject_literature								
+work_2381	#subject_history								
+work_5830	#subject_christian_literature								
+work_7418	#subject_theology								
+work_7422	#subject_theology								
+work_7436	#subject_theology								
+work_4034	#subject_bible								
+work_4035	#subject_bible								
+work_4036	#subject_bible								
+work_4037	#subject_bible								
+work_4038	#subject_music								
+work_4039	#subject_hagiography								
+work_3818	#subject_grammar								
+work_4040	#subject_bible	#subject_bible	#subject_bible						
+work_4041	#subject_theology								
+work_7360	#subject_theology								
+work_7023	#subject_grammar	#subject_history							
+work_7417	#subject_theology								
+work_7416	#subject_theology								
+work_4043	#subject_theology								
+work_4042	#subject_christian_literature								
+work_4044	#subject_theology	#subject_theology							
+work_6072	#subject_theology								
+work_4045	#subject_hagiography	#subject_liturgy							
+work_4046	#subject_bible								
+work_4047	#subject_monasticism_and_religious_orders								
+work_4048	#subject_monasticism_and_religious_orders								
+work_4049	#subject_theology								
+work_4050	#subject_hagiography								
+work_6313	#subject_monasticism_and_religious_orders	#subject_monasticism_and_religious_orders							
+work_4051	#subject_hagiography								
+work_6597	#subject_theology								
+work_7420	#subject_theology								
+work_2394	#subject_theology								
+work_2395	#subject_theology								
+work_2408	#subject_bible								
+work_2397	#subject_bible								
+work_2398	#subject_bible								
+work_2399	#subject_bible								
+work_2402	#subject_bible								
+work_2403	#subject_bible								
+work_2404	#subject_bible								
+work_2405	#subject_bible								
+work_2406	#subject_bible								
+work_6321	#subject_bible	#subject_liturgy							
+work_2407	#subject_bible								
+work_2409	#subject_theology								
+work_2434	#subject_bible	#subject_geography							
+work_2410	#subject_history								
+work_2411	#subject_bible	#subject_theology							
+work_2412	#subject_theology								
+work_7100	#subject_theology	#subject_christian_literature							
+work_2416	#subject_theology	#subject_christian_literature							
+work_2417	#subject_theology	#subject_christian_literature							
+work_7419	#subject_theology								
+work_2418	#subject_theology	#subject_bible	#subject_christian_literature						
+work_2419	#subject_theology	#subject_christian_literature							
+work_7118	#subject_theology	#subject_christian_literature							
+work_7022	#subject_theology	#subject_bible	#subject_christian_literature						
+work_2420	#subject_theology	#subject_clergy	#subject_christian_literature						
+work_7162	#subject_theology	#subject_christian_literature							
+work_2414	#subject_theology	#subject_bible	#subject_christian_literature						
+work_2413	#subject_theology	#subject_bible	#subject_christian_literature						
+work_2421	#subject_monasticism_and_religious_orders								
+work_2422	#subject_christian_literature								
+work_2423	#subject_theology								
+work_2424	#subject_theology	#subject_christian_literature							
+work_2426	#subject_theology	#subject_christian_literature							
+work_2425	#subject_theology	#subject_christian_literature							
+work_2427	#subject_bible								
+work_2428	#subject_bible								
+work_2429	#subject_bible								
+work_2430	#subject_hagiography								
+work_2431	#subject_hagiography	#subject_monasticism_and_religious_orders							
+work_2432	#subject_hagiography								
+work_2433	#subject_theology								
+work_2046	#subject_bible								
+work_12440	#subject_history								
+work_2448	#subject_medicine								
+work_2535	#subject_law								
+work_2808	#subject_medicine								
+work_2810	#subject_medicine								
+work_7196	#subject_science								
+work_2851	#subject_philosophy								
+work_2852	#subject_science								
+work_6099	#subject_science								
+work_2562	#subject_history								
+work_2836	#subject_christian_literature								
+work_2837	#subject_christian_literature								
+work_2550	#subject_law								
+work_2551	#subject_law								
+work_2552	#subject_law								
+work_2553	#subject_law								
+work_2229	#subject_law								
+work_2443	#subject_hagiography								
+work_6066	#subject_history								
+work_2879	#subject_law								
+work_6316	#subject_medicine								
+work_2455	#subject_bible	#subject_philosophy							
+work_2456	#subject_philosophy								
+work_6447	#subject_rhetoric								
+work_187	#subject_bible								
+work_2480	#subject_medicine								
+work_6242	#subject_sermons								
+work_2549	#subject_medicine								
+work_2558	#subject_sermons								
+work_4054	#subject_music								
+work_2581	#subject_medicine								
+work_6367	#subject_sermons								
+work_2594	#subject_grammar								
+work_2602	#subject_theology								
+work_2607	#subject_medicine								
+work_6122	#subject_classical_literature								
+work_6121	#subject_classical_literature								
+work_2493	#subject_grammar	#subject_philosophy							
+work_2498	#subject_medicine								
+work_2507	#subject_theology								
+work_6315	#subject_philosophy								
+work_2590	#subject_science								
+work_2591	#subject_science								
+work_2592	#subject_science								
+work_4053	#subject_philosophy								
+work_7403	#subject_medicine								
+work_2531	#subject_science								
+work_2624	#subject_history								
+work_2461	#subject_rhetoric								
+work_2811	#subject_theology								
+work_2464	#subject_science								
+work_2718	#subject_science								
+work_2640	#subject_science								
+work_2641	#subject_science								
+work_2813	#subject_hagiography								
+work_2220	#subject_hagiography								
+work_2472	#subject_sermons								
+work_2473	#subject_literature								
+work_2474	#subject_theology								
+work_2816	#subject_theology								
+work_2820	#subject_theology								
+work_2210	#subject_theology								
+work_5857	#subject_theology								
+work_2817	#subject_theology								
+work_2818	#subject_theology								
+work_2475	#subject_theology								
+work_2819	#subject_theology								
+work_7076	#subject_theology								
+work_5800	#subject_sermons								
+work_6005	#subject_theology								
+work_2209	#subject_christian_literature								
+work_7075	#subject_philosophy								
+work_2821	#subject_philosophy								
+work_2208	#subject_science								
+work_2822	#subject_christian_literature								
+work_2477	#subject_sermons								
+work_2823	#subject_theology								
+work_2478	#subject_theology								
+work_2479	#subject_theology								
+work_2537	#subject_history								
+work_2538	#subject_christian_literature								
+work_2539	#subject_christian_literature								
+work_2825	#subject_theology								
+work_2556	#subject_theology								
+work_2608	#subject_theology	#subject_theology							
+work_7371	#subject_theology								
+work_7330	#subject_law								
+work_2557	#subject_theology	#subject_theology							
+work_7370	#subject_theology								
+work_7331	#subject_indexes								
+work_6227	#subject_christian_literature								
+work_2228	#subject_literature								
+work_2572	#subject_medicine								
+work_2573	#subject_science								
+work_2574	#subject_science								
+work_2575	#subject_science								
+work_5600	#subject_law								
+work_2583	#subject_science								
+work_2230	#subject_science								
+work_6177	#subject_science								
+work_2587	#subject_medicine								
+work_2588	#subject_medicine								
+work_2593	#subject_medicine								
+work_7390	#subject_medicine								
+work_2802	#subject_medicine								
+work_2846	#subject_medicine								
+work_2845	#subject_medicine								
+work_2589	#subject_medicine								
+work_2853	#subject_philosophy								
+work_2595	#subject_grammar								
+work_2596	#subject_grammar								
+work_2597	#subject_grammar								
+work_2231	#subject_theology								
+work_2599	#subject_theology								
+work_2603	#subject_bible								
+work_2604	#subject_bible								
+work_2605	#subject_sermons								
+work_2483	#subject_rhetoric								
+work_2211	#subject_rhetoric								
+work_2688	#subject_rhetoric								
+work_2485	#subject_law								
+work_2488	#subject_law								
+work_2693	#subject_sermons								
+work_2694	#subject_sermons								
+work_2695	#subject_sermons								
+work_6254	#subject_law								
+work_6253	#subject_law								
+work_2782	#subject_indexes								
+work_2711	#subject_rhetoric								
+work_2719	#subject_rhetoric								
+work_2841	#subject_christian_literature	#subject_rhetoric							
+work_7133	#subject_theology								
+work_7131	#subject_theology								
+work_7135	#subject_theology								
+work_6140	#subject_theology								
+work_7130	#subject_theology								
+work_7132	#subject_theology								
+work_7136	#subject_theology								
+work_7134	#subject_theology								
+work_6251	#subject_law								
+work_2759	#subject_classical_literature								
+work_7086	#subject_bible								
+work_2761	#subject_bible								
+work_2767	#subject_history								
+work_2765	#subject_science								
+work_2766	#subject_science								
+work_2609	#subject_sermons								
+work_2524	#subject_sermons								
+work_2858	#subject_history								
+work_6062	#subject_hagiography								
+work_6061	#subject_hagiography								
+work_2770	#subject_liturgy	#subject_theology	#subject_clergy						
+work_2530	#subject_bible								
+work_7431	#subject_sermons								
+work_2612	#subject_medicine								
+work_2611	#subject_medicine								
+work_2627	#subject_science								
+work_5822	#subject_theology								
+work_5636	#subject_sermons								
+work_4055	#subject_sermons	#subject_hagiography							
+work_6455	#subject_sermons								
+work_4056	#subject_bible								
+work_5821	#subject_theology								
+work_4057	#subject_sermons								
+work_7437	#subject_theology								
+work_5870	#subject_monasticism_and_religious_orders								
+work_5867	#subject_theology								
+work_5825	#subject_theology								
+work_5880	#subject_theology								
+work_6223	#subject_sermons								
+work_5908	#subject_theology								
+work_6224	#subject_theology								
+work_2642	#subject_theology								
+work_7421	#subject_theology								
+work_2644	#subject_theology								
+work_5982	#subject_sermons								
+work_5692	#subject_theology								
+work_2646	#subject_bible								
+work_5981	#subject_sermons								
+work_5965	#subject_theology								
+work_5728	#subject_theology								
+work_5783	#subject_sermons								
+work_6017	#subject_theology								
+work_5963	#subject_sermons								
+work_6034	#subject_theology								
+work_5709	#subject_theology								
+work_5823	#subject_theology								
+work_5960	#subject_sermons								
+work_2647	#subject_theology								
+work_5711	#subject_theology								
+work_5701	#subject_theology								
+work_5964	#subject_sermons								
+work_5829	#subject_theology								
+work_5986	#subject_sermons								
+work_5734	#subject_theology								
+work_2648	#subject_theology								
+work_5727	#subject_theology								
+work_5710	#subject_theology								
+work_6032	#subject_theology								
+work_5716	#subject_sermons								
+work_5707	#subject_theology								
+work_5980	#subject_sermons								
+work_2649	#subject_theology								
+work_2650	#subject_theology								
+work_5696	#subject_theology								
+work_6045	#subject_theology								
+work_5827	#subject_theology								
+work_5828	#subject_theology								
+work_2651	#subject_theology								
+work_5706	#subject_theology								
+work_5961	#subject_sermons								
+work_2652	#subject_philosophy								
+work_5799	#subject_theology								
+work_5962	#subject_theology								
+work_6020	#subject_sermons								
+work_5721	#subject_sermons								
+work_6035	#subject_sermons								
+work_5824	#subject_liturgy								
+work_5858	#subject_sermons								
+work_6018	#subject_theology								
+work_5985	#subject_sermons								
+work_2653	#subject_theology								
+work_5979	#subject_theology								
+work_2654	#subject_theology								
+work_5720	#subject_theology								
+work_5693	#subject_theology								
+work_5715	#subject_theology								
+work_5705	#subject_theology								
+work_2655	#subject_theology								
+work_2656	#subject_theology								
+work_5694	#subject_theology								
+work_2658	#subject_theology								
+work_5732	#subject_monasticism_and_religious_orders								
+work_2205	#subject_theology								
+work_2659	#subject_theology								
+work_5990	#subject_sermons								
+work_5795	#subject_sermons								
+work_2660	#subject_sermons								
+work_2662	#subject_sermons								
+work_2674	#subject_sermons								
+work_2675	#subject_sermons								
+work_2663	#subject_sermons								
+work_2665	#subject_sermons								
+work_2666	#subject_sermons								
+work_2667	#subject_sermons								
+work_2661	#subject_sermons								
+work_5761	#subject_bible								
+work_2668	#subject_sermons								
+work_2673	#subject_sermons								
+work_5762	#subject_bible								
+work_2669	#subject_sermons								
+work_2670	#subject_sermons								
+work_2671	#subject_sermons								
+work_5668	#subject_sermons								
+work_5713	#subject_sermons								
+work_5700	#subject_sermons								
+work_5852	#subject_sermons								
+work_5695	#subject_sermons								
+work_5859	#subject_sermons								
+work_6016	#subject_sermons								
+work_5691	#subject_sermons								
+work_5860	#subject_sermons								
+work_6046	#subject_sermons								
+work_5987	#subject_sermons								
+work_6025	#subject_sermons								
+work_5141	#subject_sermons								
+work_5724	#subject_sermons								
+work_5984	#subject_sermons								
+work_5983	#subject_sermons								
+work_5708	#subject_sermons								
+work_5714	#subject_sermons								
+work_5719	#subject_sermons								
+work_5718	#subject_sermons								
+work_5712	#subject_sermons								
+work_5699	#subject_sermons								
+work_5697	#subject_sermons								
+work_5704	#subject_sermons								
+work_5726	#subject_sermons								
+work_6036	#subject_sermons								
+work_5851	#subject_sermons								
+work_6044	#subject_sermons								
+work_5640	#subject_sermons								
+work_5872	#subject_bible								
+work_6019	#subject_sermons								
+work_6014	#subject_sermons								
+work_5643	#subject_sermons								
+work_6023	#subject_sermons								
+work_5864	#subject_sermons								
+work_5975	#subject_sermons								
+work_5976	#subject_sermons								
+work_5977	#subject_sermons								
+work_5978	#subject_sermons								
+work_6037	#subject_sermons								
+work_5874	#subject_sermons								
+work_2678	#subject_liturgy								
+work_5150	#subject_sermons	#subject_hagiography							
+work_5717	#subject_theology	#subject_clergy							
+work_5856	#subject_theology								
+work_6039	#subject_theology								
+work_2657	#subject_sermons								
+work_5826	#subject_sermons								
+work_2680	#subject_theology								
+work_2681	#subject_theology								
+work_2800	#subject_science								
+work_2801	#subject_law								
+work_7319	#subject_philosophy								
+work_2812	#subject_grammar								
+work_2814	#subject_grammar								
+work_4062	#subject_hagiography	#subject_christian_literature							
+work_4052	#subject_hagiography	#subject_christian_literature							
+work_4060	#subject_hagiography	#subject_christian_literature							
+work_2826	#subject_sermons								
+work_2600	#subject_medicine								
+work_2857	#subject_medicine								
+work_2791	#subject_law								
+work_2792	#subject_law								
+work_2795	#subject_law								
+work_2796	#subject_law								
+work_64	#subject_theology								
+work_2466	#subject_theology								
+work_2470	#subject_theology								
+work_2467	#subject_theology								
+work_2468	#subject_theology								
+work_2469	#subject_theology								
+work_7280	#subject_philosophy								
+work_7279	#subject_philosophy								
+work_2214	#subject_law								
+work_2807	#subject_history								
+work_1775	#subject_theology								
+work_2465	#subject_law								
+work_2544	#subject_monasticism_and_religious_orders								
+work_1789	#subject_sermons								
+work_2545	#subject_theology								
+work_2827	#subject_medicine								
+work_2559	#subject_grammar								
+work_2828	#subject_grammar								
+work_2829	#subject_liturgy	#subject_clergy							
+work_2560	#subject_grammar								
+work_2561	#subject_grammar								
+work_2830	#subject_hagiography								
+work_2831	#subject_classical_literature								
+work_2832	#subject_rhetoric								
+work_2833	#subject_rhetoric								
+work_2834	#subject_grammar								
+work_2835	#subject_history								
+work_2843	#subject_magic								
+work_6348	#subject_literature								
+work_2847	#subject_philosophy								
+work_2848	#subject_philosophy								
+work_2849	#subject_hagiography								
+work_2855	#subject_music								
+work_2856	#subject_music								
+work_2773	#subject_sermons								
+work_2775	#subject_philosophy								
+work_2776	#subject_sermons								
+work_2780	#subject_theology								
+work_2781	#subject_sermons								
+work_6064	#subject_history								
+work_2862	#subject_hagiography								
+work_6107	#subject_hagiography								
+work_12456	#subject_law								
+work_12457	#subject_law								
+work_2867	#subject_christian_literature								
+work_2868	#subject_sermons								
+work_2869	#subject_sermons								
+work_6290	#subject_sermons								
+work_2863	#subject_history								
+work_4063	#subject_science								
+work_4064	#subject_science								
+work_2865	#subject_science								
+work_2866	#subject_science								
+work_2872	#subject_history	#subject_literature							
+work_5854	#subject_sermons								
+work_1530	#subject_history								
+work_2873	#subject_history								
+work_2875	#subject_history								
+work_2874	#subject_history								
+work_12450	#subject_history								
+work_17131	#subject_law								
+work_12451	#subject_law								
+work_12452	#subject_law								
+work_2881	#subject_history								
+work_2283	#subject_literature								
+work_2282	#subject_literature								
+work_2286	#subject_rhetoric								
+work_12455	#subject_law								
+work_2888	#subject_law								
+work_2889	#subject_law								
+work_2890	#subject_law								
+work_2891	#subject_law								
+work_2892	#subject_law								
+work_2893	#subject_law								
+work_12396	#subject_law								
+work_2894	#subject_law								
+work_2895	#subject_law								
+work_2887	#subject_history								
+work_4065	#subject_theology								
+work_2896	#subject_literature								
+work_2287	#subject_bible								
+work_12458	#subject_science								
+work_1971	#subject_monasticism_and_religious_orders								
+work_2717	#subject_clergy								
+work_12459	#subject_literature								
+work_4258	#subject_philosophy								
+work_7046	#subject_theology								
+work_7246	#subject_philosophy								
+work_7276	#subject_philosophy								
+work_7035	#subject_theology								
+work_4395	#subject_philosophy								
+work_7039	#subject_philosophy								
+work_7047	#subject_theology								
+work_4396	#subject_philosophy								
+work_6204	#subject_grammar								
+work_7044	#subject_theology								
+work_7111	#subject_theology								
+work_4397	#subject_philosophy								
+work_1373	#subject_bible								
+work_435	#subject_medicine								
+work_438	#subject_philosophy								
+work_439	#subject_philosophy								
+work_436	#subject_philosophy								
+work_440	#subject_science								
+work_437	#subject_science								
+work_441	#subject_philosophy								
+work_12460	#subject_literature								
+work_12462	#subject_literature								
+work_12901	#subject_hagiography								
+work_12463	#subject_literature								
+work_1995	#subject_monasticism_and_religious_orders								
+work_2494	#subject_theology								
+work_12467	#subject_literature								
+work_12468	#subject_literature								
+work_1996	#subject_history								
+work_4009	#subject_history								
+work_3461	#subject_sermons								
+work_1301	#subject_monasticism_and_religious_orders								
+work_1308	#subject_theology								
+work_1307	#subject_theology								
+work_12469	#subject_liturgy								
+work_12470	#subject_theology								
+work_4739	#subject_philosophy								
+work_3331	#subject_science								
+work_3332	#subject_science								
+work_17129	#subject_law								
+work_17130	#subject_law								
+work_12471	#subject_liturgy	#subject_music							
+work_12472	#subject_liturgy								
+work_12473	#subject_liturgy								
+work_16276	#subject_conduct								
+work_12475	#subject_literature								
+work_12476	#subject_literature								
+work_12477	#subject_literature								
+work_12478	#subject_law								
+work_12479	#subject_law								
+work_12480	#subject_history	#subject_literature							
+work_12481	#subject_bible								
+work_12482	#subject_literature								
+work_3375	#subject_literature								
+work_16324	#subject_history								
+work_12483	#subject_literature	#subject_literature							
+work_555	#subject_literature								
+work_17013	#subject_history								
+work_12484	#subject_monasticism_and_religious_orders								
+work_3013	#subject_classical_literature								
+work_2907	#subject_theology								
+work_2908	#subject_theology								
+work_2909	#subject_theology								
+work_2910	#subject_theology								
+work_2911	#subject_theology								
+work_2912	#subject_theology								
+work_1695	#subject_grammar								
+work_2343	#subject_christian_literature								
+work_12490	#subject_literature								
+work_12491	#subject_literature								
+work_12492	#subject_literature								
+work_12493	#subject_literature								
+work_12495	#subject_literature								
+work_12494	#subject_literature								
+work_12496	#subject_literature								
+work_12497	#subject_literature								
+work_12498	#subject_documents								
+work_12499	#subject_documents								
+work_12500	#subject_documents								
+work_2224	#subject_documents								
+work_2495	#subject_documents								
+work_2913	#subject_law								
+work_2914	#subject_theology								
+work_2915	#subject_grammar								
+work_2916	#subject_medicine								
+work_5016	#subject_christian_literature								
+work_7432	#subject_theology								
+work_4622	#subject_grammar	#subject_theology	#subject_bible						
+work_4621	#subject_bible								
+work_4610	#subject_bible								
+work_4611	#subject_bible								
+work_4612	#subject_bible								
+work_7372	#subject_bible								
+work_4613	#subject_bible								
+work_4614	#subject_bible								
+work_4615	#subject_bible								
+work_4616	#subject_bible								
+work_4617	#subject_bible								
+work_4618	#subject_bible								
+work_4619	#subject_bible								
+work_4620	#subject_theology								
+work_7379	#subject_sermons								
+work_4126	#subject_theology								
+work_1922	#subject_theology								
+work_12501	#subject_natural_history								
+work_12502	#subject_natural_history								
+work_12503	#subject_natural_history								
+work_12504	#subject_natural_history								
+work_12505	#subject_natural_history								
+work_12506	#subject_natural_history								
+work_2919	#subject_politics_and_government								
+work_1313	#subject_rhetoric								
+work_1314	#subject_history								
+work_2799	#subject_grammar								
+work_16058	#subject_geography								
+work_7374	#subject_theology								
+work_7107	#subject_bible								
+work_12507	#subject_grammar								
+work_12508	#subject_grammar								
+work_12509	#subject_grammar								
+work_12510	#subject_grammar								
+work_12511	#subject_grammar								
+work_12512	#subject_grammar								
+work_12513	#subject_grammar								
+work_1162	#subject_politics_and_government	#subject_natural_history							
+work_1163	#subject_politics_and_government	#subject_natural_history							
+work_1164	#subject_politics_and_government	#subject_natural_history							
+work_12515	#subject_liturgy								
+work_2924	#subject_theology								
+work_2927	#subject_science								
+work_2931	#subject_history	#subject_bible							
+work_2932	#subject_hagiography								
+work_2921	#subject_rhetoric								
+work_2930	#subject_rhetoric								
+work_4262	#subject_philosophy								
+work_4259	#subject_philosophy								
+work_4260	#subject_theology	#subject_classical_literature							
+work_4261	#subject_christian_literature								
+work_12516	#subject_law								
+work_12517	#subject_law								
+work_12518	#subject_law								
+work_12519	#subject_law								
+work_2998	#subject_christian_literature								
+work_2929	#subject_rhetoric								
+work_12520	#subject_law								
+work_12522	#subject_law								
+work_12521	#subject_law								
+work_12523	#subject_law								
+work_12524	#subject_theology								
+work_2379	#subject_history								
+work_12525	#subject_heraldry								
+work_12526	#subject_literature	#subject_history							
+work_12527	#subject_literature								
+work_12528	#subject_geography								
+work_12529	#subject_science	#subject_philosophy							
+work_12530	#subject_science								
+work_12532	#subject_literature								
+work_12535	#subject_documents								
+work_12536	#subject_documents								
+work_12537	#subject_documents								
+work_12538	#subject_documents								
+work_12539	#subject_documents								
+work_12540	#subject_documents								
+work_12541	#subject_documents								
+work_12542	#subject_documents								
+work_12543	#subject_documents								
+work_12544	#subject_documents								
+work_12545	#subject_documents								
+work_12546	#subject_documents								
+work_12547	#subject_documents								
+work_12548	#subject_documents								
+work_12549	#subject_documents								
+work_12550	#subject_documents								
+work_12551	#subject_documents								
+work_12552	#subject_documents								
+work_12554	#subject_liturgy								
+work_12555	#subject_liturgy								
+work_12556	#subject_liturgy								
+work_12557	#subject_liturgy								
+work_12558	#subject_liturgy								
+work_12559	#subject_liturgy								
+work_12561	#subject_liturgy								
+work_12562	#subject_liturgy								
+work_12563	#subject_liturgy								
+work_12564	#subject_liturgy								
+work_12565	#subject_liturgy								
+work_12566	#subject_liturgy								
+work_12567	#subject_liturgy								
+work_12568	#subject_documents	#subject_theology							
+work_12569	#subject_documents	#subject_law							
+work_12570	#subject_law	#subject_theology							
+work_12571	#subject_law	#subject_theology							
+work_12572	#subject_law								
+work_12573	#subject_law								
+work_12574	#subject_law								
+work_12575	#subject_law								
+work_12576	#subject_documents	#subject_law							
+work_12577	#subject_law								
+work_12578	#subject_law								
+work_12579	#subject_law								
+work_12580	#subject_law								
+work_12581	#subject_law								
+work_12582	#subject_documents								
+work_12583	#subject_law	#subject_history	#subject_documents						
+work_12584	#subject_law								
+work_12585	#subject_law								
+work_12596	#subject_law								
+work_12586	#subject_law								
+work_12587	#subject_law								
+work_12588	#subject_law								
+work_12589	#subject_documents	#subject_law							
+work_12592	#subject_law								
+work_12593	#subject_law								
+work_12594	#subject_law								
+work_12597	#subject_law								
+work_12598	#subject_law								
+work_12591	#subject_law								
+work_12590	#subject_law								
+work_12595	#subject_law								
+work_12600	#subject_hagiography								
+work_12599	#subject_bible								
+work_12602	#subject_bible								
+work_12604	#subject_hagiography	#subject_history							
+work_12605	#subject_liturgy								
+work_12606	#subject_liturgy								
+work_12607	#subject_liturgy								
+work_12608	#subject_history								
+work_12609	#subject_sermons	#subject_liturgy							
+work_12612	#subject_hagiography								
+work_12610	#subject_hagiography	#subject_hagiography	#subject_theology						
+work_12613	#subject_law								
+work_12614	#subject_law								
+work_12615	#subject_law								
+work_4812	#subject_literature	#subject_history							
+work_2302	#subject_christian_literature								
+work_2933	#subject_law								
+work_11710	#subject_bible								
+work_7406	#subject_bible								
+work_4597	#subject_sermons								
+work_2942	#subject_sermons								
+work_2939	#subject_sermons								
+work_5657	#subject_history								
+work_2943	#subject_history								
+work_2944	#subject_history								
+work_1533	#subject_science								
+work_2969	#subject_theology								
+work_2970	#subject_theology								
+work_2971	#subject_theology								
+work_2972	#subject_theology								
+work_5878	#subject_sermons								
+work_6038	#subject_sermons								
+work_5698	#subject_sermons								
+work_12617	#subject_literature								
+work_12618	#subject_literature								
+work_12620	#subject_law								
+work_12621	#subject_liturgy								
+work_2973	#subject_hagiography								
+work_3750	#subject_classical_literature								
+work_3751	#subject_rhetoric								
+work_12622	#subject_documents								
+work_12623	#subject_documents								
+work_12624	#subject_documents								
+work_12625	#subject_documents								
+work_12626	#subject_documents								
+work_12627	#subject_documents								
+work_12628	#subject_documents								
+work_12629	#subject_documents								
+work_12630	#subject_documents								
+work_12631	#subject_documents								
+work_12632	#subject_documents								
+work_12633	#subject_documents								
+work_12639	#subject_documents								
+work_12634	#subject_documents								
+work_17125	#subject_documents								
+work_12635	#subject_documents								
+work_12636	#subject_documents								
+work_12637	#subject_documents								
+work_12638	#subject_documents								
+work_12640	#subject_documents								
+work_12641	#subject_documents								
+work_12642	#subject_documents								
+work_12643	#subject_literature	#subject_documents							
+work_12644	#subject_documents	#subject_literature							
+work_12645	#subject_documents								
+work_12646	#subject_documents								
+work_12647	#subject_documents								
+work_12648	#subject_documents								
+work_12649	#subject_documents								
+work_12650	#subject_documents								
+work_12651	#subject_documents								
+work_12652	#subject_documents								
+work_12653	#subject_documents								
+work_12654	#subject_documents								
+work_12655	#subject_documents								
+work_12656	#subject_documents								
+work_12657	#subject_documents								
+work_12658	#subject_documents								
+work_12659	#subject_documents								
+work_12660	#subject_documents								
+work_12661	#subject_christian_literature								
+work_12662	#subject_documents								
+work_12663	#subject_documents								
+work_12664	#subject_documents								
+work_12665	#subject_documents								
+work_12666	#subject_documents								
+work_12667	#subject_documents								
+work_12668	#subject_documents								
+work_12669	#subject_documents								
+work_12670	#subject_documents								
+work_12671	#subject_documents								
+work_12673	#subject_documents								
+work_12672	#subject_documents								
+work_12674	#subject_documents								
+work_12675	#subject_documents								
+work_12677	#subject_documents								
+work_12678	#subject_documents								
+work_12679	#subject_documents								
+work_12680	#subject_documents								
+work_12681	#subject_documents								
+work_12682	#subject_documents								
+work_12683	#subject_documents								
+work_12684	#subject_documents								
+work_12685	#subject_documents								
+work_12676	#subject_documents								
+work_12686	#subject_documents	#subject_medicine							
+work_12687	#subject_documents								
+work_12688	#subject_documents								
+work_12689	#subject_documents								
+work_12690	#subject_documents								
+work_12691	#subject_documents								
+work_12692	#subject_documents								
+work_12693	#subject_documents								
+work_12694	#subject_documents								
+work_12695	#subject_documents								
+work_12696	#subject_documents								
+work_12697	#subject_documents								
+work_12698	#subject_documents								
+work_12699	#subject_documents								
+work_12700	#subject_documents								
+work_12703	#subject_monasticism_and_religious_orders								
+work_12702	#subject_theology								
+work_1354	#subject_history								
+work_12704	#subject_documents								
+work_12705	#subject_documents								
+work_12706	#subject_documents								
+work_12707	#subject_documents								
+work_12708	#subject_documents								
+work_12709	#subject_documents								
+work_12710	#subject_documents								
+work_12711	#subject_documents								
+work_12712	#subject_documents								
+work_12713	#subject_documents								
+work_12714	#subject_documents								
+work_12715	#subject_documents								
+work_12716	#subject_documents								
+work_12717	#subject_documents								
+work_12718	#subject_documents								
+work_12720	#subject_documents								
+work_12721	#subject_documents								
+work_12722	#subject_documents								
+work_12719	#subject_documents								
+work_12723	#subject_documents								
+work_12724	#subject_documents								
+work_12725	#subject_documents								
+work_12726	#subject_documents								
+work_12727	#subject_monasticism_and_religious_orders								
+work_12728	#subject_documents								
+work_12729	#subject_documents								
+work_12730	#subject_documents	#subject_literature							
+work_12731	#subject_documents	#subject_literature							
+work_12732	#subject_literature	#subject_documents							
+work_12733	#subject_documents								
+work_12734	#subject_documents								
+work_12736	#subject_clergy	#subject_documents							
+work_12737	#subject_clergy								
+work_12738	#subject_documents	#subject_monasticism_and_religious_orders							
+work_12735	#subject_documents								
+work_12739	#subject_documents								
+work_12740	#subject_rhetoric								
+work_12741	#subject_hagiography								
+work_12743	#subject_documents								
+work_12744	#subject_documents								
+work_12745	#subject_hagiography	#subject_history							
+work_12746	#subject_theology								
+work_17115	#subject_law								
+work_12747	#subject_documents								
+work_12748	#subject_documents								
+work_12749	#subject_bible								
+work_12750	#subject_literature								
+work_12751	#subject_literature								
+work_12752	#subject_clergy								
+work_12754	#subject_documents								
+work_12755	#subject_clergy								
+work_12757	#subject_documents	#subject_law							
+work_12758	#subject_documents								
+work_12759	#subject_documents								
+work_12760	#subject_documents								
+work_12761	#subject_documents								
+work_12762	#subject_documents								
+work_12763	#subject_documents								
+work_12764	#subject_documents								
+work_12767	#subject_documents	#subject_monasticism_and_religious_orders							
+work_12766	#subject_documents								
+work_12768	#subject_documents								
+work_12770	#subject_documents								
+work_12771	#subject_documents								
+work_12742	#subject_literature								
+work_12756	#subject_rhetoric								
+work_12765	#subject_literature								
+work_16277	#subject_medicine								
+work_12773	#subject_grammar								
+work_12775	#subject_grammar								
+work_12774	#subject_grammar	#subject_rhetoric	#subject_science	#subject_theology					
+work_17023	#subject_theology	#subject_bible							
+work_12778	#subject_grammar								
+work_12779	#subject_grammar								
+work_12780	#subject_grammar								
+work_12777	#subject_grammar	#subject_bible							
+work_16365	#subject_grammar								
+work_3151	#subject_sermons								
+work_16072	#subject_literature								
+work_12781	#subject_christian_literature								
+work_2975	#subject_rhetoric								
+work_2976	#subject_rhetoric								
+work_53	#subject_rhetoric								
+work_2977	#subject_rhetoric								
+work_70	#subject_rhetoric								
+work_2979	#subject_rhetoric								
+work_2980	#subject_rhetoric								
+work_2981	#subject_rhetoric								
+work_145	#subject_rhetoric								
+work_5157	#subject_rhetoric								
+work_171	#subject_rhetoric								
+work_2982	#subject_rhetoric								
+work_154	#subject_rhetoric								
+work_163	#subject_rhetoric								
+work_12783	#subject_history								
+work_12784	#subject_science								
+work_12785	#subject_theology								
+work_12786	#subject_grammar								
+work_12787	#subject_science								
+work_12788	#subject_liturgy								
+work_12789	#subject_science	#subject_liturgy							
+work_12790	#subject_theology								
+work_12791	#subject_medicine								
+work_12792	#subject_medicine								
+work_16197	#subject_theology								
+work_12794	#subject_science								
+work_12795	#subject_hagiography								
+work_17103	#subject_theology								
+work_12796	#subject_monasticism_and_religious_orders								
+work_12797	#subject_grammar								
+work_12798	#subject_sermons								
+work_12799	#subject_literature	#subject_theology							
+work_12800	#subject_history								
+work_16325	#subject_bible								
+work_12801	#subject_liturgy								
+work_12802	#subject_bible								
+work_12803	#subject_science								
+work_12804	#subject_christian_literature	#subject_hagiography	#subject_hagiography						
+work_12805	#subject_natural_history								
+work_12806	#subject_science								
+work_12807	#subject_grammar								
+work_12808	#subject_science								
+work_17040	#subject_theology	#subject_theology	#subject_theology						
+work_12809	#subject_history								
+work_16010	#subject_clergy								
+work_12811	#subject_theology								
+work_12813	#subject_law								
+work_12814	#subject_clergy								
+work_11031	#subject_liturgy								
+work_12815	#subject_science								
+work_12816	#subject_monasticism_and_religious_orders	#subject_bibliography							
+work_12817	#subject_bibliography								
+work_12818	#subject_literature								
+work_2497	#subject_magic								
+work_2974	#subject_bible								
+work_16188	#subject_hagiography								
+work_16186	#subject_hagiography								
+work_12820	#subject_hagiography	#subject_hagiography							
+work_16093	#subject_hagiography								
+work_16123	#subject_hagiography								
+work_16178	#subject_hagiography								
+work_16019	#subject_hagiography								
+work_12822	#subject_bible								
+work_16200	#subject_bible	#subject_christian_literature							
+work_12824	#subject_history								
+work_12827	#subject_hagiography								
+work_12830	#subject_hagiography								
+work_12829	#subject_hagiography								
+work_16203	#subject_hagiography								
+work_12831	#subject_history								
+work_12832	#subject_hagiography								
+work_16134	#subject_hagiography								
+work_16082	#subject_hagiography								
+work_17126	#subject_history								
+work_12834	#subject_hagiography								
+work_12835	#subject_hagiography								
+work_12836	#subject_hagiography								
+work_16207	#subject_hagiography								
+work_16149	#subject_hagiography								
+work_16158	#subject_hagiography								
+work_16142	#subject_hagiography								
+work_16166	#subject_hagiography								
+work_12826	#subject_hagiography								
+work_16151	#subject_hagiography								
+work_12850	#subject_hagiography								
+work_16124	#subject_hagiography								
+work_16161	#subject_hagiography								
+work_16094	#subject_hagiography								
+work_16121	#subject_hagiography								
+work_17085	#subject_hagiography								
+work_16125	#subject_hagiography								
+work_16144	#subject_hagiography								
+work_16129	#subject_hagiography								
+work_16095	#subject_hagiography								
+work_16136	#subject_hagiography								
+work_12877	#subject_hagiography								
+work_17089	#subject_hagiography								
+work_12886	#subject_hagiography								
+work_12888	#subject_hagiography								
+work_16022	#subject_hagiography								
+work_16180	#subject_hagiography								
+work_16191	#subject_hagiography								
+work_16015	#subject_hagiography								
+work_12893	#subject_hagiography								
+work_12894	#subject_hagiography								
+work_16182	#subject_hagiography								
+work_16133	#subject_hagiography								
+work_12899	#subject_hagiography								
+work_16096	#subject_hagiography								
+work_16157	#subject_hagiography								
+work_16159	#subject_hagiography								
+work_17087	#subject_hagiography								
+work_16090	#subject_hagiography								
+work_16206	#subject_hagiography								
+work_16208	#subject_hagiography								
+work_16040	#subject_hagiography								
+work_16156	#subject_hagiography								
+work_16268	#subject_hagiography								
+work_16162	#subject_hagiography								
+work_16147	#subject_hagiography								
+work_16104	#subject_hagiography								
+work_16112	#subject_hagiography								
+work_16183	#subject_hagiography								
+work_16135	#subject_hagiography								
+work_12907	#subject_hagiography								
+work_12909	#subject_hagiography								
+work_12837	#subject_hagiography								
+work_12838	#subject_hagiography								
+work_12839	#subject_hagiography								
+work_12840	#subject_hagiography								
+work_12841	#subject_hagiography								
+work_12842	#subject_hagiography								
+work_12843	#subject_hagiography								
+work_12844	#subject_hagiography								
+work_12845	#subject_hagiography								
+work_12848	#subject_hagiography								
+work_12849	#subject_hagiography								
+work_12851	#subject_hagiography								
+work_12852	#subject_hagiography								
+work_12853	#subject_hagiography								
+work_12854	#subject_hagiography								
+work_12855	#subject_hagiography								
+work_12856	#subject_hagiography								
+work_12857	#subject_hagiography								
+work_12911	#subject_literature	#subject_hagiography							
+work_12858	#subject_hagiography								
+work_12859	#subject_hagiography								
+work_12860	#subject_hagiography								
+work_12861	#subject_hagiography								
+work_12862	#subject_hagiography								
+work_12863	#subject_hagiography								
+work_12864	#subject_hagiography								
+work_12865	#subject_hagiography								
+work_12866	#subject_hagiography								
+work_12867	#subject_hagiography								
+work_12868	#subject_hagiography								
+work_12869	#subject_hagiography								
+work_12871	#subject_hagiography								
+work_12870	#subject_hagiography								
+work_12873	#subject_hagiography								
+work_12874	#subject_hagiography								
+work_12875	#subject_hagiography								
+work_12876	#subject_hagiography								
+work_12878	#subject_literature	#subject_hagiography							
+work_12883	#subject_hagiography								
+work_12846	#subject_hagiography								
+work_16338	#subject_hagiography								
+work_12847	#subject_hagiography								
+work_12884	#subject_hagiography								
+work_12885	#subject_hagiography								
+work_12887	#subject_hagiography								
+work_12890	#subject_hagiography								
+work_12891	#subject_hagiography								
+work_12896	#subject_hagiography								
+work_12897	#subject_hagiography								
+work_12892	#subject_hagiography								
+work_12898	#subject_hagiography								
+work_12900	#subject_hagiography								
+work_12902	#subject_hagiography								
+work_16018	#subject_hagiography								
+work_12903	#subject_hagiography								
+work_12904	#subject_hagiography								
+work_12905	#subject_hagiography								
+work_12906	#subject_hagiography								
+work_12908	#subject_hagiography								
+work_16128	#subject_hagiography								
+work_12828	#subject_hagiography								
+work_12912	#subject_hagiography								
+work_12913	#subject_hagiography	#subject_hagiography							
+work_12914	#subject_hagiography								
+work_12915	#subject_hagiography								
+work_12916	#subject_hagiography								
+work_12821	#subject_hagiography	#subject_hagiography	#subject_liturgy						
+work_17088	#subject_hagiography								
+work_3689	#subject_history								
+work_5017	#subject_magic	#subject_hagiography							
+work_5018	#subject_science								
+work_3060	#subject_science								
+work_12918	#subject_grammar	#subject_theology							
+work_7179	#subject_indexes								
+work_12919	#subject_documents								
+work_12983	#subject_sermons								
+work_12993	#subject_indexes								
+work_12920	#subject_documents								
+work_12921	#subject_documents								
+work_12923	#subject_documents								
+work_12924	#subject_bibliography								
+work_12925	#subject_heraldry								
+work_12926	#subject_documents	#subject_clergy							
+work_12927	#subject_documents	#subject_clergy							
+work_12928	#subject_bibliography								
+work_12929	#subject_bible								
+work_12930	#subject_law								
+work_12931	#subject_documents	#subject_clergy							
+work_12932	#subject_documents								
+work_12934	#subject_documents	#subject_monasticism_and_religious_orders							
+work_12935	#subject_documents								
+work_12936	#subject_history								
+work_12937	#subject_law								
+work_12938	#subject_documents	#subject_literature							
+work_12940	#subject_documents								
+work_12942	#subject_documents								
+work_12943	#subject_history								
+work_12944	#subject_monasticism_and_religious_orders								
+work_12945	#subject_documents								
+work_12946	#subject_documents								
+work_12948	#subject_medicine								
+work_12949	#subject_documents								
+work_12950	#subject_documents								
+work_12952	#subject_documents								
+work_12953	#subject_documents								
+work_12954	#subject_documents								
+work_12955	#subject_documents								
+work_12956	#subject_documents								
+work_12957	#subject_christian_literature								
+work_12958	#subject_documents								
+work_12959	#subject_documents								
+work_12960	#subject_documents								
+work_12961	#subject_documents								
+work_12962	#subject_clergy	#subject_history							
+work_12963	#subject_history	#subject_clergy							
+work_12964	#subject_documents								
+work_12965	#subject_documents								
+work_12966	#subject_documents								
+work_12967	#subject_documents								
+work_12968	#subject_documents								
+work_12969	#subject_documents								
+work_12970	#subject_history								
+work_12972	#subject_documents								
+work_12973	#subject_documents								
+work_12974	#subject_documents								
+work_12976	#subject_documents								
+work_12975	#subject_documents								
+work_12977	#subject_documents								
+work_12978	#subject_documents								
+work_12979	#subject_history								
+work_12980	#subject_medicine								
+work_12981	#subject_clergy								
+work_12982	#subject_monasticism_and_religious_orders								
+work_12984	#subject_literature								
+work_12985	#subject_clergy								
+work_17038	#subject_law								
+work_12986	#subject_history								
+work_12987	#subject_history								
+work_12988	#subject_grammar								
+work_12989	#subject_medicine								
+work_12990	#subject_documents								
+work_12922	#subject_history	#subject_clergy							
+work_12951	#subject_philosophy								
+work_12991	#subject_theology								
+work_12992	#subject_documents								
+work_12994	#subject_documents								
+work_12998	#subject_bibliography								
+work_12999	#subject_indexes								
+work_13000	#subject_history								
+work_13002	#subject_documents								
+work_13003	#subject_documents								
+work_13004	#subject_documents								
+work_13005	#subject_documents								
+work_13006	#subject_sermons								
+work_12996	#subject_history	#subject_clergy							
+work_12997	#subject_clergy	#subject_history							
+work_13007	#subject_history								
+work_13008	#subject_liturgy								
+work_13009	#subject_liturgy								
+work_13010	#subject_literature								
+work_13011	#subject_literature								
+work_13012	#subject_literature								
+work_13013	#subject_literature								
+work_13014	#subject_literature								
+work_13015	#subject_literature								
+work_13016	#subject_literature								
+work_13017	#subject_literature								
+work_13018	#subject_literature								
+work_13019	#subject_literature								
+work_13020	#subject_literature								
+work_13021	#subject_literature								
+work_13022	#subject_literature								
+work_13023	#subject_literature	#subject_rhetoric							
+work_13024	#subject_literature								
+work_13025	#subject_documents								
+work_4813	#subject_law								
+work_13027	#subject_liturgy	#subject_theology							
+work_13028	#subject_liturgy								
+work_13029	#subject_liturgy								
+work_13030	#subject_liturgy	#subject_music							
+work_13031	#subject_sermons	#subject_liturgy							
+work_13032	#subject_liturgy								
+work_13034	#subject_liturgy								
+work_13038	#subject_liturgy								
+work_13037	#subject_liturgy								
+work_13036	#subject_liturgy								
+work_13039	#subject_liturgy	#subject_christian_literature	#subject_christian_literature						
+work_13041	#subject_liturgy								
+work_13042	#subject_liturgy								
+work_13044	#subject_hagiography	#subject_hagiography							
+work_13045	#subject_bible								
+work_13046	#subject_history								
+work_13047	#subject_monasticism_and_religious_orders								
+work_13048	#subject_hagiography								
+work_13049	#subject_hagiography								
+work_13051	#subject_hagiography								
+work_13052	#subject_history								
+work_13053	#subject_history	#subject_monasticism_and_religious_orders							
+work_13054	#subject_hagiography								
+work_13056	#subject_hagiography								
+work_14476	#subject_hagiography								
+work_13058	#subject_hagiography								
+work_13059	#subject_hagiography								
+work_13060	#subject_hagiography	#subject_monasticism_and_religious_orders							
+work_13061	#subject_hagiography	#subject_sermons							
+work_13062	#subject_hagiography								
+work_13063	#subject_hagiography								
+work_13064	#subject_hagiography								
+work_13065	#subject_literature	#subject_hagiography							
+work_13066	#subject_hagiography								
+work_13067	#subject_hagiography								
+work_13068	#subject_hagiography								
+work_13069	#subject_hagiography								
+work_13070	#subject_hagiography								
+work_13071	#subject_hagiography								
+work_13073	#subject_hagiography								
+work_13050	#subject_monasticism_and_religious_orders								
+work_13074	#subject_documents								
+work_13075	#subject_theology	#subject_christian_literature							
+work_13076	#subject_heraldry								
+work_2989	#subject_history								
+work_2984	#subject_history								
+work_2986	#subject_history								
+work_2988	#subject_history								
+work_4196	#subject_magic								
+work_4197	#subject_philosophy								
+work_4198	#subject_rhetoric								
+work_4199	#subject_philosophy								
+work_4200	#subject_medicine								
+work_7009	#subject_philosophy								
+work_7011	#subject_philosophy								
+work_4201	#subject_philosophy								
+work_7008	#subject_science								
+work_7007	#subject_philosophy								
+work_7010	#subject_philosophy	#subject_theology							
+work_7006	#subject_philosophy								
+work_4202	#subject_theology								
+work_4476	#subject_philosophy								
+work_4223	#subject_magic								
+work_4203	#subject_philosophy								
+work_4204	#subject_rhetoric								
+work_4222	#subject_theology								
+work_4205	#subject_theology								
+work_4206	#subject_philosophy								
+work_4207	#subject_theology								
+work_4208	#subject_philosophy								
+work_4209	#subject_literature								
+work_4211	#subject_theology								
+work_4477	#subject_theology								
+work_4224	#subject_theology								
+work_4478	#subject_theology								
+work_13077	#subject_documents								
+work_13078	#subject_documents								
+work_13079	#subject_documents								
+work_13080	#subject_documents								
+work_13082	#subject_philosophy	#subject_grammar							
+work_13083	#subject_philosophy	#subject_science							
+work_13085	#subject_philosophy								
+work_13084	#subject_philosophy								
+work_13680	#subject_philosophy								
+work_13086	#subject_theology	#subject_clergy							
+work_583	#subject_rhetoric								
+work_581	#subject_politics_and_government								
+work_582	#subject_literature								
+work_13087	#subject_literature	#subject_music							
+work_3000	#subject_science								
+work_3001	#subject_history								
+work_3002	#subject_sermons								
+work_11	#subject_classical_literature								
+work_19	#subject_classical_literature								
+work_3003	#subject_classical_literature								
+work_3007	#subject_classical_literature								
+work_24	#subject_classical_literature								
+work_55	#subject_literature								
+work_3008	#subject_classical_literature								
+work_80	#subject_classical_literature								
+work_3009	#subject_classical_literature								
+work_97	#subject_classical_literature								
+work_98	#subject_classical_literature								
+work_6377	#subject_classical_literature								
+work_3004	#subject_classical_literature								
+work_3010	#subject_classical_literature								
+work_101	#subject_classical_literature								
+work_125	#subject_classical_literature								
+work_127	#subject_classical_literature								
+work_133	#subject_classical_literature								
+work_3006	#subject_classical_literature								
+work_3005	#subject_geography								
+work_3012	#subject_philosophy	#subject_classical_literature							
+work_3015	#subject_bible								
+work_3016	#subject_theology								
+work_3014	#subject_grammar								
+work_5131	#subject_rhetoric								
+work_3022	#subject_law								
+work_3019	#subject_sermons	#subject_bible							
+work_3020	#subject_sermons								
+work_3023	#subject_theology								
+work_4101	#subject_science								
+work_4099	#subject_medicine								
+work_4100	#subject_science								
+work_4113	#subject_medicine								
+work_4102	#subject_natural_history								
+work_13088	#subject_theology								
+work_13089	#subject_science								
+work_13090	#subject_literature								
+work_3026	#subject_literature								
+work_3027	#subject_classical_literature	#subject_rhetoric							
+work_2729	#subject_literature								
+work_2736	#subject_literature								
+work_2720	#subject_literature								
+work_2721	#subject_literature								
+work_2722	#subject_medicine								
+work_2723	#subject_literature								
+work_2724	#subject_literature								
+work_2725	#subject_hagiography								
+work_2726	#subject_hagiography								
+work_2727	#subject_hagiography								
+work_6145	#subject_literature								
+work_2728	#subject_literature								
+work_6595	#subject_literature								
+work_5611	#subject_literature								
+work_6326	#subject_literature								
+work_2731	#subject_literature								
+work_6327	#subject_literature								
+work_2732	#subject_literature								
+work_2733	#subject_literature								
+work_2734	#subject_history								
+work_2735	#subject_literature								
+work_5019	#subject_law								
+work_13091	#subject_literature								
+work_3028	#subject_rhetoric	#subject_classical_literature							
+work_3029	#subject_rhetoric	#subject_classical_literature							
+work_3030	#subject_rhetoric	#subject_classical_literature							
+work_3031	#subject_rhetoric	#subject_classical_literature							
+work_3032	#subject_rhetoric	#subject_classical_literature							
+work_3033	#subject_philosophy	#subject_classical_literature							
+work_189	#subject_medicine								
+work_191	#subject_medicine								
+work_6256	#subject_history								
+work_4068	#subject_monasticism_and_religious_orders								
+work_4066	#subject_monasticism_and_religious_orders								
+work_13095	#subject_science								
+work_4604	#subject_hagiography								
+work_3038	#subject_philosophy								
+work_6063	#subject_grammar								
+work_3039	#subject_classical_literature								
+work_13096	#subject_music								
+work_5925	#subject_literature								
+work_2298	#subject_literature								
+work_1221	#subject_politics_and_government	#subject_theology							
+work_3460	#subject_monasticism_and_religious_orders								
+work_13097	#subject_magic								
+work_13098	#subject_magic								
+work_13099	#subject_magic								
+work_13100	#subject_law								
+work_13102	#subject_law								
+work_13101	#subject_law								
+work_13103	#subject_law								
+work_13104	#subject_history	#subject_monasticism_and_religious_orders							
+work_4263	#subject_history								
+work_4264	#subject_theology								
+work_4265	#subject_bible								
+work_4266	#subject_science								
+work_3221	#subject_theology								
+work_7197	#subject_science								
+work_3048	#subject_bible								
+work_3049	#subject_bible								
+work_6226	#subject_sermons								
+work_3050	#subject_theology								
+work_2737	#subject_history								
+work_2380	#subject_theology								
+work_2738	#subject_medicine								
+work_1316	#subject_history								
+work_1328	#subject_history								
+work_5647	#subject_literature								
+work_13105	#subject_documents								
+work_13106	#subject_documents								
+work_13107	#subject_documents								
+work_13108	#subject_geography								
+work_2739	#subject_geography								
+work_188	#subject_geography								
+work_2740	#subject_geography								
+work_2741	#subject_geography								
+work_1796	#subject_medicine								
+work_3051	#subject_science	#subject_theology							
+work_7350	#subject_history								
+work_4398	#subject_theology								
+work_6185	#subject_theology								
+work_13110	#subject_liturgy								
+work_13111	#subject_liturgy								
+work_13112	#subject_liturgy								
+work_13114	#subject_theology								
+work_13115	#subject_sermons								
+work_13116	#subject_clergy								
+work_13117	#subject_theology								
+work_13654	#subject_liturgy								
+work_13119	#subject_science								
+work_13120	#subject_theology								
+work_13121	#subject_theology								
+work_13122	#subject_theology								
+work_16339	#subject_law								
+work_13123	#subject_theology								
+work_13113	#subject_liturgy								
+work_13125	#subject_liturgy								
+work_13126	#subject_liturgy								
+work_13127	#subject_law								
+work_6585	#subject_law								
+work_3053	#subject_theology								
+work_3059	#subject_music								
+work_13129	#subject_geography								
+work_13130	#subject_geography								
+work_13128	#subject_geography								
+work_4963	#subject_clergy								
+work_4966	#subject_theology								
+work_4965	#subject_literature								
+work_13131	#subject_science								
+work_13132	#subject_geography								
+work_4069	#subject_natural_history								
+work_3071	#subject_rhetoric								
+work_3072	#subject_natural_history								
+work_3073	#subject_literature								
+work_3075	#subject_history								
+work_3074	#subject_history								
+work_5888	#subject_theology								
+work_2742	#subject_literature								
+work_3077	#subject_liturgy								
+work_3078	#subject_liturgy								
+work_3079	#subject_liturgy								
+work_3153	#subject_liturgy								
+work_3086	#subject_sermons								
+work_3088	#subject_literature								
+work_6065	#subject_history								
+work_3089	#subject_christian_literature								
+work_13135	#subject_documents								
+work_1689	#subject_science								
+work_7368	#subject_theology								
+work_3097	#subject_philosophy								
+work_3093	#subject_philosophy								
+work_3098	#subject_politics_and_government								
+work_3099	#subject_politics_and_government								
+work_3100	#subject_politics_and_government								
+work_1205	#subject_literature								
+work_3101	#subject_literature								
+work_3102	#subject_literature								
+work_3103	#subject_literature								
+work_3104	#subject_classical_literature								
+work_3105	#subject_rhetoric								
+work_3106	#subject_hagiography								
+work_6136	#subject_law								
+work_5746	#subject_science								
+work_3111	#subject_science								
+work_4122	#subject_conduct								
+work_3109	#subject_conduct								
+work_3110	#subject_conduct								
+work_6205	#subject_theology								
+work_2437	#subject_geography								
+work_3113	#subject_philosophy								
+work_6213	#subject_philosophy								
+work_6252	#subject_sermons								
+work_3112	#subject_history								
+work_3115	#subject_history								
+work_3116	#subject_history								
+work_3117	#subject_law								
+work_7364	#subject_sermons								
+work_6248	#subject_sermons								
+work_13136	#subject_liturgy								
+work_13137	#subject_liturgy								
+work_13138	#subject_liturgy								
+work_13139	#subject_liturgy								
+work_13140	#subject_liturgy								
+work_13141	#subject_liturgy	#subject_monasticism_and_religious_orders							
+work_13142	#subject_liturgy								
+work_3035	#subject_history	#subject_documents							
+work_13143	#subject_geography								
+work_13144	#subject_literature								
+work_3174	#subject_science								
+work_3175	#subject_science								
+work_3176	#subject_science								
+work_3177	#subject_science								
+work_3178	#subject_natural_history								
+work_3179	#subject_natural_history								
+work_3180	#subject_science								
+work_3181	#subject_science								
+work_3182	#subject_science								
+work_7040	#subject_rhetoric								
+work_13145	#subject_liturgy								
+work_16064	#subject_liturgy								
+work_13146	#subject_liturgy								
+work_13147	#subject_liturgy								
+work_13148	#subject_history								
+work_13149	#subject_science								
+work_13150	#subject_science	#subject_science							
+work_13151	#subject_science	#subject_science							
+work_13152	#subject_science								
+work_13153	#subject_science								
+work_13154	#subject_science								
+work_13156	#subject_science								
+work_13155	#subject_science								
+work_13157	#subject_literature	#subject_science							
+work_13158	#subject_law								
+work_6267	#subject_literature								
+work_6259	#subject_theology								
+work_6260	#subject_theology								
+work_6262	#subject_theology								
+work_6264	#subject_theology								
+work_6266	#subject_theology								
+work_6261	#subject_theology								
+work_6265	#subject_theology	#subject_clergy							
+work_6263	#subject_theology								
+work_3127	#subject_rhetoric								
+work_3128	#subject_rhetoric	#subject_christian_literature	#subject_liturgy						
+work_3141	#subject_rhetoric								
+work_3135	#subject_bible								
+work_6362	#subject_theology								
+work_3138	#subject_theology								
+work_6341	#subject_liturgy								
+work_3139	#subject_clergy								
+work_6169	#subject_sermons								
+work_3143	#subject_rhetoric								
+work_3140	#subject_rhetoric								
+work_1523	#subject_literature								
+work_13162	#subject_liturgy								
+work_3147	#subject_sermons								
+work_3148	#subject_sermons								
+work_3149	#subject_sermons								
+work_3145	#subject_bible								
+work_195	#subject_medicine								
+work_7020	#subject_christian_literature								
+work_3152	#subject_hagiography								
+work_3150	#subject_bible	#subject_sermons							
+work_3154	#subject_medicine								
+work_3155	#subject_literature								
+work_6083	#subject_theology								
+work_5142	#subject_theology								
+work_3156	#subject_theology								
+work_22	#subject_theology								
+work_23	#subject_theology								
+work_3159	#subject_philosophy								
+work_39	#subject_theology								
+work_40	#subject_theology								
+work_3157	#subject_theology								
+work_62	#subject_theology								
+work_75	#subject_theology								
+work_45	#subject_theology								
+work_5942	#subject_theology								
+work_140	#subject_theology								
+work_141	#subject_theology								
+work_3158	#subject_theology								
+work_162	#subject_theology								
+work_4070	#subject_christian_literature	#subject_classical_literature							
+work_4598	#subject_sermons								
+work_3163	#subject_philosophy								
+work_13163	#subject_literature								
+work_10495	#subject_christian_literature								
+work_3165	#subject_christian_literature								
+work_3164	#subject_christian_literature								
+work_6228	#subject_christian_literature								
+work_13164	#subject_theology								
+work_13165	#subject_medicine								
+work_13167	#subject_science	#subject_medicine							
+work_13168	#subject_science	#subject_medicine							
+work_13169	#subject_medicine	#subject_science							
+work_13170	#subject_science	#subject_medicine							
+work_13171	#subject_science	#subject_medicine							
+work_13172	#subject_science	#subject_medicine							
+work_13173	#subject_medicine	#subject_science							
+work_13174	#subject_medicine	#subject_science							
+work_13175	#subject_medicine	#subject_science							
+work_13176	#subject_medicine								
+work_13178	#subject_medicine								
+work_13179	#subject_medicine								
+work_13177	#subject_medicine								
+work_13180	#subject_medicine								
+work_13181	#subject_medicine								
+work_13182	#subject_medicine	#subject_science							
+work_13183	#subject_medicine								
+work_13184	#subject_medicine								
+work_13185	#subject_medicine	#subject_science							
+work_13186	#subject_medicine	#subject_science							
+work_13187	#subject_medicine	#subject_natural_history							
+work_13190	#subject_medicine								
+work_13191	#subject_medicine								
+work_13192	#subject_medicine								
+work_13193	#subject_medicine								
+work_13194	#subject_medicine								
+work_13195	#subject_medicine								
+work_13196	#subject_medicine								
+work_13197	#subject_medicine								
+work_13198	#subject_literature	#subject_medicine							
+work_13199	#subject_medicine								
+work_13200	#subject_medicine								
+work_13201	#subject_medicine								
+work_13203	#subject_medicine								
+work_13204	#subject_medicine								
+work_13205	#subject_medicine								
+work_13206	#subject_medicine								
+work_13207	#subject_medicine								
+work_13208	#subject_medicine								
+work_13209	#subject_medicine								
+work_13210	#subject_medicine								
+work_13212	#subject_medicine								
+work_13213	#subject_medicine								
+work_13216	#subject_medicine								
+work_13214	#subject_medicine	#subject_history	#subject_magic						
+work_13215	#subject_medicine	#subject_natural_history							
+work_13217	#subject_medicine								
+work_13218	#subject_medicine	#subject_christian_literature	#subject_magic						
+work_13219	#subject_medicine								
+work_13220	#subject_medicine								
+work_13225	#subject_medicine								
+work_13227	#subject_medicine								
+work_13228	#subject_medicine								
+work_13231	#subject_medicine								
+work_13233	#subject_medicine								
+work_13234	#subject_medicine								
+work_13246	#subject_medicine								
+work_13235	#subject_medicine								
+work_13236	#subject_medicine								
+work_13237	#subject_medicine								
+work_13238	#subject_medicine								
+work_13240	#subject_medicine								
+work_13239	#subject_medicine								
+work_13221	#subject_medicine								
+work_13222	#subject_medicine								
+work_13226	#subject_medicine								
+work_13232	#subject_medicine								
+work_13241	#subject_medicine								
+work_13242	#subject_medicine								
+work_13243	#subject_medicine								
+work_13223	#subject_medicine								
+work_13229	#subject_medicine								
+work_13230	#subject_medicine								
+work_13244	#subject_medicine								
+work_13245	#subject_medicine								
+work_13247	#subject_medicine								
+work_13248	#subject_medicine								
+work_13249	#subject_medicine								
+work_13250	#subject_medicine								
+work_13251	#subject_medicine								
+work_13252	#subject_medicine								
+work_13253	#subject_literature	#subject_medicine							
+work_13254	#subject_medicine								
+work_13166	#subject_medicine	#subject_science	#subject_science						
+work_13188	#subject_theology	#subject_medicine	#subject_science						
+work_13189	#subject_science	#subject_medicine							
+work_13256	#subject_medicine								
+work_2997	#subject_christian_literature								
+work_13257	#subject_medicine								
+work_13258	#subject_medicine	#subject_science							
+work_3481	#subject_geography								
+work_17022	#subject_theology								
+work_13259	#subject_christian_literature								
+work_13260	#subject_christian_literature								
+work_13261	#subject_christian_literature								
+work_13262	#subject_christian_literature								
+work_13263	#subject_bible	#subject_christian_literature							
+work_13264	#subject_christian_literature								
+work_13265	#subject_christian_literature								
+work_13266	#subject_christian_literature	#subject_christian_literature	#subject_christian_literature						
+work_13268	#subject_christian_literature								
+work_13269	#subject_christian_literature	#subject_christian_literature							
+work_13270	#subject_grammar								
+work_3752	#subject_geography								
+work_5722	#subject_medicine								
+work_4708	#subject_science								
+work_4071	#subject_bible								
+work_3166	#subject_sermons								
+work_13271	#subject_documents								
+work_13272	#subject_documents								
+work_13273	#subject_theology								
+work_13274	#subject_liturgy								
+work_13275	#subject_liturgy								
+work_13277	#subject_liturgy								
+work_13276	#subject_liturgy								
+work_3168	#subject_classical_literature								
+work_3170	#subject_classical_literature								
+work_3171	#subject_classical_literature								
+work_3172	#subject_theology								
+work_5871	#subject_hagiography								
+work_3173	#subject_bible								
+work_13278	#subject_liturgy								
+work_13284	#subject_liturgy								
+work_13287	#subject_liturgy								
+work_13285	#subject_liturgy								
+work_13289	#subject_liturgy								
+work_13297	#subject_liturgy								
+work_13288	#subject_liturgy								
+work_13286	#subject_liturgy								
+work_13279	#subject_liturgy								
+work_13290	#subject_liturgy								
+work_13298	#subject_liturgy								
+work_13292	#subject_liturgy								
+work_13291	#subject_liturgy								
+work_13280	#subject_liturgy								
+work_13281	#subject_liturgy								
+work_13293	#subject_liturgy								
+work_13294	#subject_liturgy								
+work_13295	#subject_liturgy								
+work_13282	#subject_liturgy								
+work_13296	#subject_liturgy								
+work_13283	#subject_liturgy								
+work_13302	#subject_liturgy								
+work_4555	#subject_politics_and_government								
+work_2045	#subject_science								
+work_2044	#subject_medicine								
+work_208	#subject_literature								
+work_4816	#subject_rhetoric								
+work_5020	#subject_science								
+work_4448	#subject_science								
+work_3183	#subject_medicine								
+work_2500	#subject_medicine								
+work_2501	#subject_medicine								
+work_2225	#subject_medicine								
+work_4072	#subject_history								
+work_4073	#subject_history								
+work_5861	#subject_sermons								
+work_4709	#subject_history	#subject_philosophy							
+work_13305	#subject_grammar	#subject_literature							
+work_13306	#subject_literature	#subject_science							
+work_13304	#subject_literature	#subject_grammar	#subject_history	#subject_philosophy					
+work_3640	#subject_hagiography								
+work_3210	#subject_sermons								
+work_3213	#subject_theology								
+work_3208	#subject_bible								
+work_3209	#subject_liturgy								
+work_3211	#subject_bible								
+work_6125	#subject_science								
+work_6126	#subject_science								
+work_6130	#subject_science								
+work_6129	#subject_science								
+work_6128	#subject_science								
+work_6124	#subject_science								
+work_6127	#subject_science								
+work_3204	#subject_rhetoric								
+work_3205	#subject_hagiography								
+work_3215	#subject_literature								
+work_4479	#subject_literature								
+work_6276	#subject_literature								
+work_2382	#subject_literature	#subject_politics_and_government							
+work_2383	#subject_hagiography	#subject_hagiography							
+work_2347	#subject_literature								
+work_6201	#subject_sermons								
+work_13307	#subject_documents								
+work_13308	#subject_documents								
+work_13310	#subject_science								
+work_13309	#subject_philosophy	#subject_science							
+work_584	#subject_science								
+work_7502	#subject_literature	#subject_conduct							
+work_7078	#subject_bible								
+work_5021	#subject_bible								
+work_13311	#subject_literature								
+work_13314	#subject_documents								
+work_13315	#subject_hagiography								
+work_16097	#subject_hagiography								
+work_13316	#subject_hagiography	#subject_liturgy							
+work_13317	#subject_hagiography								
+work_13318	#subject_hagiography								
+work_13320	#subject_hagiography								
+work_17149	#subject_hagiography								
+work_13319	#subject_hagiography								
+work_13321	#subject_hagiography								
+work_13322	#subject_hagiography								
+work_16172	#subject_hagiography								
+work_16205	#subject_hagiography	#subject_hagiography							
+work_16037	#subject_hagiography	#subject_hagiography							
+work_2842	#subject_medicine								
+work_5612	#subject_medicine								
+work_2743	#subject_hagiography								
+work_2744	#subject_clergy								
+work_2745	#subject_clergy								
+work_13323	#subject_history								
+work_13325	#subject_history								
+work_13327	#subject_hagiography								
+work_13329	#subject_christian_literature								
+work_13331	#subject_theology	#subject_theology	#subject_theology						
+work_13333	#subject_documents								
+work_13336	#subject_literature								
+work_13337	#subject_literature								
+work_13338	#subject_literature	#subject_hagiography							
+work_13342	#subject_liturgy								
+work_3218	#subject_philosophy								
+work_3217	#subject_philosophy								
+work_13344	#subject_liturgy								
+work_13345	#subject_liturgy								
+work_13357	#subject_liturgy								
+work_13346	#subject_liturgy								
+work_13347	#subject_liturgy								
+work_13349	#subject_liturgy								
+work_13350	#subject_liturgy								
+work_13351	#subject_liturgy								
+work_13355	#subject_liturgy								
+work_13356	#subject_liturgy								
+work_16063	#subject_liturgy								
+work_13358	#subject_liturgy								
+work_13352	#subject_liturgy								
+work_13359	#subject_liturgy								
+work_13361	#subject_liturgy								
+work_13362	#subject_liturgy								
+work_13353	#subject_liturgy								
+work_13364	#subject_liturgy								
+work_13365	#subject_liturgy								
+work_13366	#subject_liturgy								
+work_13367	#subject_liturgy								
+work_13368	#subject_liturgy								
+work_13370	#subject_liturgy								
+work_13371	#subject_liturgy								
+work_13372	#subject_liturgy								
+work_13373	#subject_liturgy								
+work_13374	#subject_liturgy								
+work_16260	#subject_liturgy								
+work_13375	#subject_liturgy								
+work_13376	#subject_liturgy								
+work_13377	#subject_liturgy								
+work_13378	#subject_literature	#subject_science							
+work_13379	#subject_literature	#subject_bible							
+work_13380	#subject_law								
+work_13381	#subject_history								
+work_13382	#subject_documents								
+work_13383	#subject_documents								
+work_13384	#subject_documents								
+work_13385	#subject_documents								
+work_13386	#subject_documents								
+work_13387	#subject_documents								
+work_2948	#subject_bible								
+work_13388	#subject_law								
+work_16321	#subject_theology								
+work_13389	#subject_law								
+work_3219	#subject_history								
+work_13390	#subject_liturgy								
+work_13391	#subject_monasticism_and_religious_orders								
+work_13392	#subject_monasticism_and_religious_orders								
+work_1969	#subject_medicine								
+work_3223	#subject_medicine								
+work_13393	#subject_documents								
+work_13394	#subject_documents								
+work_13395	#subject_law	#subject_documents							
+work_4267	#subject_indexes	#subject_history							
+work_13396	#subject_grammar								
+work_10111	#subject_literature								
+work_882	#subject_medicine								
+work_2454	#subject_medicine								
+work_3220	#subject_literature								
+work_495	#subject_literature								
+work_13397	#subject_documents								
+work_13398	#subject_documents								
+work_13399	#subject_documents								
+work_13400	#subject_theology	#subject_christian_literature							
+work_13401	#subject_literature	#subject_christian_literature							
+work_13402	#subject_christian_literature	#subject_literature							
+work_13403	#subject_theology								
+work_13404	#subject_theology								
+work_13405	#subject_theology								
+work_13406	#subject_theology								
+work_13408	#subject_theology								
+work_13409	#subject_theology								
+work_13407	#subject_heraldry	#subject_theology	#subject_christian_literature						
+work_13410	#subject_theology	#subject_science	#subject_christian_literature						
+work_16070	#subject_theology								
+work_4599	#subject_christian_literature								
+work_4817	#subject_christian_literature								
+work_13411	#subject_documents								
+work_13412	#subject_documents								
+work_35	#subject_grammar								
+work_3063	#subject_grammar								
+work_3064	#subject_grammar								
+work_3067	#subject_classical_literature								
+work_3066	#subject_grammar								
+work_13413	#subject_music	#subject_literature							
+work_13414	#subject_music	#subject_liturgy	#subject_literature						
+work_13415	#subject_music	#subject_literature							
+work_1938	#subject_bible								
+work_290	#subject_science								
+work_13416	#subject_science								
+work_13417	#subject_science								
+work_3222	#subject_medicine								
+work_2577	#subject_science								
+work_2578	#subject_science								
+work_2579	#subject_music								
+work_2580	#subject_music								
+work_3224	#subject_grammar								
+work_3225	#subject_medicine								
+work_13418	#subject_music								
+work_13419	#subject_music								
+work_13420	#subject_music								
+work_13421	#subject_music								
+work_325	#subject_literature								
+work_3333	#subject_medicine								
+work_13422	#subject_literature								
+work_13423	#subject_science								
+work_196	#subject_literature								
+work_197	#subject_literature								
+work_198	#subject_literature								
+work_13424	#subject_documents								
+work_13425	#subject_documents								
+work_1782	#subject_bible								
+work_4268	#subject_science								
+work_4269	#subject_medicine								
+work_3122	#subject_theology	#subject_christian_literature	#subject_bible						
+work_13426	#subject_hagiography								
+work_13427	#subject_literature								
+work_16091	#subject_hagiography								
+work_16194	#subject_hagiography								
+work_16107	#subject_hagiography								
+work_16101	#subject_hagiography								
+work_17021	#subject_theology								
+work_13428	#subject_hagiography	#subject_hagiography							
+work_5633	#subject_sermons								
+work_13430	#subject_law								
+work_13431	#subject_hagiography								
+work_13432	#subject_hagiography								
+work_13433	#subject_science	#subject_geography							
+work_7181	#subject_bible								
+work_6243	#subject_theology	#subject_theology							
+work_16067	#subject_bible								
+work_399	#subject_literature								
+work_400	#subject_bible								
+work_401	#subject_bible	#subject_grammar							
+work_402	#subject_grammar								
+work_403	#subject_sermons								
+work_404	#subject_bible								
+work_3226	#subject_theology								
+work_3227	#subject_history								
+work_5723	#subject_bible								
+work_1334	#subject_classical_literature	#subject_history							
+work_3228	#subject_law								
+work_4819	#subject_theology								
+work_4820	#subject_theology								
+work_4818	#subject_theology								
+work_13451	#subject_liturgy								
+work_5729	#subject_hagiography								
+work_3231	#subject_hagiography								
+work_1534	#subject_history								
+work_6137	#subject_sermons								
+work_6138	#subject_law								
+work_13453	#subject_theology	#subject_theology							
+work_3242	#subject_liturgy								
+work_5862	#subject_hagiography								
+work_3245	#subject_hagiography								
+work_6233	#subject_monasticism_and_religious_orders								
+work_3239	#subject_bible								
+work_3241	#subject_philosophy								
+work_6237	#subject_philosophy								
+work_6234	#subject_philosophy								
+work_6236	#subject_philosophy								
+work_3240	#subject_philosophy								
+work_69	#subject_natural_history								
+work_3235	#subject_natural_history								
+work_3238	#subject_philosophy								
+work_3236	#subject_sermons								
+work_3350	#subject_hagiography								
+work_3258	#subject_bible								
+work_3253	#subject_sermons								
+work_3254	#subject_literature								
+work_6225	#subject_grammar								
+work_3252	#subject_literature								
+work_5669	#subject_hagiography								
+work_3264	#subject_law								
+work_3265	#subject_law								
+work_3266	#subject_law	#subject_monasticism_and_religious_orders							
+work_3267	#subject_law								
+work_3306	#subject_philosophy								
+work_3351	#subject_christian_literature								
+work_3310	#subject_medicine	#subject_science							
+work_3309	#subject_science								
+work_3341	#subject_bible								
+work_3312	#subject_bible								
+work_3299	#subject_bible								
+work_3342	#subject_bible								
+work_3343	#subject_bible								
+work_3300	#subject_bible								
+work_3314	#subject_theology								
+work_3301	#subject_theology								
+work_6420	#subject_bible								
+work_3302	#subject_philosophy								
+work_7041	#subject_bible								
+work_3304	#subject_bible								
+work_3316	#subject_bible								
+work_3313	#subject_bible								
+work_3303	#subject_bible								
+work_3345	#subject_theology								
+work_3311	#subject_theology								
+work_7071	#subject_theology								
+work_3232	#subject_christian_literature								
+work_3285	#subject_law								
+work_3324	#subject_indexes								
+work_7082	#subject_bible								
+work_7081	#subject_bible								
+work_7084	#subject_bible								
+work_7083	#subject_bible								
+work_7080	#subject_bible								
+work_3290	#subject_bible								
+work_3340	#subject_bible								
+work_3328	#subject_bible								
+work_3291	#subject_bible								
+work_3292	#subject_bible								
+work_3293	#subject_bible								
+work_3294	#subject_theology								
+work_3263	#subject_sermons								
+work_3305	#subject_theology								
+work_5756	#subject_law								
+work_5126	#subject_literature								
+work_7321	#subject_sermons								
+work_3347	#subject_sermons								
+work_3287	#subject_theology								
+work_3261	#subject_sermons								
+work_3288	#subject_theology								
+work_3307	#subject_theology	#subject_politics_and_government							
+work_3323	#subject_medicine	#subject_science							
+work_3319	#subject_theology								
+work_3320	#subject_hagiography								
+work_3318	#subject_grammar								
+work_7386	#subject_medicine								
+work_3348	#subject_science								
+work_2447	#subject_theology								
+work_6166	#subject_history								
+work_6195	#subject_theology								
+work_6197	#subject_theology								
+work_3346	#subject_theology								
+work_3270	#subject_sermons								
+work_6350	#subject_theology								
+work_5937	#subject_sermons								
+work_5938	#subject_sermons								
+work_5939	#subject_theology								
+work_3355	#subject_monasticism_and_religious_orders								
+work_3353	#subject_theology								
+work_4270	#subject_monasticism_and_religious_orders								
+work_13454	#subject_liturgy								
+work_13455	#subject_documents								
+work_13456	#subject_documents								
+work_13457	#subject_documents								
+work_13458	#subject_law								
+work_3356	#subject_grammar	#subject_classical_literature							
+work_4074	#subject_classical_literature	#subject_theology							
+work_13459	#subject_theology								
+work_13460	#subject_sermons								
+work_2746	#subject_monasticism_and_religious_orders								
+work_4821	#subject_science								
+work_13462	#subject_law								
+work_13482	#subject_theology								
+work_13464	#subject_monasticism_and_religious_orders								
+work_13465	#subject_history								
+work_13466	#subject_history								
+work_13467	#subject_geography								
+work_13469	#subject_history								
+work_13471	#subject_medicine								
+work_13472	#subject_medicine								
+work_13475	#subject_medicine								
+work_13476	#subject_theology								
+work_13480	#subject_science								
+work_13481	#subject_grammar								
+work_13468	#subject_liturgy								
+work_13470	#subject_theology								
+work_13473	#subject_clergy								
+work_13474	#subject_theology								
+work_13477	#subject_bible								
+work_13478	#subject_geography								
+work_13479	#subject_documents								
+work_13484	#subject_hagiography								
+work_13485	#subject_science								
+work_13486	#subject_science								
+work_13487	#subject_history								
+work_13488	#subject_literature								
+work_13489	#subject_literature								
+work_13490	#subject_sermons								
+work_13496	#subject_theology								
+work_13491	#subject_science								
+work_13494	#subject_literature								
+work_13495	#subject_history								
+work_13497	#subject_science	#subject_liturgy							
+work_13498	#subject_sermons								
+work_13499	#subject_sermons								
+work_13502	#subject_natural_history								
+work_13504	#subject_classical_literature								
+work_13505	#subject_philosophy								
+work_13506	#subject_philosophy								
+work_13510	#subject_bible								
+work_13511	#subject_law								
+work_13513	#subject_rhetoric								
+work_13514	#subject_law								
+work_13515	#subject_history								
+work_13516	#subject_history								
+work_13517	#subject_classical_literature								
+work_13519	#subject_geography								
+work_13520	#subject_science	#subject_grammar	#subject_geography	#subject_philosophy	#subject_history	#subject_rhetoric	#subject_philosophy	#subject_science	#subject_music
+work_13521	#subject_music								
+work_13522	#subject_music	#subject_geography							
+work_13523	#subject_science								
+work_13524	#subject_grammar								
+work_13525	#subject_bible								
+work_13527	#subject_history								
+work_13528	#subject_science								
+work_13529	#subject_history								
+work_13531	#subject_classical_literature								
+work_13532	#subject_bible								
+work_16001	#subject_history								
+work_13503	#subject_history								
+work_13507	#subject_bible								
+work_13508	#subject_history								
+work_13518	#subject_law								
+work_13526	#subject_bible								
+work_13530	#subject_theology								
+work_13533	#subject_classical_literature								
+work_13534	#subject_medicine								
+work_13535	#subject_geography								
+work_13536	#subject_history								
+work_13537	#subject_history								
+work_13501	#subject_monasticism_and_religious_orders								
+work_13538	#subject_documents								
+work_13539	#subject_documents								
+work_13540	#subject_documents								
+work_13541	#subject_documents								
+work_13542	#subject_documents								
+work_13543	#subject_history	#subject_geography	#subject_documents						
+work_16057	#subject_geography								
+work_16061	#subject_geography								
+work_16062	#subject_geography								
+work_3357	#subject_history								
+work_10467	#subject_hagiography								
+work_16341	#subject_law								
+work_13544	#subject_law								
+work_13545	#subject_law								
+work_13546	#subject_literature								
+work_13547	#subject_law								
+work_13548	#subject_literature								
+work_3230	#subject_history								
+work_13552	#subject_theology								
+work_13553	#subject_liturgy								
+work_13554	#subject_documents								
+work_13555	#subject_monasticism_and_religious_orders								
+work_13558	#subject_literature								
+work_3358	#subject_sermons								
+work_3359	#subject_hagiography								
+work_3360	#subject_hagiography								
+work_4975	#subject_science								
+work_3361	#subject_bible								
+work_5833	#subject_bible								
+work_3364	#subject_literature								
+work_3362	#subject_literature								
+work_3365	#subject_sermons								
+work_6358	#subject_hagiography								
+work_3363	#subject_liturgy	#subject_theology							
+work_3366	#subject_theology								
+work_3367	#subject_sermons								
+work_3368	#subject_bible								
+work_6421	#subject_christian_literature								
+work_3369	#subject_sermons								
+work_3370	#subject_geography								
+work_13560	#subject_documents								
+work_16041	#subject_liturgy								
+work_13561	#subject_liturgy								
+work_13562	#subject_liturgy								
+work_13563	#subject_liturgy								
+work_13564	#subject_liturgy								
+work_13565	#subject_liturgy								
+work_13567	#subject_liturgy								
+work_13568	#subject_liturgy								
+work_13569	#subject_liturgy								
+work_13570	#subject_liturgy	#subject_monasticism_and_religious_orders							
+work_13571	#subject_liturgy	#subject_theology							
+work_13572	#subject_liturgy								
+work_13577	#subject_liturgy	#subject_theology							
+work_16354	#subject_liturgy								
+work_13578	#subject_liturgy								
+work_13579	#subject_liturgy								
+work_13580	#subject_liturgy								
+work_13581	#subject_liturgy								
+work_13582	#subject_liturgy	#subject_music							
+work_13583	#subject_liturgy								
+work_13574	#subject_liturgy								
+work_13575	#subject_liturgy								
+work_13576	#subject_liturgy								
+work_13584	#subject_liturgy								
+work_13585	#subject_liturgy	#subject_christian_literature							
+work_13586	#subject_liturgy								
+work_13587	#subject_liturgy								
+work_13588	#subject_liturgy	#subject_christian_literature							
+work_13589	#subject_liturgy	#subject_christian_literature							
+work_13590	#subject_liturgy	#subject_christian_literature							
+work_13591	#subject_liturgy	#subject_christian_literature							
+work_13592	#subject_liturgy								
+work_13593	#subject_liturgy								
+work_13595	#subject_liturgy								
+work_13596	#subject_liturgy								
+work_13597	#subject_liturgy								
+work_13598	#subject_liturgy	#subject_christian_literature	#subject_christian_literature						
+work_13599	#subject_documents								
+work_13600	#subject_documents								
+work_13601	#subject_documents								
+work_13602	#subject_documents								
+work_13603	#subject_liturgy	#subject_hagiography							
+work_13604	#subject_liturgy								
+work_7366	#subject_theology								
+work_3372	#subject_sermons								
+work_3371	#subject_bible								
+work_13614	#subject_history	#subject_bible							
+work_13615	#subject_history								
+work_13616	#subject_liturgy								
+work_2109	#subject_law	#subject_clergy							
+work_3374	#subject_history								
+work_3590	#subject_sermons								
+work_14969	#subject_law								
+work_3024	#subject_monasticism_and_religious_orders								
+work_3377	#subject_bible								
+work_3376	#subject_philosophy								
+work_13623	#subject_history								
+work_16017	#subject_hagiography								
+work_16132	#subject_hagiography								
+work_16103	#subject_philosophy								
+work_3381	#subject_classical_literature	#subject_politics_and_government							
+work_3382	#subject_classical_literature	#subject_politics_and_government							
+work_13624	#subject_science	#subject_history							
+work_13625	#subject_christian_literature								
+work_13626	#subject_law								
+work_3383	#subject_classical_literature								
+work_3384	#subject_classical_literature								
+work_14640	#subject_history								
+work_13627	#subject_history								
+work_13628	#subject_rhetoric								
+work_13629	#subject_christian_literature								
+work_13630	#subject_rhetoric								
+work_13631	#subject_rhetoric								
+work_13632	#subject_rhetoric								
+work_13633	#subject_rhetoric								
+work_13634	#subject_documents								
+work_13635	#subject_documents								
+work_13636	#subject_liturgy	#subject_monasticism_and_religious_orders							
+work_13637	#subject_documents								
+work_13638	#subject_documents								
+work_13639	#subject_documents								
+work_13640	#subject_liturgy								
+work_13641	#subject_theology								
+work_13642	#subject_liturgy								
+work_13643	#subject_liturgy								
+work_13645	#subject_liturgy	#subject_monasticism_and_religious_orders							
+work_13644	#subject_liturgy								
+work_13646	#subject_documents								
+work_13647	#subject_documents								
+work_13648	#subject_documents								
+work_13649	#subject_liturgy								
+work_13650	#subject_liturgy								
+work_13651	#subject_liturgy								
+work_13652	#subject_liturgy								
+work_13659	#subject_liturgy								
+work_13655	#subject_liturgy								
+work_13653	#subject_liturgy								
+work_13656	#subject_liturgy								
+work_13657	#subject_liturgy								
+work_13658	#subject_liturgy								
+work_13660	#subject_documents								
+work_13661	#subject_documents								
+work_13662	#subject_documents								
+work_13663	#subject_documents								
+work_13664	#subject_documents								
+work_13665	#subject_documents								
+work_13668	#subject_monasticism_and_religious_orders								
+work_13667	#subject_monasticism_and_religious_orders								
+work_13670	#subject_clergy								
+work_13666	#subject_clergy								
+work_13669	#subject_documents								
+work_13671	#subject_documents	#subject_law							
+work_13674	#subject_liturgy	#subject_monasticism_and_religious_orders							
+work_13675	#subject_liturgy								
+work_13676	#subject_liturgy								
+work_13677	#subject_documents								
+work_3271	#subject_natural_history								
+work_3272	#subject_natural_history								
+work_3273	#subject_natural_history								
+work_3387	#subject_bible								
+work_3388	#subject_theology								
+work_3389	#subject_theology								
+work_3400	#subject_sermons								
+work_3391	#subject_sermons								
+work_5750	#subject_bible								
+work_3392	#subject_sermons								
+work_3393	#subject_sermons								
+work_3394	#subject_sermons								
+work_3395	#subject_sermons								
+work_5749	#subject_bible								
+work_3396	#subject_sermons								
+work_7092	#subject_sermons								
+work_3397	#subject_sermons								
+work_3398	#subject_sermons								
+work_3399	#subject_sermons								
+work_3390	#subject_sermons								
+work_3401	#subject_theology								
+work_3402	#subject_theology								
+work_4075	#subject_sermons								
+work_7093	#subject_sermons								
+work_4076	#subject_theology								
+work_13678	#subject_history								
+work_3403	#subject_sermons								
+work_3404	#subject_history								
+work_3405	#subject_history								
+work_199	#subject_classical_literature								
+work_13679	#subject_grammar								
+work_7398	#subject_medicine								
+work_3406	#subject_medicine								
+work_2747	#subject_bible								
+work_3409	#subject_grammar								
+work_3407	#subject_hagiography								
+work_3408	#subject_hagiography								
+work_3410	#subject_hagiography								
+work_7512	#subject_literature	#subject_grammar							
+work_6431	#subject_politics_and_government								
+work_3411	#subject_law	#subject_clergy							
+work_3412	#subject_theology								
+work_3413	#subject_grammar								
+work_3415	#subject_classical_literature								
+work_3416	#subject_classical_literature								
+work_3417	#subject_classical_literature								
+work_3418	#subject_classical_literature								
+work_3419	#subject_classical_literature								
+work_3420	#subject_classical_literature								
+work_3421	#subject_classical_literature								
+work_3422	#subject_classical_literature								
+work_3423	#subject_classical_literature								
+work_3424	#subject_classical_literature								
+work_3425	#subject_classical_literature								
+work_3426	#subject_classical_literature								
+work_3427	#subject_classical_literature								
+work_3428	#subject_classical_literature								
+work_4077	#subject_classical_literature								
+work_4078	#subject_classical_literature								
+work_4079	#subject_classical_literature								
+work_4080	#subject_classical_literature								
+work_4081	#subject_classical_literature								
+work_13681	#subject_literature								
+work_6232	#subject_bible								
+work_3472	#subject_theology								
+work_1705	#subject_philosophy								
+work_2748	#subject_history								
+work_3229	#subject_hagiography								
+work_3437	#subject_history								
+work_3436	#subject_history								
+work_3434	#subject_classical_literature								
+work_3435	#subject_classical_literature								
+work_1539	#subject_literature								
+work_3136	#subject_history								
+work_3438	#subject_theology								
+work_13682	#subject_literature								
+work_3439	#subject_literature								
+work_3757	#subject_literature								
+work_3018	#subject_medicine								
+work_5853	#subject_sermons								
+work_6449	#subject_hagiography								
+work_2162	#subject_christian_literature								
+work_3475	#subject_philosophy								
+work_3451	#subject_philosophy								
+work_3452	#subject_philosophy								
+work_3477	#subject_philosophy								
+work_3453	#subject_philosophy								
+work_3471	#subject_natural_history								
+work_3454	#subject_theology								
+work_13683	#subject_documents								
+work_13684	#subject_documents								
+work_13685	#subject_clergy								
+work_13686	#subject_documents	#subject_clergy							
+work_13687	#subject_clergy	#subject_documents							
+work_13688	#subject_law	#subject_clergy							
+work_13689	#subject_law	#subject_clergy							
+work_13690	#subject_documents	#subject_clergy							
+work_13691	#subject_documents								
+work_13692	#subject_clergy	#subject_documents							
+work_13693	#subject_documents								
+work_13694	#subject_documents								
+work_13695	#subject_documents								
+work_13696	#subject_documents								
+work_3442	#subject_hagiography								
+work_3443	#subject_hagiography								
+work_3444	#subject_grammar								
+work_3445	#subject_science								
+work_13697	#subject_theology								
+work_13698	#subject_theology								
+work_13699	#subject_literature								
+work_13700	#subject_liturgy								
+work_13702	#subject_sermons								
+work_16098	#subject_bible								
+work_13703	#subject_documents								
+work_13704	#subject_liturgy								
+work_13705	#subject_philosophy								
+work_1078	#subject_theology	#subject_liturgy							
+work_6134	#subject_history								
+work_4399	#subject_hagiography								
+work_1930	#subject_science								
+work_13707	#subject_literature								
+work_13708	#subject_liturgy								
+work_3446	#subject_science								
+work_3447	#subject_theology								
+work_3448	#subject_theology								
+work_16238	#subject_hagiography								
+work_16163	#subject_hagiography								
+work_16179	#subject_hagiography								
+work_16160	#subject_hagiography								
+work_16169	#subject_hagiography								
+work_16164	#subject_hagiography								
+work_16176	#subject_hagiography								
+work_16105	#subject_hagiography								
+work_16181	#subject_hagiography								
+work_16113	#subject_hagiography								
+work_16106	#subject_hagiography								
+work_16155	#subject_hagiography								
+work_16190	#subject_hagiography								
+work_16168	#subject_hagiography								
+work_16114	#subject_hagiography								
+work_16165	#subject_hagiography								
+work_16140	#subject_hagiography								
+work_16116	#subject_hagiography								
+work_16119	#subject_hagiography								
+work_16131	#subject_hagiography								
+work_16021	#subject_hagiography								
+work_16170	#subject_hagiography								
+work_16146	#subject_hagiography								
+work_16171	#subject_hagiography								
+work_16122	#subject_hagiography								
+work_16143	#subject_hagiography								
+work_16138	#subject_hagiography								
+work_16115	#subject_hagiography								
+work_16189	#subject_hagiography								
+work_16145	#subject_hagiography								
+work_16141	#subject_hagiography								
+work_16110	#subject_hagiography								
+work_16109	#subject_hagiography								
+work_16120	#subject_hagiography								
+work_16187	#subject_hagiography								
+work_16192	#subject_hagiography								
+work_16185	#subject_hagiography								
+work_16127	#subject_hagiography								
+work_16108	#subject_hagiography								
+work_16130	#subject_hagiography								
+work_16111	#subject_hagiography								
+work_16020	#subject_hagiography								
+work_16117	#subject_hagiography								
+work_16118	#subject_hagiography								
+work_16139	#subject_hagiography								
+work_16193	#subject_hagiography								
+work_16177	#subject_hagiography								
+work_13709	#subject_hagiography								
+work_16237	#subject_hagiography								
+work_16233	#subject_hagiography								
+work_16239	#subject_hagiography								
+work_16236	#subject_hagiography								
+work_16235	#subject_hagiography								
+work_13710	#subject_hagiography								
+work_13711	#subject_bible								
+work_13712	#subject_hagiography								
+work_16265	#subject_hagiography								
+work_13713	#subject_hagiography								
+work_16089	#subject_hagiography								
+work_16209	#subject_hagiography								
+work_16086	#subject_hagiography								
+work_16087	#subject_hagiography								
+work_13714	#subject_hagiography								
+work_13715	#subject_hagiography								
+work_12910	#subject_hagiography								
+work_13716	#subject_hagiography								
+work_16100	#subject_hagiography								
+work_16267	#subject_hagiography								
+work_13717	#subject_liturgy								
+work_13719	#subject_documents								
+work_16291	#subject_theology								
+work_15323	#subject_theology								
+work_3449	#subject_bible								
+work_3450	#subject_theology								
+work_13721	#subject_literature	#subject_theology							
+work_13722	#subject_theology	#subject_literature							
+work_13723	#subject_literature	#subject_theology							
+work_13724	#subject_theology								
+work_13725	#subject_literature	#subject_theology							
+work_13726	#subject_theology	#subject_literature							
+work_13728	#subject_theology	#subject_literature							
+work_13729	#subject_theology	#subject_literature							
+work_13730	#subject_literature	#subject_theology							
+work_13731	#subject_literature	#subject_theology							
+work_13732	#subject_hagiography								
+work_13733	#subject_theology	#subject_literature							
+work_13734	#subject_theology	#subject_sermons							
+work_13735	#subject_literature	#subject_theology							
+work_13736	#subject_literature	#subject_theology							
+work_13737	#subject_theology	#subject_sermons							
+work_13740	#subject_theology								
+work_13738	#subject_theology								
+work_13739	#subject_theology	#subject_theology							
+work_13741	#subject_literature	#subject_theology							
+work_13742	#subject_theology								
+work_13727	#subject_literature	#subject_theology							
+work_1558	#subject_grammar	#subject_rhetoric							
+work_4083	#subject_sermons								
+work_5881	#subject_hagiography								
+work_3755	#subject_law								
+work_3462	#subject_grammar	#subject_history							
+work_3455	#subject_history								
+work_3456	#subject_history								
+work_3463	#subject_sermons								
+work_3457	#subject_hagiography								
+work_3459	#subject_theology	#subject_christian_literature	#subject_politics_and_government						
+work_3474	#subject_law								
+work_3464	#subject_theology								
+work_6364	#subject_theology								
+work_13755	#subject_documents								
+work_13756	#subject_documents								
+work_13757	#subject_documents								
+work_13758	#subject_documents								
+work_16348	#subject_theology								
+work_423	#subject_christian_literature								
+work_7140	#subject_christian_literature								
+work_2749	#subject_sermons								
+work_2750	#subject_bible								
+work_2751	#subject_law								
+work_2755	#subject_law								
+work_7396	#subject_law								
+work_2752	#subject_liturgy								
+work_2753	#subject_science								
+work_2754	#subject_christian_literature								
+work_7024	#subject_theology								
+work_4059	#subject_theology								
+work_4232	#subject_theology								
+work_4233	#subject_theology								
+work_2502	#subject_science	#subject_classical_literature							
+work_6123	#subject_classical_literature								
+work_2503	#subject_classical_literature								
+work_2504	#subject_science								
+work_2506	#subject_science								
+work_13759	#subject_history								
+work_13760	#subject_history								
+work_13762	#subject_history	#subject_monasticism_and_religious_orders							
+work_13761	#subject_history								
+work_1092	#subject_philosophy								
+work_1094	#subject_philosophy								
+work_1090	#subject_philosophy								
+work_1093	#subject_science								
+work_1089	#subject_science								
+work_3482	#subject_theology	#subject_christian_literature							
+work_5760	#subject_bible								
+work_3483	#subject_theology								
+work_7355	#subject_theology								
+work_3484	#subject_theology								
+work_13764	#subject_theology								
+work_13765	#subject_theology								
+work_16218	#subject_law								
+work_13767	#subject_theology								
+work_13770	#subject_theology								
+work_13772	#subject_liturgy								
+work_13773	#subject_liturgy								
+work_13775	#subject_theology								
+work_3513	#subject_science								
+work_3485	#subject_sermons								
+work_3465	#subject_philosophy								
+work_3466	#subject_philosophy								
+work_3467	#subject_philosophy								
+work_3468	#subject_philosophy								
+work_3469	#subject_philosophy								
+work_13776	#subject_liturgy								
+work_522	#subject_law								
+work_523	#subject_law								
+work_3680	#subject_classical_literature								
+work_13777	#subject_literature								
+work_3488	#subject_classical_literature								
+work_3489	#subject_classical_literature								
+work_3497	#subject_monasticism_and_religious_orders	#subject_theology							
+work_3498	#subject_monasticism_and_religious_orders								
+work_5603	#subject_theology								
+work_3499	#subject_monasticism_and_religious_orders								
+work_3500	#subject_theology								
+work_3501	#subject_sermons								
+work_3502	#subject_hagiography								
+work_3503	#subject_hagiography								
+work_3505	#subject_theology								
+work_3506	#subject_bible								
+work_3508	#subject_bible								
+work_3509	#subject_bible								
+work_3507	#subject_bible								
+work_3510	#subject_theology								
+work_3511	#subject_sermons								
+work_3529	#subject_law								
+work_4084	#subject_christian_literature								
+work_4085	#subject_christian_literature								
+work_3616	#subject_theology								
+work_7303	#subject_philosophy								
+work_3591	#subject_bible	#subject_theology							
+work_3534	#subject_theology								
+work_3544	#subject_hagiography	#subject_monasticism_and_religious_orders							
+work_6031	#subject_hagiography								
+work_3580	#subject_sermons								
+work_7218	#subject_philosophy								
+work_7225	#subject_philosophy								
+work_7226	#subject_philosophy								
+work_7224	#subject_philosophy								
+work_7233	#subject_philosophy								
+work_7222	#subject_philosophy								
+work_7221	#subject_philosophy								
+work_7216	#subject_philosophy								
+work_7223	#subject_philosophy								
+work_7234	#subject_philosophy								
+work_7286	#subject_philosophy								
+work_3519	#subject_bible								
+work_3520	#subject_christian_literature								
+work_3521	#subject_hagiography								
+work_3522	#subject_geography								
+work_3523	#subject_christian_literature								
+work_3530	#subject_christian_literature								
+work_7034	#subject_christian_literature								
+work_3525	#subject_christian_literature								
+work_3526	#subject_christian_literature								
+work_3527	#subject_hagiography								
+work_7109	#subject_theology								
+work_3532	#subject_history								
+work_7414	#subject_grammar								
+work_3535	#subject_bible								
+work_3536	#subject_bible								
+work_3537	#subject_bible								
+work_3539	#subject_theology								
+work_3540	#subject_sermons								
+work_3545	#subject_theology								
+work_13778	#subject_documents								
+work_13779	#subject_documents								
+work_13780	#subject_documents								
+work_13781	#subject_documents								
+work_13782	#subject_documents								
+work_13783	#subject_documents								
+work_13784	#subject_documents								
+work_13785	#subject_documents								
+work_13786	#subject_documents								
+work_13787	#subject_documents								
+work_13788	#subject_documents								
+work_13789	#subject_documents								
+work_13790	#subject_documents								
+work_13791	#subject_documents								
+work_13792	#subject_documents	#subject_monasticism_and_religious_orders							
+work_13793	#subject_documents								
+work_13794	#subject_documents								
+work_13795	#subject_documents								
+work_13796	#subject_documents								
+work_13797	#subject_documents								
+work_13798	#subject_documents								
+work_13799	#subject_documents								
+work_13800	#subject_documents								
+work_13803	#subject_documents								
+work_13804	#subject_documents								
+work_13807	#subject_documents								
+work_13808	#subject_documents								
+work_13801	#subject_documents								
+work_13805	#subject_documents								
+work_13806	#subject_documents								
+work_13809	#subject_documents								
+work_13810	#subject_documents								
+work_3552	#subject_literature								
+work_3553	#subject_literature								
+work_3554	#subject_literature								
+work_3555	#subject_literature								
+work_3556	#subject_literature	#subject_history							
+work_3557	#subject_monasticism_and_religious_orders	#subject_literature	#subject_philosophy						
+work_3558	#subject_literature								
+work_3559	#subject_literature								
+work_3560	#subject_literature								
+work_3561	#subject_literature								
+work_7347	#subject_literature								
+work_3562	#subject_literature								
+work_3563	#subject_literature								
+work_3564	#subject_literature								
+work_7415	#subject_literature								
+work_3566	#subject_christian_literature								
+work_3567	#subject_christian_literature								
+work_3568	#subject_literature								
+work_3569	#subject_literature	#subject_history							
+work_3570	#subject_literature								
+work_17502	#subject_medicine								
+work_1578	#subject_law								
+work_3571	#subject_theology								
+work_5903	#subject_natural_history								
+work_3613	#subject_grammar								
+work_3614	#subject_science								
+work_3622	#subject_grammar								
+work_3630	#subject_theology								
+work_3623	#subject_science								
+work_7301	#subject_rhetoric								
+work_3585	#subject_philosophy								
+work_3586	#subject_philosophy								
+work_3584	#subject_medicine								
+work_3587	#subject_medicine								
+work_3589	#subject_medicine								
+work_6257	#subject_theology								
+work_3607	#subject_philosophy								
+work_6317	#subject_medicine								
+work_3598	#subject_medicine								
+work_3603	#subject_theology								
+work_3546	#subject_bible								
+work_3547	#subject_bible								
+work_3548	#subject_bible								
+work_3549	#subject_theology								
+work_3551	#subject_theology								
+work_3492	#subject_bible								
+work_3493	#subject_bible								
+work_3491	#subject_bible								
+work_3494	#subject_bible								
+work_3495	#subject_theology	#subject_history	#subject_bible						
+work_3496	#subject_sermons								
+work_3606	#subject_philosophy								
+work_3517	#subject_science								
+work_3518	#subject_medicine								
+work_3604	#subject_science								
+work_3605	#subject_medicine								
+work_3618	#subject_science								
+work_3619	#subject_science								
+work_3620	#subject_indexes	#subject_science							
+work_3681	#subject_geography								
+work_3621	#subject_bible								
+work_3624	#subject_theology								
+work_3600	#subject_theology	#subject_law							
+work_3601	#subject_sermons								
+work_3626	#subject_science								
+work_3531	#subject_history								
+work_3602	#subject_christian_literature	#subject_bible							
+work_6589	#subject_literature								
+work_3334	#subject_literature								
+work_4086	#subject_literature								
+work_4087	#subject_literature								
+work_3632	#subject_philosophy								
+work_4736	#subject_sermons								
+work_3633	#subject_medicine								
+work_3637	#subject_hagiography								
+work_7149	#subject_philosophy								
+work_3638	#subject_hagiography								
+work_7188	#subject_natural_history								
+work_3639	#subject_sermons								
+work_3646	#subject_sermons								
+work_3643	#subject_bible								
+work_3647	#subject_philosophy								
+work_3648	#subject_theology								
+work_3650	#subject_philosophy								
+work_3651	#subject_bible	#subject_theology							
+work_3649	#subject_bible								
+work_3653	#subject_science								
+work_2012	#subject_philosophy								
+work_2509	#subject_philosophy								
+work_2510	#subject_science								
+work_2511	#subject_theology								
+work_2512	#subject_science								
+work_2757	#subject_grammar								
+work_2442	#subject_philosophy								
+work_164	#subject_theology								
+work_2212	#subject_grammar								
+work_5151	#subject_grammar								
+work_2213	#subject_grammar								
+work_16028	#subject_medicine	#subject_philosophy							
+work_13811	#subject_philosophy	#subject_science							
+work_13812	#subject_philosophy	#subject_theology							
+work_13813	#subject_philosophy								
+work_13815	#subject_philosophy								
+work_13817	#subject_philosophy								
+work_13816	#subject_philosophy								
+work_13818	#subject_philosophy								
+work_13814	#subject_philosophy	#subject_philosophy	#subject_rhetoric	#subject_history					
+work_3655	#subject_classical_literature								
+work_3654	#subject_classical_literature								
+work_5637	#subject_hagiography	#subject_sermons							
+work_13819	#subject_philosophy								
+work_3662	#subject_grammar								
+work_4090	#subject_literature								
+work_3664	#subject_classical_literature								
+work_3666	#subject_law								
+work_3663	#subject_theology								
+work_16204	#subject_science	#subject_natural_history							
+work_13820	#subject_science	#subject_natural_history							
+work_13821	#subject_natural_history								
+work_13822	#subject_bible								
+work_13823	#subject_history								
+work_3629	#subject_rhetoric								
+work_4877	#subject_literature								
+work_3533	#subject_theology	#subject_science	#subject_theology	#subject_clergy	#subject_theology				
+work_3599	#subject_science								
+work_13824	#subject_literature								
+work_3682	#subject_theology								
+work_3684	#subject_classical_literature								
+work_6374	#subject_classical_literature								
+work_6375	#subject_classical_literature								
+work_3685	#subject_classical_literature								
+work_3686	#subject_classical_literature								
+work_3687	#subject_classical_literature								
+work_6047	#subject_christian_literature								
+work_3690	#subject_documents								
+work_272	#subject_theology								
+work_271	#subject_theology								
+work_3691	#subject_theology								
+work_3692	#subject_theology								
+work_270	#subject_theology								
+work_16008	#subject_law								
+work_4522	#subject_medicine								
+work_13828	#subject_medicine								
+work_13829	#subject_hagiography								
+work_3160	#subject_science								
+work_3161	#subject_grammar								
+work_5940	#subject_theology								
+work_3162	#subject_hagiography								
+work_1570	#subject_theology								
+work_1571	#subject_law								
+work_1572	#subject_theology								
+work_2513	#subject_medicine								
+work_3131	#subject_medicine								
+work_3132	#subject_medicine								
+work_3133	#subject_medicine								
+work_6381	#subject_philosophy								
+work_4091	#subject_philosophy								
+work_6445	#subject_philosophy								
+work_3693	#subject_philosophy								
+work_6446	#subject_philosophy								
+work_3694	#subject_philosophy								
+work_3695	#subject_philosophy								
+work_3696	#subject_philosophy								
+work_3697	#subject_philosophy								
+work_3698	#subject_philosophy								
+work_3699	#subject_philosophy								
+work_7318	#subject_philosophy	#subject_politics_and_government							
+work_3700	#subject_philosophy								
+work_2514	#subject_history								
+work_3701	#subject_classical_literature								
+work_17145	#subject_law								
+work_6320	#subject_magic								
+work_3702	#subject_natural_history								
+work_3703	#subject_classical_literature								
+work_3704	#subject_philosophy	#subject_classical_literature							
+work_5687	#subject_sermons								
+work_2871	#subject_politics_and_government	#subject_clergy	#subject_theology						
+work_3709	#subject_classical_literature								
+work_4092	#subject_classical_literature								
+work_6414	#subject_classical_literature								
+work_3710	#subject_music								
+work_6411	#subject_classical_literature								
+work_3705	#subject_classical_literature								
+work_3706	#subject_classical_literature								
+work_3707	#subject_classical_literature								
+work_3708	#subject_classical_literature								
+work_6412	#subject_classical_literature								
+work_6413	#subject_classical_literature								
+work_3713	#subject_classical_literature								
+work_3714	#subject_classical_literature								
+work_3715	#subject_classical_literature								
+work_3712	#subject_classical_literature								
+work_3724	#subject_classical_literature								
+work_3717	#subject_classical_literature								
+work_3725	#subject_classical_literature								
+work_3718	#subject_classical_literature								
+work_3721	#subject_classical_literature								
+work_3719	#subject_classical_literature								
+work_3720	#subject_classical_literature								
+work_3722	#subject_classical_literature								
+work_6415	#subject_classical_literature								
+work_3723	#subject_sermons								
+work_13830	#subject_literature								
+work_13831	#subject_literature								
+work_13832	#subject_literature								
+work_13836	#subject_literature	#subject_music							
+work_13837	#subject_literature	#subject_literature	#subject_clergy						
+work_13838	#subject_literature	#subject_clergy							
+work_13839	#subject_literature								
+work_13840	#subject_literature	#subject_hagiography							
+work_13841	#subject_literature								
+work_13842	#subject_literature								
+work_17026	#subject_literature								
+work_13843	#subject_literature	#subject_medicine							
+work_13848	#subject_literature	#subject_history							
+work_13852	#subject_history								
+work_13853	#subject_literature	#subject_theology							
+work_13854	#subject_literature	#subject_music							
+work_13855	#subject_literature	#subject_bible	#subject_hagiography						
+work_13858	#subject_literature	#subject_theology							
+work_13859	#subject_literature	#subject_clergy							
+work_13860	#subject_literature	#subject_history							
+work_13862	#subject_literature	#subject_sermons							
+work_13864	#subject_literature	#subject_hagiography							
+work_13865	#subject_literature	#subject_science							
+work_13844	#subject_literature	#subject_history							
+work_13845	#subject_literature	#subject_christian_literature							
+work_13846	#subject_literature	#subject_history	#subject_literature						
+work_13847	#subject_literature	#subject_hagiography							
+work_13849	#subject_literature	#subject_medicine							
+work_13850	#subject_literature	#subject_christian_literature							
+work_13851	#subject_literature	#subject_history							
+work_13856	#subject_literature	#subject_christian_literature							
+work_13857	#subject_literature	#subject_hagiography	#subject_christian_literature						
+work_13861	#subject_liturgy	#subject_theology	#subject_clergy	#subject_christian_literature					
+work_13863	#subject_literature	#subject_theology							
+work_13866	#subject_literature								
+work_13867	#subject_literature								
+work_13868	#subject_history	#subject_literature							
+work_13870	#subject_literature	#subject_science							
+work_13869	#subject_theology	#subject_literature							
+work_13871	#subject_literature	#subject_music							
+work_13872	#subject_literature	#subject_theology							
+work_13873	#subject_literature								
+work_13874	#subject_literature								
+work_13875	#subject_literature								
+work_13876	#subject_literature								
+work_13877	#subject_literature								
+work_13878	#subject_literature								
+work_13879	#subject_literature								
+work_13880	#subject_literature								
+work_13881	#subject_literature								
+work_13882	#subject_literature								
+work_13883	#subject_literature								
+work_13884	#subject_literature								
+work_13886	#subject_literature								
+work_13887	#subject_literature								
+work_13888	#subject_literature	#subject_christian_literature							
+work_13889	#subject_history								
+work_13890	#subject_literature	#subject_literature	#subject_christian_literature	#subject_history					
+work_13891	#subject_literature								
+work_13892	#subject_literature	#subject_hagiography							
+work_17091	#subject_literature	#subject_hagiography							
+work_13895	#subject_literature	#subject_christian_literature							
+work_13896	#subject_literature								
+work_13897	#subject_literature								
+work_13898	#subject_literature	#subject_history							
+work_13899	#subject_literature								
+work_13900	#subject_literature								
+work_13901	#subject_literature	#subject_music							
+work_13902	#subject_literature								
+work_13893	#subject_literature	#subject_liturgy	#subject_christian_literature						
+work_13894	#subject_literature	#subject_literature							
+work_16330	#subject_law								
+work_16331	#subject_law								
+work_16223	#subject_law								
+work_13903	#subject_literature								
+work_13904	#subject_literature	#subject_literature							
+work_4527	#subject_literature								
+work_4526	#subject_history								
+work_13905	#subject_literature	#subject_literature							
+work_3741	#subject_literature								
+work_520	#subject_literature								
+work_13906	#subject_documents								
+work_2885	#subject_grammar								
+work_3080	#subject_geography								
+work_3081	#subject_geography								
+work_3742	#subject_politics_and_government								
+work_3743	#subject_history								
+work_3744	#subject_history								
+work_3745	#subject_bible								
+work_13907	#subject_music	#subject_literature							
+work_13908	#subject_music								
+work_13909	#subject_literature	#subject_music							
+work_13910	#subject_music								
+work_12344	#subject_liturgy	#subject_music							
+work_13911	#subject_music								
+work_3746	#subject_monasticism_and_religious_orders	#subject_conduct							
+work_1783	#subject_literature								
+work_1784	#subject_literature								
+work_13912	#subject_liturgy								
+work_13913	#subject_liturgy								
+work_13914	#subject_liturgy	#subject_music							
+work_13915	#subject_liturgy								
+work_13916	#subject_liturgy								
+work_13917	#subject_liturgy								
+work_3754	#subject_medicine								
+work_13918	#subject_theology	#subject_christian_literature	#subject_christian_literature	#subject_theology					
+work_7186	#subject_theology								
+work_3087	#subject_christian_literature								
+work_3765	#subject_philosophy								
+work_3758	#subject_philosophy	#subject_classical_literature							
+work_3759	#subject_music								
+work_3762	#subject_philosophy	#subject_classical_literature							
+work_3764	#subject_philosophy	#subject_classical_literature							
+work_3763	#subject_philosophy	#subject_classical_literature							
+work_6370	#subject_philosophy	#subject_classical_literature							
+work_3760	#subject_philosophy								
+work_3766	#subject_philosophy								
+work_3761	#subject_philosophy	#subject_classical_literature							
+work_13920	#subject_geography								
+work_13921	#subject_geography								
+work_3767	#subject_hagiography								
+work_13922	#subject_bible								
+work_3769	#subject_sermons								
+work_13924	#subject_medicine								
+work_17072	#subject_medicine								
+work_17027	#subject_medicine								
+work_13925	#subject_rhetoric								
+work_3770	#subject_theology								
+work_13926	#subject_christian_literature								
+work_2515	#subject_law								
+work_13927	#subject_liturgy								
+work_13928	#subject_christian_literature								
+work_13929	#subject_christian_literature								
+work_13934	#subject_christian_literature	#subject_theology							
+work_13931	#subject_christian_literature								
+work_13932	#subject_christian_literature								
+work_13933	#subject_literature								
+work_13935	#subject_christian_literature								
+work_13936	#subject_christian_literature								
+work_13937	#subject_christian_literature								
+work_13938	#subject_christian_literature	#subject_magic							
+work_13939	#subject_christian_literature								
+work_13940	#subject_christian_literature								
+work_13941	#subject_christian_literature								
+work_13930	#subject_christian_literature								
+work_13942	#subject_christian_literature								
+work_13943	#subject_christian_literature								
+work_13944	#subject_christian_literature								
+work_13945	#subject_christian_literature								
+work_13946	#subject_christian_literature								
+work_13947	#subject_christian_literature								
+work_13948	#subject_christian_literature								
+work_13949	#subject_christian_literature								
+work_13950	#subject_christian_literature								
+work_13951	#subject_christian_literature	#subject_christian_literature							
+work_13952	#subject_christian_literature	#subject_christian_literature							
+work_13953	#subject_christian_literature	#subject_christian_literature							
+work_13954	#subject_christian_literature	#subject_christian_literature							
+work_13955	#subject_liturgy	#subject_christian_literature							
+work_13956	#subject_liturgy	#subject_christian_literature							
+work_13957	#subject_christian_literature	#subject_christian_literature							
+work_13958	#subject_christian_literature	#subject_christian_literature							
+work_13959	#subject_christian_literature	#subject_christian_literature							
+work_13960	#subject_christian_literature	#subject_liturgy							
+work_13961	#subject_liturgy	#subject_bible	#subject_christian_literature						
+work_13962	#subject_christian_literature	#subject_theology							
+work_13963	#subject_christian_literature								
+work_13965	#subject_christian_literature								
+work_13966	#subject_christian_literature	#subject_theology							
+work_13973	#subject_christian_literature								
+work_13974	#subject_christian_literature	#subject_theology							
+work_13975	#subject_christian_literature								
+work_13976	#subject_christian_literature	#subject_liturgy							
+work_13964	#subject_christian_literature								
+work_13968	#subject_liturgy	#subject_christian_literature	#subject_music						
+work_13967	#subject_liturgy	#subject_christian_literature	#subject_christian_literature						
+work_13969	#subject_christian_literature	#subject_christian_literature	#subject_christian_literature						
+work_13970	#subject_liturgy	#subject_christian_literature							
+work_13971	#subject_liturgy	#subject_christian_literature							
+work_13972	#subject_liturgy	#subject_bible	#subject_christian_literature						
+work_13978	#subject_bible								
+work_13979	#subject_documents								
+work_16044	#subject_history								
+work_1440	#subject_literature								
+work_13982	#subject_theology	#subject_christian_literature							
+work_16210	#subject_hagiography								
+work_3771	#subject_bible								
+work_16066	#subject_bible								
+work_3773	#subject_grammar								
+work_3772	#subject_grammar								
+work_3774	#subject_grammar								
+work_3775	#subject_grammar	#subject_classical_literature							
+work_3776	#subject_grammar								
+work_3777	#subject_grammar								
+work_3780	#subject_classical_literature	#subject_philosophy							
+work_16344	#subject_clergy								
+work_13987	#subject_documents								
+work_13988	#subject_christian_literature								
+work_13991	#subject_christian_literature								
+work_13989	#subject_christian_literature								
+work_13990	#subject_christian_literature								
+work_13993	#subject_documents								
+work_13992	#subject_documents								
+work_13994	#subject_christian_literature								
+work_13995	#subject_documents								
+work_13996	#subject_christian_literature								
+work_13997	#subject_christian_literature	#subject_christian_literature	#subject_liturgy						
+work_13998	#subject_liturgy	#subject_christian_literature							
+work_13999	#subject_documents	#subject_monasticism_and_religious_orders							
+work_14000	#subject_monasticism_and_religious_orders								
+work_14001	#subject_monasticism_and_religious_orders								
+work_14002	#subject_documents								
+work_3781	#subject_classical_literature								
+work_14003	#subject_documents	#subject_law	#subject_monasticism_and_religious_orders						
+work_14004	#subject_law								
+work_14005	#subject_law								
+work_14006	#subject_documents								
+work_13706	#subject_documents	#subject_law							
+work_14008	#subject_liturgy								
+work_14009	#subject_liturgy								
+work_14010	#subject_liturgy								
+work_14011	#subject_liturgy								
+work_14012	#subject_liturgy								
+work_14013	#subject_liturgy								
+work_14014	#subject_liturgy								
+work_14015	#subject_liturgy								
+work_14016	#subject_liturgy								
+work_14017	#subject_liturgy								
+work_14018	#subject_liturgy	#subject_music							
+work_14019	#subject_liturgy	#subject_music							
+work_6190	#subject_hagiography								
+work_3782	#subject_science								
+work_3791	#subject_philosophy								
+work_3783	#subject_philosophy								
+work_5121	#subject_philosophy								
+work_3784	#subject_philosophy								
+work_3785	#subject_philosophy								
+work_3786	#subject_philosophy	#subject_classical_literature							
+work_3787	#subject_philosophy								
+work_3788	#subject_philosophy	#subject_classical_literature							
+work_3792	#subject_philosophy								
+work_3790	#subject_classical_literature								
+work_3789	#subject_philosophy								
+work_5797	#subject_sermons								
+work_6002	#subject_bible								
+work_3795	#subject_bible								
+work_6001	#subject_christian_literature	#subject_classical_literature							
+work_3798	#subject_science								
+work_3796	#subject_science								
+work_3797	#subject_indexes	#subject_history							
+work_14020	#subject_history								
+work_14021	#subject_history								
+work_14022	#subject_history								
+work_14023	#subject_history								
+work_16043	#subject_history								
+work_14024	#subject_history								
+work_14025	#subject_classical_literature								
+work_14026	#subject_classical_literature								
+work_14027	#subject_history								
+work_14028	#subject_history								
+work_3799	#subject_classical_literature								
+work_14029	#subject_documents								
+work_14035	#subject_history								
+work_14030	#subject_history								
+work_14031	#subject_history								
+work_14032	#subject_history								
+work_14033	#subject_history								
+work_14034	#subject_history								
+work_14040	#subject_history								
+work_14041	#subject_history								
+work_14042	#subject_bible								
+work_14043	#subject_liturgy								
+work_3800	#subject_science								
+work_3801	#subject_law								
+work_14046	#subject_literature								
+work_14047	#subject_literature								
+work_14048	#subject_literature								
+work_14049	#subject_theology	#subject_christian_literature							
+work_14050	#subject_literature								
+work_14052	#subject_liturgy								
+work_4094	#subject_christian_literature								
+work_3809	#subject_christian_literature								
+work_3804	#subject_christian_literature								
+work_3802	#subject_theology								
+work_3805	#subject_christian_literature								
+work_3806	#subject_christian_literature								
+work_3807	#subject_history								
+work_3808	#subject_christian_literature								
+work_3803	#subject_theology								
+work_5993	#subject_theology								
+work_5994	#subject_theology								
+work_14053	#subject_documents								
+work_17104	#subject_literature								
+work_17099	#subject_literature								
+work_14055	#subject_literature								
+work_14056	#subject_literature								
+work_14057	#subject_literature								
+work_14058	#subject_literature								
+work_14059	#subject_literature	#subject_literature							
+work_14060	#subject_literature								
+work_14061	#subject_literature								
+work_17140	#subject_literature								
+work_14062	#subject_literature								
+work_14063	#subject_literature								
+work_14064	#subject_literature								
+work_14065	#subject_literature								
+work_16342	#subject_literature								
+work_14067	#subject_literature	#subject_liturgy							
+work_14073	#subject_literature								
+work_14074	#subject_literature								
+work_17007	#subject_theology								
+work_14075	#subject_documents								
+work_3810	#subject_christian_literature								
+work_5739	#subject_christian_literature								
+work_3811	#subject_christian_literature								
+work_5738	#subject_christian_literature								
+work_5737	#subject_christian_literature								
+work_3812	#subject_christian_literature								
+work_3814	#subject_christian_literature								
+work_14076	#subject_literature								
+work_14086	#subject_christian_literature	#subject_bible							
+work_14087	#subject_christian_literature	#subject_liturgy							
+work_14089	#subject_liturgy	#subject_bible	#subject_christian_literature						
+work_14091	#subject_liturgy	#subject_bible							
+work_14117	#subject_liturgy	#subject_bible							
+work_14103	#subject_liturgy	#subject_bible							
+work_14108	#subject_liturgy								
+work_14109	#subject_liturgy	#subject_bible							
+work_14110	#subject_liturgy	#subject_bible							
+work_14111	#subject_liturgy	#subject_bible							
+work_14112	#subject_liturgy	#subject_bible							
+work_14113	#subject_liturgy	#subject_bible							
+work_14114	#subject_liturgy	#subject_bible							
+work_14115	#subject_liturgy	#subject_bible							
+work_14118	#subject_liturgy	#subject_bible							
+work_14119	#subject_liturgy	#subject_bible							
+work_14120	#subject_liturgy	#subject_bible							
+work_14121	#subject_liturgy	#subject_bible							
+work_14122	#subject_bible	#subject_liturgy							
+work_14137	#subject_bible								
+work_16275	#subject_bible								
+work_14138	#subject_liturgy								
+work_14147	#subject_liturgy	#subject_bible							
+work_14148	#subject_bible	#subject_liturgy							
+work_14150	#subject_liturgy	#subject_bible							
+work_14155	#subject_bible	#subject_liturgy							
+work_14129	#subject_liturgy	#subject_bible							
+work_14130	#subject_theology	#subject_liturgy	#subject_bible						
+work_14153	#subject_liturgy	#subject_bible							
+work_14158	#subject_liturgy	#subject_bible							
+work_14116	#subject_liturgy	#subject_bible							
+work_14159	#subject_liturgy								
+work_16279	#subject_liturgy								
+work_14123	#subject_liturgy	#subject_bible							
+work_14092	#subject_liturgy								
+work_14093	#subject_liturgy	#subject_bible							
+work_14164	#subject_liturgy	#subject_bible							
+work_14094	#subject_liturgy	#subject_bible							
+work_14098	#subject_liturgy	#subject_bible							
+work_14127	#subject_bible	#subject_liturgy	#subject_literature						
+work_16000	#subject_liturgy	#subject_bible							
+work_14135	#subject_liturgy								
+work_14167	#subject_liturgy	#subject_bible							
+work_14140	#subject_liturgy	#subject_bible	#subject_music						
+work_14142	#subject_liturgy	#subject_bible							
+work_14143	#subject_liturgy	#subject_bible							
+work_14144	#subject_liturgy	#subject_bible							
+work_14145	#subject_liturgy	#subject_bible							
+work_14141	#subject_liturgy	#subject_bible							
+work_14146	#subject_liturgy	#subject_bible							
+work_14157	#subject_liturgy	#subject_bible							
+work_14133	#subject_bible	#subject_liturgy							
+work_14134	#subject_liturgy	#subject_bible							
+work_14160	#subject_liturgy								
+work_14161	#subject_liturgy	#subject_bible							
+work_3193	#subject_literature								
+work_3192	#subject_science								
+work_38	#subject_theology								
+work_3200	#subject_medicine								
+work_46	#subject_law								
+work_3194	#subject_literature								
+work_3195	#subject_classical_literature								
+work_5999	#subject_christian_literature								
+work_29	#subject_law								
+work_3196	#subject_medicine								
+work_143	#subject_bible								
+work_3197	#subject_theology								
+work_3198	#subject_bible								
+work_3199	#subject_sermons								
+work_6593	#subject_literature								
+work_4144	#subject_classical_literature	#subject_science							
+work_4145	#subject_classical_literature	#subject_science							
+work_4147	#subject_classical_literature	#subject_science							
+work_4149	#subject_classical_literature	#subject_geography							
+work_4150	#subject_classical_literature	#subject_science							
+work_1285	#subject_classical_literature	#subject_science							
+work_4152	#subject_classical_literature	#subject_science							
+work_4151	#subject_classical_literature	#subject_science							
+work_4153	#subject_classical_literature								
+work_4096	#subject_classical_literature	#subject_science							
+work_4097	#subject_classical_literature	#subject_science							
+work_5630	#subject_theology								
+work_2999	#subject_literature								
+work_4882	#subject_history								
+work_4883	#subject_geography								
+work_14169	#subject_recreation								
+work_4154	#subject_classical_literature	#subject_philosophy							
+work_4155	#subject_classical_literature	#subject_philosophy							
+work_14170	#subject_science								
+work_14171	#subject_documents								
+work_14172	#subject_law	#subject_theology							
+work_16356	#subject_history								
+work_17001	#subject_theology								
+work_17005	#subject_theology								
+work_16046	#subject_history								
+work_14173	#subject_philosophy								
+work_14174	#subject_medicine								
+work_14175	#subject_theology								
+work_17071	#subject_medicine								
+work_17047	#subject_philosophy								
+work_17046	#subject_philosophy								
+work_14178	#subject_theology								
+work_17042	#subject_medicine								
+work_14179	#subject_medicine								
+work_14180	#subject_medicine								
+work_17043	#subject_medicine								
+work_17002	#subject_theology								
+work_16349	#subject_theology								
+work_14184	#subject_theology	#subject_theology							
+work_14185	#subject_theology								
+work_14186	#subject_medicine								
+work_14187	#subject_monasticism_and_religious_orders								
+work_14188	#subject_theology								
+work_4158	#subject_history								
+work_3514	#subject_law								
+work_5674	#subject_theology								
+work_14190	#subject_christian_literature								
+work_4098	#subject_rhetoric								
+work_4159	#subject_classical_literature	#subject_rhetoric							
+work_2928	#subject_rhetoric								
+work_14191	#subject_philosophy	#subject_theology							
+work_3870	#subject_theology								
+work_6605	#subject_sermons								
+work_6285	#subject_sermons								
+work_4163	#subject_theology								
+work_4164	#subject_sermons								
+work_4165	#subject_sermons								
+work_17061	#subject_grammar	#subject_rhetoric							
+work_4167	#subject_natural_history								
+work_4170	#subject_bible								
+work_4169	#subject_bible								
+work_2102	#subject_bible								
+work_4172	#subject_bible								
+work_4173	#subject_bible								
+work_4246	#subject_bible								
+work_2104	#subject_bible								
+work_4174	#subject_clergy								
+work_4175	#subject_science								
+work_4176	#subject_theology								
+work_2105	#subject_theology								
+work_4177	#subject_natural_history								
+work_6089	#subject_sermons								
+work_4468	#subject_science								
+work_4193	#subject_bible								
+work_4194	#subject_bible								
+work_16318	#subject_literature								
+work_4216	#subject_law								
+work_4179	#subject_bible								
+work_4227	#subject_theology								
+work_4195	#subject_geography								
+work_5815	#subject_theology								
+work_4189	#subject_theology								
+work_4190	#subject_theology								
+work_4191	#subject_monasticism_and_religious_orders								
+work_4192	#subject_theology								
+work_5924	#subject_sermons								
+work_4188	#subject_science								
+work_6081	#subject_christian_literature								
+work_4225	#subject_science								
+work_4218	#subject_hagiography								
+work_4178	#subject_christian_literature								
+work_4220	#subject_philosophy								
+work_4219	#subject_theology	#subject_theology							
+work_4217	#subject_theology	#subject_theology							
+work_4247	#subject_medicine								
+work_4228	#subject_medicine								
+work_7165	#subject_medicine								
+work_4229	#subject_medicine								
+work_4248	#subject_medicine								
+work_4249	#subject_medicine								
+work_4230	#subject_medicine								
+work_4231	#subject_medicine								
+work_14192	#subject_law								
+work_14193	#subject_law								
+work_14195	#subject_law								
+work_14194	#subject_law								
+work_14196	#subject_grammar	#subject_liturgy							
+work_14197	#subject_documents								
+work_14198	#subject_documents								
+work_14199	#subject_documents								
+work_14200	#subject_documents								
+work_14201	#subject_documents								
+work_14202	#subject_documents								
+work_14203	#subject_documents								
+work_14204	#subject_documents								
+work_14205	#subject_documents								
+work_14206	#subject_documents								
+work_14207	#subject_documents								
+work_14208	#subject_documents								
+work_14210	#subject_documents								
+work_14211	#subject_documents								
+work_14212	#subject_documents								
+work_14213	#subject_documents								
+work_14214	#subject_documents								
+work_14215	#subject_documents								
+work_14216	#subject_documents								
+work_14218	#subject_documents								
+work_14219	#subject_documents								
+work_14220	#subject_documents								
+work_14221	#subject_documents								
+work_14222	#subject_documents								
+work_14209	#subject_documents								
+work_14217	#subject_documents								
+work_14223	#subject_documents								
+work_14225	#subject_documents								
+work_14226	#subject_documents								
+work_14227	#subject_documents								
+work_14228	#subject_documents								
+work_17144	#subject_documents								
+work_14229	#subject_documents								
+work_14230	#subject_documents								
+work_14231	#subject_documents								
+work_14232	#subject_documents								
+work_14233	#subject_science								
+work_14234	#subject_medicine								
+work_14235	#subject_medicine								
+work_14236	#subject_science								
+work_14237	#subject_science								
+work_16241	#subject_medicine								
+work_14238	#subject_science								
+work_14239	#subject_medicine								
+work_14240	#subject_natural_history								
+work_14241	#subject_science								
+work_14242	#subject_medicine	#subject_science							
+work_14244	#subject_documents	#subject_monasticism_and_religious_orders							
+work_14245	#subject_documents	#subject_monasticism_and_religious_orders	#subject_clergy						
+work_14246	#subject_documents								
+work_14247	#subject_history	#subject_liturgy							
+work_14248	#subject_documents								
+work_14249	#subject_documents								
+work_14250	#subject_law								
+work_14251	#subject_monasticism_and_religious_orders								
+work_14252	#subject_documents								
+work_4272	#subject_history								
+work_5025	#subject_indexes	#subject_law							
+work_5026	#subject_indexes	#subject_law							
+work_14253	#subject_theology	#subject_clergy							
+work_16313	#subject_medicine								
+work_14255	#subject_medicine								
+work_4234	#subject_literature								
+work_4235	#subject_hagiography								
+work_4239	#subject_hagiography								
+work_4236	#subject_hagiography								
+work_4237	#subject_hagiography								
+work_4240	#subject_sermons								
+work_4238	#subject_hagiography								
+work_4241	#subject_music								
+work_14259	#subject_documents								
+work_14262	#subject_documents	#subject_monasticism_and_religious_orders							
+work_14263	#subject_documents								
+work_14264	#subject_theology	#subject_documents	#subject_monasticism_and_religious_orders	#subject_clergy					
+work_14265	#subject_documents								
+work_14266	#subject_documents								
+work_14267	#subject_documents								
+work_14268	#subject_documents								
+work_14270	#subject_documents								
+work_14271	#subject_documents								
+work_14272	#subject_documents								
+work_14273	#subject_documents								
+work_14274	#subject_documents								
+work_14275	#subject_documents								
+work_14278	#subject_law								
+work_14279	#subject_documents	#subject_law							
+work_14280	#subject_law	#subject_documents							
+work_14281	#subject_documents								
+work_14282	#subject_documents	#subject_monasticism_and_religious_orders							
+work_14283	#subject_monasticism_and_religious_orders	#subject_documents							
+work_14284	#subject_documents								
+work_14257	#subject_documents	#subject_monasticism_and_religious_orders							
+work_14258	#subject_documents								
+work_14260	#subject_documents								
+work_14261	#subject_documents	#subject_monasticism_and_religious_orders							
+work_14269	#subject_documents	#subject_law	#subject_clergy	#subject_documents					
+work_14276	#subject_documents	#subject_monasticism_and_religious_orders							
+work_14277	#subject_documents	#subject_monasticism_and_religious_orders							
+work_14285	#subject_documents								
+work_14286	#subject_law								
+work_14288	#subject_law								
+work_14289	#subject_law								
+work_14290	#subject_documents								
+work_14291	#subject_law								
+work_14292	#subject_documents								
+work_14293	#subject_documents								
+work_14294	#subject_documents	#subject_monasticism_and_religious_orders							
+work_14295	#subject_theology	#subject_christian_literature							
+work_994	#subject_medicine								
+work_14297	#subject_monasticism_and_religious_orders								
+work_14298	#subject_monasticism_and_religious_orders								
+work_14299	#subject_monasticism_and_religious_orders								
+work_14300	#subject_monasticism_and_religious_orders								
+work_14456	#subject_monasticism_and_religious_orders								
+work_16295	#subject_monasticism_and_religious_orders								
+work_14301	#subject_monasticism_and_religious_orders								
+work_14302	#subject_monasticism_and_religious_orders								
+work_14304	#subject_monasticism_and_religious_orders								
+work_14303	#subject_monasticism_and_religious_orders								
+work_14305	#subject_monasticism_and_religious_orders								
+work_14306	#subject_monasticism_and_religious_orders								
+work_14307	#subject_monasticism_and_religious_orders								
+work_14308	#subject_monasticism_and_religious_orders								
+work_14309	#subject_monasticism_and_religious_orders								
+work_16340	#subject_law								
+work_14310	#subject_grammar								
+work_14311	#subject_grammar								
+work_16312	#subject_medicine								
+work_14312	#subject_documents								
+work_14313	#subject_documents								
+work_14314	#subject_literature								
+work_14315	#subject_liturgy								
+work_14316	#subject_theology	#subject_christian_literature	#subject_clergy						
+work_14318	#subject_theology	#subject_christian_literature							
+work_14320	#subject_theology	#subject_christian_literature							
+work_14321	#subject_christian_literature								
+work_14322	#subject_theology	#subject_christian_literature							
+work_14323	#subject_literature	#subject_christian_literature							
+work_14324	#subject_literature	#subject_christian_literature	#subject_music						
+work_14325	#subject_music	#subject_literature	#subject_christian_literature						
+work_14326	#subject_theology	#subject_christian_literature							
+work_14327	#subject_literature	#subject_christian_literature							
+work_14328	#subject_theology	#subject_christian_literature	#subject_literature						
+work_14329	#subject_theology	#subject_christian_literature							
+work_14330	#subject_theology								
+work_16011	#subject_literature								
+work_14331	#subject_theology	#subject_christian_literature							
+work_14332	#subject_theology	#subject_christian_literature							
+work_14333	#subject_theology	#subject_christian_literature							
+work_14334	#subject_theology	#subject_christian_literature							
+work_14335	#subject_christian_literature	#subject_theology							
+work_14336	#subject_christian_literature	#subject_theology	#subject_sermons	#subject_hagiography					
+work_14338	#subject_theology	#subject_christian_literature							
+work_14339	#subject_theology	#subject_christian_literature							
+work_14340	#subject_theology	#subject_christian_literature	#subject_liturgy						
+work_14352	#subject_christian_literature	#subject_christian_literature	#subject_theology						
+work_14371	#subject_theology	#subject_christian_literature							
+work_14355	#subject_christian_literature								
+work_14341	#subject_literature	#subject_christian_literature							
+work_14342	#subject_literature	#subject_christian_literature							
+work_14343	#subject_theology	#subject_christian_literature							
+work_14344	#subject_literature	#subject_christian_literature	#subject_theology						
+work_14345	#subject_literature	#subject_christian_literature							
+work_14346	#subject_literature	#subject_christian_literature							
+work_14347	#subject_theology	#subject_christian_literature							
+work_14348	#subject_literature	#subject_christian_literature							
+work_14349	#subject_christian_literature	#subject_literature	#subject_theology						
+work_14350	#subject_christian_literature	#subject_literature							
+work_14351	#subject_literature	#subject_christian_literature							
+work_14357	#subject_theology	#subject_christian_literature							
+work_14358	#subject_theology	#subject_christian_literature							
+work_14359	#subject_theology	#subject_christian_literature	#subject_christian_literature						
+work_14360	#subject_theology								
+work_14353	#subject_theology	#subject_christian_literature	#subject_theology						
+work_14354	#subject_christian_literature	#subject_theology							
+work_14362	#subject_theology	#subject_hagiography							
+work_14356	#subject_theology	#subject_christian_literature							
+work_14363	#subject_theology	#subject_christian_literature							
+work_14364	#subject_christian_literature	#subject_christian_literature							
+work_14365	#subject_christian_literature	#subject_christian_literature							
+work_14366	#subject_theology	#subject_christian_literature							
+work_14367	#subject_theology	#subject_christian_literature							
+work_14368	#subject_theology	#subject_christian_literature	#subject_literature						
+work_14369	#subject_literature	#subject_theology	#subject_christian_literature						
+work_14370	#subject_christian_literature	#subject_literature							
+work_14337	#subject_theology	#subject_christian_literature	#subject_science	#subject_hagiography					
+work_4244	#subject_theology								
+work_7038	#subject_liturgy	#subject_theology							
+work_4242	#subject_classical_literature								
+work_6275	#subject_christian_literature								
+work_4243	#subject_bible								
+work_5817	#subject_liturgy								
+work_14373	#subject_literature								
+work_14374	#subject_documents								
+work_14375	#subject_documents								
+work_14377	#subject_documents								
+work_14378	#subject_documents								
+work_14379	#subject_documents	#subject_monasticism_and_religious_orders							
+work_14376	#subject_documents	#subject_monasticism_and_religious_orders							
+work_14380	#subject_documents	#subject_monasticism_and_religious_orders							
+work_14381	#subject_documents	#subject_monasticism_and_religious_orders							
+work_14382	#subject_documents	#subject_monasticism_and_religious_orders							
+work_984	#subject_bible								
+work_14383	#subject_documents								
+work_3636	#subject_sermons								
+work_14386	#subject_documents								
+work_14387	#subject_documents								
+work_14388	#subject_documents	#subject_law							
+work_14389	#subject_documents	#subject_law							
+work_14390	#subject_documents								
+work_14391	#subject_documents								
+work_14392	#subject_documents								
+work_14393	#subject_documents								
+work_14394	#subject_documents								
+work_14395	#subject_documents								
+work_14396	#subject_documents	#subject_law							
+work_14397	#subject_law								
+work_14398	#subject_documents								
+work_14399	#subject_documents								
+work_14400	#subject_liturgy	#subject_bible							
+work_14401	#subject_documents								
+work_14402	#subject_documents								
+work_14403	#subject_documents								
+work_14404	#subject_documents								
+work_14405	#subject_documents								
+work_2758	#subject_theology								
+work_14406	#subject_history	#subject_hagiography							
+work_14409	#subject_hagiography	#subject_hagiography							
+work_14410	#subject_documents	#subject_law							
+work_14411	#subject_natural_history								
+work_3779	#subject_science								
+work_14412	#subject_history	#subject_rhetoric							
+work_14413	#subject_rhetoric	#subject_philosophy							
+work_14414	#subject_rhetoric	#subject_philosophy							
+work_14415	#subject_rhetoric	#subject_theology							
+work_14417	#subject_rhetoric								
+work_14418	#subject_rhetoric								
+work_14419	#subject_rhetoric								
+work_14420	#subject_rhetoric								
+work_14416	#subject_rhetoric	#subject_grammar	#subject_literature						
+work_14421	#subject_theology	#subject_law	#subject_rhetoric						
+work_4250	#subject_hagiography								
+work_4251	#subject_philosophy								
+work_7336	#subject_medicine								
+work_4252	#subject_theology								
+work_7065	#subject_theology								
+work_4312	#subject_theology								
+work_3214	#subject_history								
+work_4345	#subject_history								
+work_1729	#subject_history								
+work_14423	#subject_literature								
+work_7124	#subject_christian_literature								
+work_4306	#subject_rhetoric								
+work_4310	#subject_medicine								
+work_4311	#subject_science								
+work_4339	#subject_christian_literature								
+work_4297	#subject_philosophy								
+work_6076	#subject_medicine								
+work_5744	#subject_medicine								
+work_4341	#subject_medicine								
+work_7389	#subject_medicine								
+work_4343	#subject_liturgy								
+work_6079	#subject_literature								
+work_4305	#subject_literature								
+work_4330	#subject_bible								
+work_4321	#subject_bible								
+work_4318	#subject_bible								
+work_4316	#subject_bible								
+work_4322	#subject_bible								
+work_4317	#subject_bible								
+work_4323	#subject_conduct								
+work_7069	#subject_theology								
+work_4324	#subject_theology	#subject_medicine							
+work_7067	#subject_theology								
+work_7428	#subject_theology								
+work_7068	#subject_theology								
+work_4325	#subject_conduct	#subject_theology							
+work_4326	#subject_theology								
+work_4331	#subject_theology	#subject_bible							
+work_4327	#subject_theology								
+work_6424	#subject_bible								
+work_4328	#subject_theology								
+work_4319	#subject_theology								
+work_4320	#subject_bible								
+work_4329	#subject_theology								
+work_4332	#subject_sermons								
+work_4333	#subject_science								
+work_4334	#subject_science								
+work_4335	#subject_science								
+work_4336	#subject_science								
+work_4337	#subject_science								
+work_4338	#subject_science								
+work_7392	#subject_medicine								
+work_4313	#subject_bible								
+work_4314	#subject_bible								
+work_4315	#subject_bible								
+work_4307	#subject_literature								
+work_4302	#subject_theology								
+work_4271	#subject_grammar								
+work_4300	#subject_science								
+work_4346	#subject_theology								
+work_6240	#subject_politics_and_government								
+work_1690	#subject_science								
+work_1692	#subject_science								
+work_1693	#subject_science								
+work_14424	#subject_music								
+work_14425	#subject_liturgy								
+work_14426	#subject_liturgy								
+work_14428	#subject_liturgy	#subject_theology	#subject_clergy						
+work_14427	#subject_liturgy								
+work_14429	#subject_liturgy								
+work_14430	#subject_liturgy								
+work_3114	#subject_rhetoric								
+work_4411	#subject_theology								
+work_13326	#subject_sermons	#subject_christian_literature							
+work_4403	#subject_sermons	#subject_christian_literature							
+work_4412	#subject_science								
+work_7425	#subject_bible								
+work_4404	#subject_history								
+work_6311	#subject_monasticism_and_religious_orders	#subject_history							
+work_4405	#subject_history								
+work_4407	#subject_bible								
+work_6246	#subject_hagiography								
+work_4409	#subject_law								
+work_4410	#subject_history								
+work_4402	#subject_history								
+work_4413	#subject_bible								
+work_4414	#subject_theology								
+work_7238	#subject_theology								
+work_4419	#subject_history								
+work_4415	#subject_hagiography								
+work_4416	#subject_science	#subject_natural_history							
+work_4417	#subject_science								
+work_4350	#subject_philosophy								
+work_4347	#subject_philosophy								
+work_4348	#subject_philosophy								
+work_4406	#subject_bible								
+work_4352	#subject_history								
+work_4420	#subject_bible								
+work_4408	#subject_law								
+work_2760	#subject_science								
+work_4823	#subject_hagiography								
+work_4421	#subject_law								
+work_4442	#subject_philosophy								
+work_4446	#subject_theology								
+work_4455	#subject_monasticism_and_religious_orders								
+work_4459	#subject_history								
+work_4461	#subject_politics_and_government								
+work_4462	#subject_history								
+work_4452	#subject_medicine								
+work_4453	#subject_medicine								
+work_4454	#subject_medicine								
+work_7388	#subject_medicine								
+work_4443	#subject_bible								
+work_4423	#subject_history								
+work_4444	#subject_monasticism_and_religious_orders	#subject_theology							
+work_4445	#subject_monasticism_and_religious_orders								
+work_4460	#subject_sermons								
+work_4456	#subject_science								
+work_4457	#subject_natural_history								
+work_4458	#subject_natural_history								
+work_4451	#subject_philosophy								
+work_4464	#subject_medicine								
+work_4465	#subject_law								
+work_4466	#subject_law								
+work_4981	#subject_theology								
+work_14431	#subject_heraldry								
+work_14432	#subject_law	#subject_documents							
+work_16195	#subject_documents								
+work_6153	#subject_theology								
+work_6152	#subject_bible								
+work_4273	#subject_bible								
+work_4274	#subject_bible								
+work_4276	#subject_bible								
+work_4277	#subject_theology								
+work_4278	#subject_theology								
+work_4279	#subject_bible								
+work_4281	#subject_bible								
+work_4282	#subject_theology								
+work_4283	#subject_christian_literature								
+work_4284	#subject_christian_literature								
+work_4285	#subject_conduct								
+work_4286	#subject_christian_literature								
+work_4280	#subject_bible								
+work_4287	#subject_monasticism_and_religious_orders								
+work_4288	#subject_christian_literature								
+work_4289	#subject_christian_literature								
+work_4290	#subject_christian_literature								
+work_4291	#subject_christian_literature								
+work_4292	#subject_christian_literature								
+work_4293	#subject_christian_literature								
+work_4294	#subject_bible								
+work_4295	#subject_bible								
+work_5966	#subject_theology								
+work_4296	#subject_theology								
+work_4103	#subject_bible								
+work_14437	#subject_literature								
+work_14435	#subject_literature								
+work_14433	#subject_literature								
+work_14434	#subject_literature								
+work_14436	#subject_literature								
+work_14438	#subject_literature								
+work_14439	#subject_literature								
+work_14440	#subject_literature								
+work_14441	#subject_literature								
+work_14442	#subject_science								
+work_14443	#subject_literature	#subject_literature							
+work_14444	#subject_literature	#subject_sermons							
+work_14446	#subject_literature								
+work_14447	#subject_literature								
+work_14448	#subject_literature								
+work_202	#subject_classical_literature								
+work_1939	#subject_christian_literature								
+work_14450	#subject_literature	#subject_bible							
+work_14449	#subject_theology								
+work_607	#subject_law								
+work_14451	#subject_documents	#subject_law							
+work_4470	#subject_theology								
+work_4469	#subject_theology								
+work_4472	#subject_theology								
+work_7178	#subject_medicine								
+work_4473	#subject_theology								
+work_4474	#subject_medicine								
+work_4523	#subject_history								
+work_4447	#subject_medicine								
+work_14452	#subject_monasticism_and_religious_orders								
+work_14453	#subject_monasticism_and_religious_orders								
+work_14457	#subject_monasticism_and_religious_orders								
+work_14460	#subject_monasticism_and_religious_orders								
+work_14459	#subject_monasticism_and_religious_orders								
+work_14455	#subject_monasticism_and_religious_orders								
+work_14461	#subject_documents								
+work_14462	#subject_documents								
+work_14463	#subject_documents								
+work_14464	#subject_theology	#subject_clergy							
+work_4475	#subject_liturgy	#subject_theology							
+work_2358	#subject_christian_literature								
+work_2359	#subject_christian_literature								
+work_1785	#subject_literature								
+work_13124	#subject_theology								
+work_14467	#subject_liturgy	#subject_theology	#subject_clergy						
+work_14469	#subject_liturgy	#subject_theology	#subject_clergy						
+work_14471	#subject_liturgy	#subject_theology	#subject_clergy						
+work_14470	#subject_liturgy	#subject_theology	#subject_clergy						
+work_14473	#subject_hagiography								
+work_1786	#subject_literature								
+work_5119	#subject_science								
+work_5120	#subject_science								
+work_5221	#subject_science								
+work_5122	#subject_science								
+work_5123	#subject_science								
+work_14478	#subject_documents								
+work_14479	#subject_documents								
+work_14480	#subject_documents								
+work_14481	#subject_documents								
+work_14482	#subject_documents								
+work_14483	#subject_documents								
+work_14484	#subject_documents								
+work_14485	#subject_documents								
+work_14486	#subject_documents								
+work_14487	#subject_documents								
+work_14488	#subject_documents								
+work_4480	#subject_classical_literature								
+work_4481	#subject_classical_literature								
+work_4482	#subject_classical_literature								
+work_4115	#subject_rhetoric	#subject_politics_and_government							
+work_4116	#subject_bible								
+work_1670	#subject_christian_literature								
+work_14489	#subject_history	#subject_bible	#subject_literature						
+work_1295	#subject_history								
+work_1296	#subject_theology								
+work_1297	#subject_literature								
+work_4483	#subject_theology								
+work_4825	#subject_rhetoric								
+work_4488	#subject_theology								
+work_4484	#subject_theology								
+work_4485	#subject_theology								
+work_4486	#subject_theology								
+work_4487	#subject_bible								
+work_1391	#subject_literature								
+work_4463	#subject_christian_literature	#subject_politics_and_government							
+work_14490	#subject_liturgy								
+work_2342	#subject_literature								
+work_3094	#subject_medicine								
+work_3095	#subject_medicine								
+work_3096	#subject_medicine								
+work_3090	#subject_theology								
+work_2983	#subject_history	#subject_hagiography							
+work_14491	#subject_medicine								
+work_4489	#subject_literature								
+work_2203	#subject_literature								
+work_14492	#subject_literature								
+work_14493	#subject_literature								
+work_1797	#subject_christian_literature								
+work_14494	#subject_theology								
+work_14495	#subject_literature	#subject_monasticism_and_religious_orders							
+work_14496	#subject_theology								
+work_16375	#subject_law								
+work_14497	#subject_theology								
+work_14498	#subject_theology								
+work_14499	#subject_theology								
+work_16357	#subject_classical_literature								
+work_14500	#subject_literature								
+work_14503	#subject_literature								
+work_14504	#subject_literature								
+work_14505	#subject_classical_literature								
+work_16229	#subject_science								
+work_16234	#subject_classical_literature								
+work_14506	#subject_literature								
+work_14507	#subject_theology								
+work_14508	#subject_theology								
+work_14510	#subject_literature								
+work_14509	#subject_literature								
+work_14511	#subject_science	#subject_science							
+work_14512	#subject_science								
+work_14513	#subject_science	#subject_science							
+work_14514	#subject_science								
+work_14515	#subject_literature	#subject_science							
+work_14517	#subject_science								
+work_14516	#subject_science								
+work_14518	#subject_science								
+work_1064	#subject_law								
+work_3201	#subject_science								
+work_3202	#subject_science								
+work_3203	#subject_science								
+work_14519	#subject_literature								
+work_17000	#subject_theology								
+work_14520	#subject_literature								
+work_14521	#subject_history								
+work_4623	#subject_philosophy								
+work_6359	#subject_hagiography								
+work_14523	#subject_theology								
+work_14524	#subject_science								
+work_17075	#subject_medicine	#subject_literature	#subject_natural_history						
+work_14525	#subject_science								
+work_14666	#subject_literature	#subject_liturgy	#subject_music						
+work_14526	#subject_literature								
+work_3212	#subject_medicine								
+work_4490	#subject_christian_literature								
+work_4491	#subject_christian_literature								
+work_4492	#subject_christian_literature								
+work_1070	#subject_history								
+work_7327	#subject_theology								
+work_4967	#subject_philosophy								
+work_7313	#subject_literature								
+work_7312	#subject_classical_literature								
+work_7309	#subject_literature								
+work_7314	#subject_classical_literature								
+work_7308	#subject_literature								
+work_7311	#subject_literature	#subject_rhetoric							
+work_7307	#subject_grammar								
+work_7310	#subject_grammar								
+work_12879	#subject_hagiography								
+work_12882	#subject_hagiography								
+work_12889	#subject_hagiography								
+work_14527	#subject_documents								
+work_883	#subject_history								
+work_4493	#subject_theology								
+work_4495	#subject_christian_literature								
+work_4506	#subject_literature								
+work_2904	#subject_rhetoric								
+work_4496	#subject_literature								
+work_2905	#subject_philosophy								
+work_2903	#subject_philosophy								
+work_4497	#subject_philosophy								
+work_5222	#subject_philosophy								
+work_4499	#subject_philosophy								
+work_4501	#subject_philosophy	#subject_literature							
+work_4502	#subject_literature								
+work_7189	#subject_natural_history								
+work_4505	#subject_literature								
+work_3011	#subject_classical_literature								
+work_4121	#subject_philosophy	#subject_theology							
+work_4117	#subject_philosophy								
+work_4118	#subject_philosophy								
+work_4119	#subject_philosophy								
+work_4120	#subject_philosophy								
+work_4123	#subject_philosophy								
+work_4124	#subject_classical_literature								
+work_4875	#subject_history								
+work_14531	#subject_literature	#subject_bible							
+work_14533	#subject_theology								
+work_14534	#subject_literature								
+work_14535	#subject_literature								
+work_14536	#subject_literature								
+work_14538	#subject_theology								
+work_16304	#subject_theology								
+work_14539	#subject_literature	#subject_literature							
+work_1452	#subject_science								
+work_14540	#subject_theology								
+work_14541	#subject_liturgy								
+work_15067	#subject_liturgy								
+work_14542	#subject_liturgy								
+work_16184	#subject_liturgy								
+work_4510	#subject_medicine								
+work_4511	#subject_medicine								
+work_4509	#subject_medicine								
+work_4508	#subject_medicine								
+work_4157	#subject_medicine								
+work_4512	#subject_monasticism_and_religious_orders								
+work_3119	#subject_theology								
+work_4513	#subject_theology	#subject_bible							
+work_4514	#subject_christian_literature								
+work_16071	#subject_theology								
+work_14552	#subject_sermons	#subject_hagiography							
+work_14543	#subject_sermons								
+work_14545	#subject_sermons								
+work_14546	#subject_sermons								
+work_14547	#subject_sermons								
+work_14548	#subject_sermons								
+work_14550	#subject_sermons								
+work_14554	#subject_sermons								
+work_14555	#subject_sermons								
+work_14556	#subject_sermons								
+work_16012	#subject_sermons	#subject_hagiography							
+work_14557	#subject_sermons								
+work_14560	#subject_sermons								
+work_14561	#subject_sermons								
+work_14562	#subject_sermons	#subject_bible							
+work_14563	#subject_sermons	#subject_bible							
+work_14564	#subject_sermons								
+work_14558	#subject_sermons								
+work_14559	#subject_sermons								
+work_15604	#subject_bible	#subject_sermons							
+work_14565	#subject_sermons								
+work_14566	#subject_sermons								
+work_14567	#subject_sermons								
+work_14553	#subject_sermons								
+work_14544	#subject_sermons								
+work_14568	#subject_sermons								
+work_14569	#subject_sermons								
+work_14570	#subject_sermons								
+work_17031	#subject_sermons								
+work_14611	#subject_sermons								
+work_14572	#subject_sermons								
+work_14573	#subject_sermons								
+work_14574	#subject_sermons								
+work_14577	#subject_sermons								
+work_14578	#subject_sermons								
+work_14579	#subject_sermons								
+work_14580	#subject_sermons								
+work_14581	#subject_sermons								
+work_14582	#subject_sermons								
+work_14583	#subject_sermons								
+work_14585	#subject_sermons								
+work_14586	#subject_sermons	#subject_hagiography							
+work_14587	#subject_sermons	#subject_clergy							
+work_14590	#subject_sermons	#subject_hagiography							
+work_14592	#subject_theology	#subject_sermons							
+work_14593	#subject_theology	#subject_sermons							
+work_14594	#subject_sermons	#subject_theology							
+work_14595	#subject_theology	#subject_sermons							
+work_14596	#subject_theology	#subject_sermons							
+work_14597	#subject_sermons								
+work_14598	#subject_sermons								
+work_14601	#subject_sermons								
+work_14610	#subject_sermons								
+work_14616	#subject_sermons	#subject_bible							
+work_14620	#subject_sermons	#subject_bible							
+work_14612	#subject_sermons								
+work_14617	#subject_sermons								
+work_14622	#subject_sermons								
+work_14624	#subject_sermons								
+work_14608	#subject_sermons								
+work_14623	#subject_sermons								
+work_4515	#subject_natural_history								
+work_14625	#subject_liturgy	#subject_music							
+work_14626	#subject_liturgy								
+work_14627	#subject_liturgy								
+work_4516	#subject_grammar								
+work_4517	#subject_classical_literature								
+work_4518	#subject_grammar								
+work_4519	#subject_grammar								
+work_14628	#subject_law								
+work_1972	#subject_christian_literature								
+work_1973	#subject_christian_literature								
+work_1974	#subject_christian_literature								
+work_1975	#subject_christian_literature								
+work_7329	#subject_sermons								
+work_5875	#subject_theology								
+work_5992	#subject_theology								
+work_6021	#subject_sermons								
+work_4520	#subject_sermons								
+work_5991	#subject_theology								
+work_5733	#subject_theology								
+work_6015	#subject_theology								
+work_6022	#subject_theology								
+work_2285	#subject_rhetoric	#subject_classical_literature							
+work_6454	#subject_theology								
+work_4630	#subject_christian_literature	#subject_hagiography							
+work_4631	#subject_christian_literature	#subject_hagiography							
+work_4632	#subject_hagiography								
+work_14631	#subject_history	#subject_bible							
+work_7341	#subject_philosophy	#subject_classical_literature							
+work_6278	#subject_philosophy								
+work_7088	#subject_theology								
+work_7089	#subject_theology	#subject_clergy							
+work_5615	#subject_philosophy								
+work_2762	#subject_philosophy								
+work_2763	#subject_philosophy								
+work_4524	#subject_sermons								
+work_7187	#subject_sermons	#subject_christian_literature							
+work_2764	#subject_science								
+work_5027	#subject_philosophy								
+work_14633	#subject_history	#subject_literature							
+work_14634	#subject_theology								
+work_14635	#subject_literature								
+work_14636	#subject_literature								
+work_14637	#subject_literature								
+work_14638	#subject_literature								
+work_14639	#subject_literature								
+work_7408	#subject_liturgy								
+work_4525	#subject_sermons								
+work_4528	#subject_literature								
+work_4529	#subject_literature								
+work_14641	#subject_science								
+work_14642	#subject_science								
+work_14643	#subject_science								
+work_14644	#subject_science								
+work_14646	#subject_history	#subject_literature							
+work_4530	#subject_history								
+work_7287	#subject_philosophy								
+work_4532	#subject_classical_literature	#subject_history							
+work_4649	#subject_literature								
+work_4536	#subject_monasticism_and_religious_orders								
+work_4539	#subject_history								
+work_4540	#subject_theology								
+work_16266	#subject_theology								
+work_4567	#subject_philosophy								
+work_4542	#subject_sermons								
+work_4543	#subject_classical_literature								
+work_4544	#subject_theology								
+work_7148	#subject_sermons								
+work_7407	#subject_bible								
+work_4560	#subject_theology								
+work_4558	#subject_philosophy								
+work_7285	#subject_philosophy								
+work_7284	#subject_philosophy								
+work_7273	#subject_philosophy								
+work_7288	#subject_philosophy								
+work_7282	#subject_philosophy								
+work_7293	#subject_philosophy								
+work_7291	#subject_philosophy								
+work_7289	#subject_philosophy								
+work_7281	#subject_philosophy								
+work_7283	#subject_philosophy								
+work_7294	#subject_science								
+work_7272	#subject_science								
+work_7290	#subject_philosophy								
+work_5816	#subject_monasticism_and_religious_orders								
+work_4559	#subject_clergy								
+work_7048	#subject_theology								
+work_4564	#subject_theology								
+work_4566	#subject_philosophy								
+work_4565	#subject_philosophy								
+work_14651	#subject_literature								
+work_14652	#subject_literature								
+work_14653	#subject_literature								
+work_4569	#subject_law								
+work_4570	#subject_law								
+work_4571	#subject_law								
+work_4572	#subject_law								
+work_3336	#subject_science								
+work_4573	#subject_bible								
+work_4574	#subject_monasticism_and_religious_orders								
+work_4575	#subject_monasticism_and_religious_orders								
+work_4576	#subject_liturgy								
+work_7016	#subject_theology								
+work_17116	#subject_law								
+work_17110	#subject_law								
+work_2471	#subject_law								
+work_5989	#subject_history								
+work_4577	#subject_geography								
+work_16042	#subject_literature								
+work_14654	#subject_history								
+work_16247	#subject_bible								
+work_14663	#subject_literature	#subject_music							
+work_14664	#subject_music	#subject_literature							
+work_14665	#subject_literature								
+work_14667	#subject_literature	#subject_music							
+work_14668	#subject_literature	#subject_music							
+work_14669	#subject_literature								
+work_4578	#subject_rhetoric	#subject_classical_literature							
+work_14670	#subject_philosophy								
+work_4579	#subject_classical_literature								
+work_4580	#subject_classical_literature								
+work_4581	#subject_classical_literature								
+work_6380	#subject_classical_literature								
+work_4582	#subject_classical_literature								
+work_4583	#subject_classical_literature								
+work_4584	#subject_classical_literature								
+work_5689	#subject_theology	#subject_conduct							
+work_4585	#subject_christian_literature								
+work_4587	#subject_christian_literature								
+work_4586	#subject_hagiography								
+work_16045	#subject_history								
+work_14804	#subject_grammar								
+work_4629	#subject_grammar								
+work_14671	#subject_hagiography								
+work_14672	#subject_hagiography								
+work_4588	#subject_grammar								
+work_4298	#subject_christian_literature								
+work_14673	#subject_literature								
+work_14676	#subject_theology	#subject_theology							
+work_14678	#subject_theology								
+work_14679	#subject_theology	#subject_bible							
+work_14681	#subject_sermons								
+work_14682	#subject_medicine								
+work_14683	#subject_theology								
+work_14684	#subject_monasticism_and_religious_orders								
+work_14685	#subject_science								
+work_14686	#subject_sermons								
+work_14687	#subject_theology								
+work_17052	#subject_rhetoric								
+work_14689	#subject_rhetoric								
+work_14690	#subject_rhetoric								
+work_14691	#subject_rhetoric								
+work_16264	#subject_law								
+work_6057	#subject_law								
+work_4589	#subject_philosophy								
+work_16284	#subject_medicine	#subject_science							
+work_14692	#subject_medicine	#subject_science							
+work_16285	#subject_medicine	#subject_science							
+work_2995	#subject_history	#subject_literature							
+work_14693	#subject_theology								
+work_3674	#subject_science								
+work_14705	#subject_liturgy	#subject_literature							
+work_16027	#subject_law	#subject_documents							
+work_14706	#subject_documents								
+work_14707	#subject_documents								
+work_4601	#subject_classical_literature								
+work_4602	#subject_classical_literature								
+work_4603	#subject_classical_literature								
+work_14708	#subject_law								
+work_16216	#subject_law								
+work_14709	#subject_law	#subject_clergy							
+work_14710	#subject_law	#subject_literature							
+work_14711	#subject_law	#subject_clergy							
+work_14454	#subject_monasticism_and_religious_orders								
+work_14713	#subject_law	#subject_clergy							
+work_14714	#subject_law								
+work_14715	#subject_law	#subject_documents							
+work_14716	#subject_law	#subject_monasticism_and_religious_orders							
+work_17113	#subject_law								
+work_17117	#subject_law								
+work_14717	#subject_monasticism_and_religious_orders								
+work_14719	#subject_law	#subject_monasticism_and_religious_orders							
+work_14720	#subject_law	#subject_monasticism_and_religious_orders							
+work_14721	#subject_monasticism_and_religious_orders	#subject_law							
+work_14727	#subject_documents	#subject_law	#subject_monasticism_and_religious_orders						
+work_14730	#subject_law								
+work_14739	#subject_law								
+work_14740	#subject_law								
+work_14741	#subject_law								
+work_14743	#subject_law								
+work_14744	#subject_law								
+work_14745	#subject_law								
+work_14746	#subject_law								
+work_14747	#subject_law								
+work_14748	#subject_law								
+work_14750	#subject_law								
+work_14752	#subject_law								
+work_14753	#subject_law								
+work_14754	#subject_law								
+work_14755	#subject_law								
+work_14756	#subject_law								
+work_14757	#subject_law								
+work_14758	#subject_law								
+work_14760	#subject_law								
+work_14731	#subject_law								
+work_14732	#subject_law								
+work_14733	#subject_law								
+work_14737	#subject_law								
+work_14738	#subject_law								
+work_14734	#subject_law								
+work_14735	#subject_law								
+work_14736	#subject_law								
+work_14749	#subject_law								
+work_14751	#subject_law								
+work_14759	#subject_law								
+work_14761	#subject_law	#subject_clergy							
+work_14762	#subject_clergy	#subject_law							
+work_14767	#subject_law	#subject_clergy							
+work_14768	#subject_law	#subject_clergy							
+work_14769	#subject_law	#subject_monasticism_and_religious_orders							
+work_14770	#subject_law	#subject_monasticism_and_religious_orders							
+work_14784	#subject_law	#subject_monasticism_and_religious_orders							
+work_14785	#subject_law								
+work_14787	#subject_documents	#subject_law							
+work_14786	#subject_law								
+work_14788	#subject_monasticism_and_religious_orders								
+work_14789	#subject_clergy								
+work_14790	#subject_law	#subject_monasticism_and_religious_orders							
+work_14791	#subject_monasticism_and_religious_orders	#subject_law							
+work_14718	#subject_clergy	#subject_law							
+work_14722	#subject_clergy	#subject_law							
+work_14724	#subject_clergy	#subject_documents							
+work_14723	#subject_law								
+work_14725	#subject_documents	#subject_law							
+work_14726	#subject_documents	#subject_law							
+work_14728	#subject_law								
+work_14729	#subject_clergy	#subject_law							
+work_14763	#subject_law	#subject_monasticism_and_religious_orders							
+work_14764	#subject_law	#subject_monasticism_and_religious_orders							
+work_14765	#subject_law								
+work_14766	#subject_monasticism_and_religious_orders								
+work_14783	#subject_documents								
+work_14776	#subject_documents								
+work_14777	#subject_law								
+work_14778	#subject_documents								
+work_14779	#subject_law								
+work_14780	#subject_law								
+work_14771	#subject_documents								
+work_14772	#subject_documents								
+work_14773	#subject_documents								
+work_14774	#subject_documents								
+work_14775	#subject_documents								
+work_14781	#subject_law								
+work_14782	#subject_documents								
+work_14796	#subject_law								
+work_14792	#subject_law	#subject_documents							
+work_14793	#subject_documents	#subject_law							
+work_14794	#subject_law								
+work_14795	#subject_documents								
+work_14797	#subject_law	#subject_clergy							
+work_14798	#subject_clergy								
+work_4609	#subject_christian_literature								
+work_168	#subject_christian_literature								
+work_6092	#subject_literature								
+work_6112	#subject_grammar								
+work_203	#subject_medicine								
+work_7018	#subject_sermons								
+work_7177	#subject_medicine								
+work_2010	#subject_science								
+work_6600	#subject_history	#subject_monasticism_and_religious_orders							
+work_2522	#subject_classical_literature								
+work_3337	#subject_liturgy								
+work_1736	#subject_rhetoric								
+work_14800	#subject_literature	#subject_history							
+work_14801	#subject_sermons								
+work_4624	#subject_geography								
+work_4625	#subject_geography								
+work_2854	#subject_law								
+work_4186	#subject_philosophy								
+work_14803	#subject_indexes								
+work_4626	#subject_classical_literature								
+work_4627	#subject_classical_literature	#subject_history							
+work_4628	#subject_classical_literature	#subject_history							
+work_14805	#subject_documents								
+work_2523	#subject_history	#subject_classical_literature							
+work_14813	#subject_theology	#subject_sermons							
+work_14808	#subject_law								
+work_14809	#subject_law	#subject_theology							
+work_14810	#subject_medicine								
+work_14811	#subject_liturgy	#subject_theology	#subject_clergy						
+work_14812	#subject_theology								
+work_14814	#subject_theology								
+work_16360	#subject_law								
+work_16359	#subject_law								
+work_16036	#subject_bible								
+work_14817	#subject_history								
+work_14816	#subject_bible								
+work_14818	#subject_bible								
+work_14819	#subject_theology								
+work_14820	#subject_law								
+work_14822	#subject_sermons								
+work_14823	#subject_medicine								
+work_14824	#subject_documents								
+work_14825	#subject_documents								
+work_14826	#subject_documents								
+work_14827	#subject_documents								
+work_14828	#subject_documents								
+work_4299	#subject_science								
+work_4633	#subject_medicine								
+work_1721	#subject_science								
+work_4127	#subject_hagiography								
+work_6000	#subject_theology								
+work_4538	#subject_theology								
+work_4650	#subject_theology								
+work_4535	#subject_history								
+work_5911	#subject_hagiography								
+work_4635	#subject_hagiography	#subject_liturgy							
+work_4636	#subject_hagiography	#subject_liturgy							
+work_4637	#subject_hagiography	#subject_liturgy							
+work_5127	#subject_hagiography								
+work_5128	#subject_hagiography								
+work_4638	#subject_hagiography								
+work_4639	#subject_hagiography								
+work_4640	#subject_hagiography								
+work_4641	#subject_hagiography								
+work_4642	#subject_hagiography								
+work_5129	#subject_hagiography								
+work_4643	#subject_hagiography								
+work_5130	#subject_hagiography								
+work_4644	#subject_hagiography								
+work_4645	#subject_hagiography								
+work_4646	#subject_theology								
+work_4537	#subject_theology								
+work_4647	#subject_liturgy	#subject_music							
+work_4648	#subject_liturgy								
+work_4651	#subject_classical_literature								
+work_4652	#subject_classical_literature								
+work_14831	#subject_liturgy								
+work_16039	#subject_hagiography								
+work_4653	#subject_science								
+work_4	#subject_science								
+work_10	#subject_history								
+work_21	#subject_literature								
+work_25	#subject_history								
+work_26	#subject_history								
+work_42	#subject_science								
+work_4655	#subject_politics_and_government								
+work_54	#subject_literature	#subject_philosophy							
+work_65	#subject_literature								
+work_77	#subject_sermons								
+work_78	#subject_sermons								
+work_79	#subject_christian_literature								
+work_4568	#subject_literature								
+work_4657	#subject_literature	#subject_christian_literature							
+work_14832	#subject_clergy								
+work_14833	#subject_liturgy								
+work_14834	#subject_medicine								
+work_14835	#subject_law								
+work_14836	#subject_bible								
+work_4658	#subject_philosophy								
+work_6088	#subject_philosophy	#subject_classical_literature							
+work_14838	#subject_science								
+work_14840	#subject_law								
+work_14842	#subject_indexes								
+work_14843	#subject_indexes	#subject_theology							
+work_14844	#subject_indexes								
+work_14845	#subject_bible								
+work_14846	#subject_theology								
+work_14847	#subject_indexes								
+work_14848	#subject_history								
+work_14849	#subject_history								
+work_14851	#subject_indexes								
+work_14852	#subject_documents								
+work_14853	#subject_science	#subject_indexes							
+work_14854	#subject_science								
+work_14855	#subject_science								
+work_14856	#subject_indexes								
+work_17032	#subject_indexes	#subject_bible							
+work_14384	#subject_law								
+work_17006	#subject_theology								
+work_14857	#subject_indexes	#subject_philosophy	#subject_medicine						
+work_14858	#subject_theology	#subject_indexes							
+work_14859	#subject_indexes								
+work_14860	#subject_bible								
+work_14861	#subject_bible	#subject_indexes							
+work_17030	#subject_theology								
+work_16289	#subject_indexes								
+work_14862	#subject_indexes								
+work_14863	#subject_indexes								
+work_7108	#subject_indexes								
+work_16300	#subject_indexes								
+work_14864	#subject_indexes	#subject_sermons							
+work_14865	#subject_indexes								
+work_14867	#subject_science								
+work_4660	#subject_classical_literature								
+work_4661	#subject_history								
+work_14868	#subject_medicine								
+work_4662	#subject_theology								
+work_4663	#subject_law								
+work_407	#subject_law								
+work_4664	#subject_bible								
+work_7504	#subject_literature								
+work_14870	#subject_documents								
+work_14871	#subject_documents								
+work_14872	#subject_documents	#subject_clergy							
+work_14873	#subject_documents								
+work_14874	#subject_documents								
+work_14875	#subject_documents								
+work_14876	#subject_documents								
+work_14877	#subject_documents								
+work_14878	#subject_documents								
+work_14879	#subject_documents								
+work_14880	#subject_documents								
+work_14881	#subject_documents								
+work_14882	#subject_documents								
+work_14883	#subject_documents	#subject_clergy							
+work_14885	#subject_documents	#subject_clergy							
+work_14886	#subject_clergy	#subject_documents							
+work_14887	#subject_documents								
+work_14888	#subject_documents								
+work_14889	#subject_documents								
+work_14890	#subject_documents								
+work_14891	#subject_documents								
+work_14892	#subject_documents								
+work_14893	#subject_documents								
+work_5028	#subject_sermons								
+work_14894	#subject_liturgy								
+work_602	#subject_literature								
+work_601	#subject_literature								
+work_603	#subject_literature								
+work_1997	#subject_theology								
+work_14895	#subject_theology								
+work_4698	#subject_medicine								
+work_4665	#subject_classical_literature								
+work_4666	#subject_classical_literature								
+work_14896	#subject_documents								
+work_4667	#subject_theology								
+work_16353	#subject_bible								
+work_14899	#subject_documents								
+work_14901	#subject_bible								
+work_14900	#subject_bible								
+work_14902	#subject_documents								
+work_14903	#subject_documents								
+work_14919	#subject_science								
+work_14921	#subject_heraldry								
+work_14933	#subject_recreation								
+work_14942	#subject_theology								
+work_14946	#subject_theology								
+work_14948	#subject_science								
+work_14965	#subject_theology								
+work_14981	#subject_theology								
+work_14982	#subject_theology								
+work_14990	#subject_clergy								
+work_15028	#subject_clergy	#subject_law	#subject_theology						
+work_16228	#subject_science								
+work_15046	#subject_science								
+work_15073	#subject_documents								
+work_15084	#subject_philosophy								
+work_16272	#subject_liturgy								
+work_15062	#subject_geography								
+work_15293	#subject_theology								
+work_15170	#subject_theology								
+work_17121	#subject_theology								
+work_16322	#subject_science								
+work_15189	#subject_history								
+work_15220	#subject_literature								
+work_14911	#subject_monasticism_and_religious_orders								
+work_14912	#subject_history	#subject_geography							
+work_14913	#subject_documents	#subject_history	#subject_monasticism_and_religious_orders						
+work_14914	#subject_clergy								
+work_14915	#subject_history	#subject_clergy							
+work_14958	#subject_science	#subject_science	#subject_history						
+work_14960	#subject_science	#subject_science							
+work_14971	#subject_science	#subject_liturgy							
+work_15001	#subject_theology								
+work_15011	#subject_conduct								
+work_15024	#subject_law								
+work_15045	#subject_science	#subject_science	#subject_history						
+work_15069	#subject_theology								
+work_15070	#subject_hagiography								
+work_15080	#subject_liturgy	#subject_theology	#subject_clergy						
+work_15086	#subject_magic	#subject_history							
+work_15092	#subject_medicine	#subject_science							
+work_15099	#subject_monasticism_and_religious_orders								
+work_15176	#subject_hagiography								
+work_14941	#subject_science								
+work_15063	#subject_geography								
+work_15072	#subject_history								
+work_15146	#subject_bible								
+work_15199	#subject_history								
+work_15213	#subject_history								
+work_15214	#subject_monasticism_and_religious_orders								
+work_15217	#subject_history								
+work_15218	#subject_hagiography								
+work_15211	#subject_clergy								
+work_15212	#subject_science								
+work_15215	#subject_history								
+work_15216	#subject_monasticism_and_religious_orders								
+work_15219	#subject_history								
+work_4668	#subject_medicine								
+work_4669	#subject_medicine								
+work_6335	#subject_medicine								
+work_10194	#subject_history								
+work_10197	#subject_history								
+work_10488	#subject_literature								
+work_10490	#subject_science								
+work_10607	#subject_christian_literature								
+work_16320	#subject_literature								
+work_10903	#subject_theology	#subject_christian_literature	#subject_christian_literature						
+work_11044	#subject_christian_literature								
+work_11046	#subject_christian_literature	#subject_theology							
+work_11311	#subject_geography								
+work_11388	#subject_literature								
+work_11407	#subject_christian_literature								
+work_11508	#subject_literature								
+work_11674	#subject_literature								
+work_11821	#subject_literature	#subject_christian_literature							
+work_11831	#subject_bible								
+work_11997	#subject_theology								
+work_12119	#subject_medicine								
+work_12461	#subject_literature								
+work_16315	#subject_medicine								
+work_12514	#subject_literature								
+work_12782	#subject_history								
+work_13109	#subject_law	#subject_history							
+work_13328	#subject_christian_literature	#subject_theology							
+work_13429	#subject_science								
+work_13461	#subject_hagiography	#subject_theology							
+work_13720	#subject_theology								
+work_13981	#subject_theology	#subject_literature	#subject_christian_literature						
+work_14136	#subject_literature								
+work_16048	#subject_theology								
+work_14629	#subject_theology	#subject_christian_literature							
+work_16316	#subject_medicine								
+work_14645	#subject_literature	#subject_history							
+work_14647	#subject_history	#subject_literature							
+work_14648	#subject_literature								
+work_14649	#subject_literature								
+work_14650	#subject_literature								
+work_14802	#subject_sermons								
+work_14869	#subject_literature								
+work_15347	#subject_literature	#subject_hagiography							
+work_15458	#subject_hagiography								
+work_16049	#subject_theology								
+work_15498	#subject_geography								
+work_15500	#subject_literature								
+work_15526	#subject_music								
+work_16370	#subject_politics_and_government								
+work_4671	#subject_science								
+work_4672	#subject_science								
+work_6336	#subject_science								
+work_6337	#subject_science								
+work_4673	#subject_science								
+work_4674	#subject_science								
+work_4675	#subject_music								
+work_16280	#subject_bible								
+work_4676	#subject_classical_literature	#subject_rhetoric							
+work_4677	#subject_philosophy								
+work_4678	#subject_philosophy								
+work_4679	#subject_philosophy								
+work_4681	#subject_hagiography								
+work_4682	#subject_classical_literature								
+work_4683	#subject_classical_literature								
+work_4706	#subject_sermons								
+work_6349	#subject_theology								
+work_6075	#subject_theology	#subject_law							
+work_4718	#subject_monasticism_and_religious_orders								
+work_6175	#subject_history								
+work_4715	#subject_christian_literature								
+work_4716	#subject_monasticism_and_religious_orders								
+work_4717	#subject_sermons								
+work_4695	#subject_bible								
+work_4687	#subject_bible								
+work_4696	#subject_theology								
+work_4688	#subject_theology								
+work_4686	#subject_theology								
+work_4689	#subject_philosophy								
+work_4690	#subject_history	#subject_theology							
+work_4692	#subject_history	#subject_theology							
+work_6003	#subject_bible								
+work_5998	#subject_bible								
+work_4693	#subject_theology								
+work_4694	#subject_bible								
+work_4748	#subject_geography								
+work_4702	#subject_hagiography								
+work_4703	#subject_sermons								
+work_5152	#subject_law								
+work_4701	#subject_law								
+work_4720	#subject_hagiography								
+work_4713	#subject_liturgy								
+work_4714	#subject_literature								
+work_5646	#subject_literature								
+work_4705	#subject_theology								
+work_4726	#subject_classical_literature	#subject_science							
+work_4727	#subject_classical_literature	#subject_science							
+work_4728	#subject_classical_literature	#subject_science							
+work_4723	#subject_grammar	#subject_classical_literature							
+work_4725	#subject_grammar								
+work_4724	#subject_grammar	#subject_classical_literature							
+work_4722	#subject_grammar								
+work_5146	#subject_grammar								
+work_4732	#subject_law								
+work_4729	#subject_law								
+work_4730	#subject_theology								
+work_4733	#subject_classical_literature								
+work_6474	#subject_classical_literature								
+work_15224	#subject_theology								
+work_15228	#subject_theology	#subject_literature	#subject_sermons	#subject_christian_literature	#subject_liturgy	#subject_monasticism_and_religious_orders			
+work_15226	#subject_theology	#subject_christian_literature							
+work_15227	#subject_theology	#subject_christian_literature							
+work_15229	#subject_theology	#subject_grammar							
+work_15230	#subject_theology	#subject_grammar							
+work_15231	#subject_theology	#subject_history							
+work_15232	#subject_theology	#subject_law							
+work_15233	#subject_theology	#subject_liturgy							
+work_15234	#subject_theology	#subject_medicine							
+work_15235	#subject_theology	#subject_literature							
+work_15236	#subject_theology	#subject_christian_literature							
+work_15237	#subject_theology	#subject_christian_literature							
+work_15238	#subject_theology	#subject_christian_literature							
+work_15239	#subject_theology								
+work_15240	#subject_theology								
+work_15241	#subject_theology								
+work_15242	#subject_theology	#subject_theology							
+work_15243	#subject_theology	#subject_theology							
+work_15245	#subject_theology	#subject_philosophy							
+work_15246	#subject_theology	#subject_christian_literature							
+work_15247	#subject_theology	#subject_christian_literature							
+work_15248	#subject_theology	#subject_christian_literature							
+work_15250	#subject_theology	#subject_science							
+work_15249	#subject_theology	#subject_science							
+work_15251	#subject_theology	#subject_science	#subject_literature						
+work_15252	#subject_theology								
+work_15253	#subject_theology								
+work_15254	#subject_theology								
+work_15255	#subject_theology								
+work_15256	#subject_theology								
+work_15257	#subject_theology								
+work_15258	#subject_theology								
+work_15259	#subject_theology								
+work_15260	#subject_theology								
+work_15261	#subject_theology	#subject_theology							
+work_15262	#subject_theology								
+work_15263	#subject_theology								
+work_15264	#subject_theology								
+work_15265	#subject_theology								
+work_15266	#subject_theology								
+work_15267	#subject_theology								
+work_15268	#subject_theology								
+work_15269	#subject_theology								
+work_15270	#subject_theology								
+work_15273	#subject_theology								
+work_15274	#subject_theology								
+work_15275	#subject_theology								
+work_15276	#subject_theology	#subject_literature							
+work_15277	#subject_theology								
+work_15278	#subject_theology	#subject_literature							
+work_15279	#subject_theology								
+work_15280	#subject_theology								
+work_15281	#subject_theology								
+work_15282	#subject_theology								
+work_15283	#subject_theology								
+work_15284	#subject_theology								
+work_15285	#subject_theology	#subject_sermons							
+work_15286	#subject_theology								
+work_15287	#subject_theology								
+work_15307	#subject_theology								
+work_15288	#subject_theology								
+work_15289	#subject_theology								
+work_15290	#subject_theology	#subject_sermons							
+work_15291	#subject_theology								
+work_15292	#subject_theology								
+work_15294	#subject_liturgy	#subject_theology	#subject_clergy						
+work_15295	#subject_theology								
+work_15299	#subject_theology								
+work_15308	#subject_theology								
+work_15300	#subject_theology								
+work_15303	#subject_theology								
+work_15306	#subject_theology								
+work_15309	#subject_theology								
+work_15310	#subject_theology								
+work_15311	#subject_theology								
+work_15312	#subject_theology								
+work_15313	#subject_theology								
+work_15314	#subject_theology								
+work_15315	#subject_theology	#subject_literature							
+work_15317	#subject_theology								
+work_15318	#subject_theology								
+work_15320	#subject_theology								
+work_15319	#subject_theology								
+work_15321	#subject_theology								
+work_15322	#subject_theology								
+work_15301	#subject_theology	#subject_christian_literature							
+work_15302	#subject_theology	#subject_theology	#subject_theology						
+work_15304	#subject_theology								
+work_15305	#subject_theology								
+work_15324	#subject_theology								
+work_15325	#subject_theology								
+work_15326	#subject_theology								
+work_15327	#subject_theology								
+work_15328	#subject_theology	#subject_sermons							
+work_15329	#subject_theology								
+work_15331	#subject_theology								
+work_15330	#subject_theology								
+work_15332	#subject_theology	#subject_christian_literature							
+work_15333	#subject_theology	#subject_sermons							
+work_15335	#subject_theology								
+work_15336	#subject_theology								
+work_15337	#subject_theology								
+work_15339	#subject_theology								
+work_15340	#subject_theology	#subject_sermons							
+work_15271	#subject_theology	#subject_grammar	#subject_history						
+work_15272	#subject_theology	#subject_science	#subject_history						
+work_15296	#subject_theology	#subject_rhetoric	#subject_history						
+work_15297	#subject_theology	#subject_science	#subject_rhetoric						
+work_15298	#subject_theology	#subject_history	#subject_history	#subject_science					
+work_4734	#subject_science								
+work_4738	#subject_medicine								
+work_4740	#subject_classical_literature								
+work_5907	#subject_theology								
+work_6417	#subject_natural_history								
+work_4743	#subject_bible								
+work_4744	#subject_bible								
+work_4745	#subject_bible								
+work_6215	#subject_sermons								
+work_15343	#subject_science								
+work_4128	#subject_hagiography								
+work_15344	#subject_liturgy								
+work_2967	#subject_clergy								
+work_205	#subject_science								
+work_4680	#subject_monasticism_and_religious_orders								
+work_4746	#subject_philosophy								
+work_4747	#subject_theology								
+work_15345	#subject_theology								
+work_4791	#subject_natural_history								
+work_4802	#subject_grammar								
+work_4839	#subject_medicine								
+work_4841	#subject_philosophy								
+work_4787	#subject_rhetoric								
+work_4845	#subject_bible								
+work_4846	#subject_clergy								
+work_7045	#subject_sermons								
+work_4865	#subject_politics_and_government								
+work_4853	#subject_theology	#subject_theology							
+work_4826	#subject_history								
+work_206	#subject_literature								
+work_4749	#subject_literature								
+work_4786	#subject_christian_literature								
+work_4854	#subject_christian_literature								
+work_4855	#subject_christian_literature								
+work_4856	#subject_christian_literature								
+work_4857	#subject_christian_literature								
+work_4858	#subject_christian_literature	#subject_monasticism_and_religious_orders							
+work_4859	#subject_conduct	#subject_theology							
+work_4860	#subject_conduct	#subject_theology							
+work_4861	#subject_christian_literature	#subject_monasticism_and_religious_orders							
+work_4862	#subject_christian_literature								
+work_4863	#subject_christian_literature								
+work_4864	#subject_theology								
+work_4750	#subject_sermons								
+work_4836	#subject_theology								
+work_4842	#subject_natural_history								
+work_4843	#subject_theology	#subject_theology							
+work_4793	#subject_bible								
+work_4840	#subject_sermons								
+work_7427	#subject_theology								
+work_4798	#subject_bible								
+work_5930	#subject_theology								
+work_4814	#subject_classical_literature								
+work_4815	#subject_classical_literature								
+work_4848	#subject_science								
+work_4849	#subject_science								
+work_4850	#subject_science								
+work_4795	#subject_history	#subject_monasticism_and_religious_orders							
+work_4837	#subject_history								
+work_4796	#subject_history								
+work_4844	#subject_christian_literature								
+work_6146	#subject_hagiography								
+work_4847	#subject_history								
+work_5952	#subject_theology								
+work_7274	#subject_philosophy								
+work_7220	#subject_philosophy								
+work_7064	#subject_theology								
+work_7063	#subject_theology								
+work_4822	#subject_bible								
+work_4449	#subject_science								
+work_4824	#subject_history								
+work_4792	#subject_bible								
+work_6192	#subject_theology								
+work_7180	#subject_sermons								
+work_4827	#subject_theology								
+work_4828	#subject_sermons								
+work_7395	#subject_bible								
+work_4830	#subject_theology								
+work_7019	#subject_indexes	#subject_classical_literature							
+work_15346	#subject_theology	#subject_christian_literature							
+work_4866	#subject_history	#subject_classical_literature							
+work_4867	#subject_classical_literature								
+work_4880	#subject_bible	#subject_theology							
+work_6181	#subject_philosophy	#subject_classical_literature							
+work_4868	#subject_theology								
+work_2525	#subject_sermons								
+work_7154	#subject_indexes								
+work_15348	#subject_bibliography								
+work_15349	#subject_history								
+work_16343	#subject_law								
+work_17019	#subject_indexes								
+work_17018	#subject_indexes								
+work_15351	#subject_literature	#subject_history							
+work_15352	#subject_literature								
+work_4872	#subject_rhetoric								
+work_15356	#subject_liturgy								
+work_15357	#subject_liturgy	#subject_music							
+work_4876	#subject_law								
+work_2232	#subject_monasticism_and_religious_orders								
+work_2526	#subject_theology	#subject_literature	#subject_clergy						
+work_3627	#subject_medicine								
+work_15358	#subject_theology								
+work_17050	#subject_theology								
+work_15359	#subject_natural_history								
+work_15360	#subject_science								
+work_16009	#subject_law								
+work_15361	#subject_science								
+work_15362	#subject_theology								
+work_16244	#subject_theology								
+work_16074	#subject_theology								
+work_15363	#subject_medicine								
+work_15364	#subject_philosophy								
+work_15365	#subject_medicine								
+work_17034	#subject_science								
+work_15366	#subject_literature	#subject_literature							
+work_15367	#subject_literature	#subject_literature							
+work_15368	#subject_theology								
+work_15369	#subject_christian_literature								
+work_15370	#subject_literature								
+work_15371	#subject_documents	#subject_law							
+work_15372	#subject_history	#subject_heraldry							
+work_16065	#subject_hagiography								
+work_15373	#subject_hagiography	#subject_hagiography							
+work_16299	#subject_hagiography								
+work_15374	#subject_hagiography								
+work_15375	#subject_hagiography								
+work_15376	#subject_theology								
+work_2925	#subject_rhetoric								
+work_15377	#subject_documents	#subject_law							
+work_14905	#subject_theology								
+work_14906	#subject_theology								
+work_14907	#subject_monasticism_and_religious_orders								
+work_14909	#subject_monasticism_and_religious_orders								
+work_14923	#subject_philosophy								
+work_14925	#subject_theology								
+work_14926	#subject_science								
+work_14927	#subject_literature	#subject_literature							
+work_14929	#subject_bible	#subject_christian_literature							
+work_14930	#subject_christian_literature	#subject_theology							
+work_14932	#subject_theology								
+work_14980	#subject_law								
+work_14934	#subject_science								
+work_14935	#subject_theology								
+work_14936	#subject_grammar								
+work_14937	#subject_grammar								
+work_14939	#subject_grammar								
+work_14943	#subject_medicine								
+work_14944	#subject_theology								
+work_14945	#subject_theology								
+work_14947	#subject_science								
+work_14949	#subject_science								
+work_14950	#subject_science								
+work_14952	#subject_literature	#subject_science							
+work_14953	#subject_philosophy								
+work_14954	#subject_history								
+work_14956	#subject_science								
+work_14957	#subject_science	#subject_history							
+work_14959	#subject_science								
+work_14961	#subject_science								
+work_14963	#subject_theology								
+work_14964	#subject_medicine	#subject_natural_history							
+work_14967	#subject_natural_history								
+work_14970	#subject_science	#subject_liturgy							
+work_14972	#subject_law								
+work_14983	#subject_theology								
+work_14984	#subject_theology								
+work_14985	#subject_documents								
+work_14986	#subject_recreation								
+work_14987	#subject_history								
+work_14991	#subject_science								
+work_14992	#subject_science								
+work_14993	#subject_science								
+work_14994	#subject_theology								
+work_14995	#subject_theology								
+work_14996	#subject_theology								
+work_14997	#subject_theology								
+work_14998	#subject_literature	#subject_theology							
+work_14999	#subject_theology								
+work_15004	#subject_philosophy								
+work_15005	#subject_christian_literature								
+work_15006	#subject_law								
+work_15008	#subject_law	#subject_documents							
+work_15009	#subject_science								
+work_15010	#subject_theology								
+work_15013	#subject_music								
+work_15014	#subject_literature								
+work_15015	#subject_medicine	#subject_science							
+work_15016	#subject_medicine								
+work_15017	#subject_documents								
+work_15018	#subject_science	#subject_history							
+work_15019	#subject_science								
+work_15021	#subject_clergy								
+work_15022	#subject_liturgy								
+work_15023	#subject_science								
+work_15025	#subject_law								
+work_15029	#subject_natural_history								
+work_15031	#subject_grammar								
+work_16258	#subject_natural_history								
+work_15032	#subject_law								
+work_15034	#subject_science								
+work_16102	#subject_science								
+work_15035	#subject_science								
+work_15036	#subject_philosophy								
+work_15037	#subject_natural_history	#subject_literature							
+work_15039	#subject_grammar								
+work_15040	#subject_geography								
+work_15041	#subject_science	#subject_history							
+work_15042	#subject_history								
+work_15043	#subject_history								
+work_15044	#subject_history								
+work_15048	#subject_science								
+work_15050	#subject_history								
+work_15052	#subject_medicine								
+work_15053	#subject_medicine								
+work_15054	#subject_natural_history								
+work_15055	#subject_natural_history								
+work_15056	#subject_heraldry								
+work_15057	#subject_heraldry								
+work_15060	#subject_theology								
+work_15061	#subject_theology								
+work_15065	#subject_christian_literature	#subject_theology							
+work_15066	#subject_medicine								
+work_17068	#subject_natural_history								
+work_15074	#subject_grammar								
+work_15075	#subject_grammar								
+work_15076	#subject_medicine								
+work_15078	#subject_science								
+work_15081	#subject_philosophy								
+work_15083	#subject_philosophy								
+work_15085	#subject_science								
+work_15089	#subject_natural_history								
+work_15097	#subject_monasticism_and_religious_orders								
+work_15098	#subject_monasticism_and_religious_orders								
+work_15100	#subject_monasticism_and_religious_orders								
+work_15101	#subject_music								
+work_15102	#subject_philosophy								
+work_15103	#subject_theology								
+work_15104	#subject_science								
+work_15105	#subject_music								
+work_15106	#subject_politics_and_government								
+work_15110	#subject_science								
+work_15112	#subject_science								
+work_15113	#subject_grammar								
+work_15115	#subject_medicine								
+work_15116	#subject_theology								
+work_15117	#subject_grammar								
+work_15118	#subject_history								
+work_15119	#subject_history								
+work_15120	#subject_history								
+work_15121	#subject_clergy								
+work_15122	#subject_clergy								
+work_15123	#subject_law								
+work_15125	#subject_theology								
+work_15127	#subject_theology								
+work_15128	#subject_theology								
+work_15129	#subject_theology								
+work_15130	#subject_theology								
+work_15131	#subject_theology								
+work_15132	#subject_theology								
+work_15133	#subject_science								
+work_15135	#subject_sermons								
+work_15136	#subject_clergy								
+work_15139	#subject_history								
+work_15147	#subject_medicine								
+work_15148	#subject_theology								
+work_15149	#subject_science								
+work_15151	#subject_monasticism_and_religious_orders								
+work_15152	#subject_christian_literature								
+work_15158	#subject_law								
+work_15159	#subject_medicine								
+work_15160	#subject_medicine								
+work_15162	#subject_philosophy								
+work_15163	#subject_bible								
+work_15164	#subject_science								
+work_15171	#subject_clergy								
+work_15173	#subject_history								
+work_15175	#subject_history								
+work_15177	#subject_bible								
+work_15178	#subject_philosophy								
+work_15179	#subject_medicine								
+work_15180	#subject_medicine								
+work_15181	#subject_science	#subject_science							
+work_15186	#subject_philosophy								
+work_14938	#subject_grammar	#subject_bible							
+work_14940	#subject_history	#subject_medicine							
+work_14955	#subject_science								
+work_14968	#subject_hagiography								
+work_16073	#subject_theology								
+work_14974	#subject_theology								
+work_14975	#subject_natural_history								
+work_14976	#subject_natural_history								
+work_14977	#subject_natural_history								
+work_14978	#subject_natural_history								
+work_17094	#subject_theology								
+work_15026	#subject_theology								
+work_15027	#subject_theology								
+work_15030	#subject_monasticism_and_religious_orders								
+work_15033	#subject_theology								
+work_15047	#subject_bible								
+work_15064	#subject_theology								
+work_15068	#subject_bible								
+work_15090	#subject_theology								
+work_15091	#subject_theology	#subject_theology							
+work_15108	#subject_hagiography								
+work_15114	#subject_law								
+work_15124	#subject_hagiography	#subject_christian_literature							
+work_15126	#subject_clergy								
+work_15138	#subject_theology								
+work_15143	#subject_law	#subject_theology							
+work_15150	#subject_science								
+work_15153	#subject_theology								
+work_15156	#subject_liturgy	#subject_theology	#subject_clergy						
+work_15161	#subject_liturgy	#subject_theology	#subject_clergy						
+work_15165	#subject_theology								
+work_15166	#subject_theology								
+work_15167	#subject_theology								
+work_15168	#subject_theology								
+work_15169	#subject_grammar	#subject_music	#subject_rhetoric	#subject_philosophy	#subject_science	#subject_science	#subject_science		
+work_15182	#subject_theology								
+work_15183	#subject_theology								
+work_15185	#subject_theology	#subject_theology							
+work_15188	#subject_theology								
+work_15191	#subject_theology								
+work_15200	#subject_hagiography								
+work_15190	#subject_science								
+work_15192	#subject_medicine								
+work_15193	#subject_medicine								
+work_15194	#subject_medicine								
+work_15196	#subject_rhetoric								
+work_15197	#subject_medicine	#subject_natural_history							
+work_15198	#subject_theology								
+work_15201	#subject_theology								
+work_15202	#subject_theology								
+work_15203	#subject_theology								
+work_15204	#subject_theology								
+work_15205	#subject_theology								
+work_15207	#subject_law								
+work_15208	#subject_science								
+work_17069	#subject_law								
+work_14910	#subject_clergy								
+work_14908	#subject_clergy								
+work_14916	#subject_science								
+work_14917	#subject_law								
+work_14920	#subject_hagiography								
+work_14922	#subject_theology								
+work_14928	#subject_rhetoric	#subject_grammar							
+work_14951	#subject_science	#subject_science							
+work_15003	#subject_theology	#subject_christian_literature							
+work_15007	#subject_clergy								
+work_15020	#subject_history	#subject_clergy							
+work_15038	#subject_natural_history								
+work_15049	#subject_grammar								
+work_15051	#subject_grammar								
+work_15059	#subject_heraldry								
+work_15071	#subject_geography								
+work_15079	#subject_rhetoric								
+work_15082	#subject_philosophy								
+work_15088	#subject_conduct								
+work_15094	#subject_literature	#subject_rhetoric							
+work_15095	#subject_literature	#subject_rhetoric							
+work_15096	#subject_literature	#subject_rhetoric							
+work_15111	#subject_science	#subject_philosophy							
+work_15134	#subject_literature	#subject_rhetoric							
+work_15141	#subject_history								
+work_15142	#subject_history	#subject_science							
+work_15144	#subject_science								
+work_15145	#subject_rhetoric								
+work_15154	#subject_rhetoric								
+work_15155	#subject_rhetoric								
+work_15157	#subject_history								
+work_15174	#subject_science								
+work_14962	#subject_clergy								
+work_14979	#subject_monasticism_and_religious_orders								
+work_14989	#subject_law	#subject_history							
+work_15109	#subject_hagiography								
+work_15137	#subject_law								
+work_15184	#subject_theology	#subject_theology							
+work_15187	#subject_theology								
+work_15195	#subject_medicine								
+work_15209	#subject_science								
+work_15210	#subject_monasticism_and_religious_orders								
+work_15378	#subject_science	#subject_science							
+work_15379	#subject_theology								
+work_15380	#subject_theology	#subject_bible	#subject_grammar	#subject_philosophy	#subject_christian_literature				
+work_15381	#subject_law								
+work_15382	#subject_law	#subject_documents							
+work_1522	#subject_politics_and_government								
+work_1521	#subject_politics_and_government								
+work_3441	#subject_monasticism_and_religious_orders								
+work_16278	#subject_medicine								
+work_7194	#subject_history								
+work_3275	#subject_history								
+work_3276	#subject_theology								
+work_3326	#subject_philosophy								
+work_7104	#subject_bible								
+work_3279	#subject_rhetoric								
+work_3277	#subject_literature								
+work_3278	#subject_bible								
+work_7105	#subject_science								
+work_7106	#subject_theology								
+work_1671	#subject_literature	#subject_literature							
+work_15384	#subject_law								
+work_1629	#subject_literature								
+work_15385	#subject_liturgy								
+work_15386	#subject_liturgy								
+work_15387	#subject_liturgy								
+work_15388	#subject_literature								
+work_4166	#subject_history								
+work_15389	#subject_liturgy								
+work_15390	#subject_liturgy								
+work_16054	#subject_medicine								
+work_15391	#subject_medicine								
+work_15393	#subject_literature								
+work_15394	#subject_literature								
+work_4879	#subject_grammar								
+work_4556	#subject_philosophy								
+work_6599	#subject_monasticism_and_religious_orders	#subject_history							
+work_15395	#subject_grammar								
+work_15396	#subject_science								
+work_15397	#subject_literature	#subject_music							
+work_15398	#subject_literature								
+work_15399	#subject_literature								
+work_15400	#subject_liturgy								
+work_15401	#subject_liturgy								
+work_2247	#subject_classical_literature								
+work_2215	#subject_classical_literature								
+work_6117	#subject_grammar								
+work_2527	#subject_classical_literature								
+work_2528	#subject_theology								
+work_524	#subject_law								
+work_3576	#subject_law								
+work_870	#subject_law								
+work_4884	#subject_theology								
+work_2175	#subject_grammar								
+work_4301	#subject_bible								
+work_4886	#subject_law								
+work_4697	#subject_medicine								
+work_15403	#subject_literature								
+work_15406	#subject_bible								
+work_3281	#subject_politics_and_government								
+work_3280	#subject_politics_and_government								
+work_15407	#subject_literature								
+work_6366	#subject_law								
+work_6110	#subject_hagiography								
+work_4887	#subject_medicine	#subject_science							
+work_4888	#subject_medicine								
+work_4889	#subject_medicine								
+work_4890	#subject_hagiography								
+work_7126	#subject_hagiography								
+work_7129	#subject_hagiography								
+work_4891	#subject_monasticism_and_religious_orders								
+work_207	#subject_literature								
+work_7300	#subject_law								
+work_521	#subject_literature								
+work_17097	#subject_literature								
+work_15408	#subject_theology								
+work_3669	#subject_literature								
+work_5777	#subject_sermons								
+work_4892	#subject_classical_literature	#subject_history							
+work_4893	#subject_classical_literature	#subject_history							
+work_4894	#subject_classical_literature	#subject_history							
+work_4132	#subject_christian_literature								
+work_4895	#subject_medicine								
+work_2996	#subject_grammar								
+work_2047	#subject_literature								
+work_15409	#subject_documents	#subject_clergy							
+work_15410	#subject_documents	#subject_clergy							
+work_4418	#subject_politics_and_government								
+work_15411	#subject_documents								
+work_5135	#subject_literature								
+work_5136	#subject_literature								
+work_986	#subject_literature	#subject_philosophy							
+work_4896	#subject_grammar								
+work_4897	#subject_classical_literature								
+work_4898	#subject_politics_and_government								
+work_4899	#subject_politics_and_government								
+work_4900	#subject_politics_and_government								
+work_3043	#subject_hagiography	#subject_christian_literature							
+work_3070	#subject_philosophy								
+work_3040	#subject_christian_literature								
+work_3044	#subject_theology								
+work_3041	#subject_law								
+work_3042	#subject_literature								
+work_2716	#subject_philosophy								
+work_4904	#subject_rhetoric								
+work_15412	#subject_monasticism_and_religious_orders								
+work_3592	#subject_conduct								
+work_3593	#subject_literature								
+work_3594	#subject_history								
+work_3595	#subject_hagiography								
+work_3597	#subject_history								
+work_3596	#subject_literature								
+work_3512	#subject_theology								
+work_17500	#subject_literature								
+work_15414	#subject_literature								
+work_15415	#subject_literature								
+work_15417	#subject_literature								
+work_15418	#subject_literature								
+work_15419	#subject_literature								
+work_15420	#subject_literature								
+work_15421	#subject_literature	#subject_literature							
+work_15422	#subject_literature	#subject_hagiography							
+work_15423	#subject_literature								
+work_15424	#subject_literature								
+work_15425	#subject_literature	#subject_literature							
+work_15426	#subject_literature	#subject_theology							
+work_15427	#subject_literature								
+work_15428	#subject_literature								
+work_15429	#subject_literature								
+work_15430	#subject_literature								
+work_15431	#subject_literature								
+work_15432	#subject_literature								
+work_15433	#subject_literature								
+work_15434	#subject_literature								
+work_15435	#subject_literature								
+work_15437	#subject_literature	#subject_theology							
+work_15438	#subject_literature								
+work_15439	#subject_literature								
+work_15440	#subject_literature	#subject_bible							
+work_15441	#subject_history	#subject_history							
+work_15442	#subject_literature	#subject_history							
+work_15446	#subject_literature								
+work_16293	#subject_literature	#subject_history							
+work_15443	#subject_history								
+work_15444	#subject_literature	#subject_history							
+work_15445	#subject_literature	#subject_history							
+work_15447	#subject_literature	#subject_science	#subject_music						
+work_17098	#subject_literature								
+work_15448	#subject_medicine	#subject_hagiography							
+work_15449	#subject_bible	#subject_literature							
+work_15450	#subject_natural_history								
+work_15451	#subject_natural_history								
+work_4905	#subject_geography								
+work_5609	#subject_medicine								
+work_4125	#subject_history								
+work_842	#subject_history								
+work_4907	#subject_history								
+work_6309	#subject_theology								
+work_4908	#subject_classical_literature	#subject_rhetoric							
+work_5757	#subject_bible								
+work_6071	#subject_science								
+work_6070	#subject_science								
+work_16286	#subject_monasticism_and_religious_orders								
+work_4910	#subject_theology								
+work_4909	#subject_theology								
+work_4911	#subject_theology								
+work_4135	#subject_theology								
+work_1787	#subject_history								
+work_1682	#subject_history								
+work_4912	#subject_sermons								
+work_7032	#subject_politics_and_government								
+work_4914	#subject_politics_and_government								
+work_7033	#subject_philosophy								
+work_4913	#subject_history								
+work_4915	#subject_history								
+work_4916	#subject_natural_history								
+work_4917	#subject_medicine								
+work_4918	#subject_medicine								
+work_16287	#subject_bible	#subject_bible							
+work_4136	#subject_classical_literature								
+work_4138	#subject_classical_literature								
+work_6206	#subject_classical_literature								
+work_6207	#subject_classical_literature								
+work_6208	#subject_classical_literature								
+work_4137	#subject_classical_literature								
+work_5736	#subject_classical_literature								
+work_4133	#subject_classical_literature								
+work_4134	#subject_classical_literature								
+work_4919	#subject_classical_literature								
+work_4920	#subject_classical_literature								
+work_4921	#subject_classical_literature								
+work_4922	#subject_classical_literature								
+work_4925	#subject_classical_literature								
+work_17107	#subject_medicine								
+work_15452	#subject_hagiography								
+work_16173	#subject_bible								
+work_15453	#subject_theology								
+work_15454	#subject_literature	#subject_theology							
+work_15455	#subject_hagiography								
+work_15456	#subject_hagiography								
+work_15457	#subject_hagiography								
+work_15459	#subject_christian_literature								
+work_15460	#subject_bible								
+work_12823	#subject_history								
+work_15461	#subject_hagiography								
+work_16196	#subject_hagiography								
+work_15462	#subject_hagiography								
+work_15463	#subject_hagiography								
+work_15464	#subject_hagiography								
+work_15465	#subject_hagiography								
+work_15466	#subject_hagiography								
+work_16261	#subject_hagiography	#subject_monasticism_and_religious_orders							
+work_16306	#subject_hagiography	#subject_monasticism_and_religious_orders							
+work_15467	#subject_hagiography								
+work_17024	#subject_hagiography								
+work_15468	#subject_hagiography								
+work_15469	#subject_hagiography								
+work_16305	#subject_hagiography								
+work_15470	#subject_hagiography								
+work_15471	#subject_hagiography								
+work_15472	#subject_hagiography								
+work_16335	#subject_hagiography								
+work_15474	#subject_hagiography								
+work_15475	#subject_hagiography								
+work_15476	#subject_hagiography								
+work_16307	#subject_hagiography								
+work_15477	#subject_hagiography								
+work_15478	#subject_hagiography								
+work_15479	#subject_hagiography								
+work_15480	#subject_hagiography								
+work_12833	#subject_history								
+work_15482	#subject_hagiography								
+work_4926	#subject_bible								
+work_4927	#subject_literature								
+work_15483	#subject_monasticism_and_religious_orders								
+work_15484	#subject_monasticism_and_religious_orders								
+work_15485	#subject_monasticism_and_religious_orders								
+work_4928	#subject_science								
+work_4929	#subject_science								
+work_15486	#subject_grammar								
+work_16363	#subject_law								
+work_15487	#subject_grammar								
+work_15488	#subject_grammar								
+work_15489	#subject_grammar								
+work_15490	#subject_grammar								
+work_15491	#subject_grammar								
+work_15492	#subject_grammar	#subject_literature							
+work_15493	#subject_law								
+work_15494	#subject_politics_and_government								
+work_16080	#subject_liturgy								
+work_15495	#subject_liturgy								
+work_4932	#subject_hagiography								
+work_15497	#subject_documents								
+work_4933	#subject_theology								
+work_4934	#subject_hagiography								
+work_6104	#subject_hagiography								
+work_6360	#subject_hagiography								
+work_5902	#subject_science								
+work_2803	#subject_sermons	#subject_theology							
+work_2804	#subject_sermons	#subject_theology							
+work_2772	#subject_sermons								
+work_2805	#subject_sermons								
+work_4450	#subject_law	#subject_clergy							
+work_6158	#subject_sermons								
+work_4831	#subject_history								
+work_4832	#subject_history								
+work_4833	#subject_history								
+work_4834	#subject_history								
+work_4935	#subject_medicine								
+work_7391	#subject_medicine								
+work_7176	#subject_medicine								
+work_7328	#subject_medicine								
+work_4936	#subject_medicine								
+work_6598	#subject_grammar								
+work_4968	#subject_theology	#subject_theology							
+work_4976	#subject_literature	#subject_christian_literature							
+work_4969	#subject_literature								
+work_4979	#subject_literature								
+work_5608	#subject_politics_and_government								
+work_4973	#subject_theology								
+work_6423	#subject_theology								
+work_4974	#subject_theology								
+work_4970	#subject_history								
+work_4980	#subject_hagiography								
+work_15499	#subject_documents								
+work_2783	#subject_history	#subject_monasticism_and_religious_orders							
+work_2384	#subject_history								
+work_2389	#subject_history								
+work_15501	#subject_documents								
+work_15502	#subject_grammar								
+work_15503	#subject_documents								
+work_15504	#subject_history								
+work_15505	#subject_rhetoric								
+work_17127	#subject_law	#subject_history							
+work_17128	#subject_law								
+work_2444	#subject_rhetoric								
+work_6282	#subject_law								
+work_5029	#subject_geography								
+work_2785	#subject_classical_literature	#subject_history							
+work_2784	#subject_documents								
+work_6058	#subject_history								
+work_2786	#subject_theology								
+work_5030	#subject_history								
+work_4401	#subject_literature								
+work_4982	#subject_bible								
+work_15506	#subject_documents								
+work_17078	#subject_documents	#subject_history	#subject_law						
+work_15507	#subject_documents								
+work_15508	#subject_documents								
+work_15509	#subject_documents								
+work_15510	#subject_documents								
+work_15511	#subject_documents								
+work_15512	#subject_documents								
+work_15513	#subject_documents								
+work_15514	#subject_documents								
+work_15515	#subject_documents								
+work_15516	#subject_documents								
+work_5045	#subject_theology	#subject_literature							
+work_6203	#subject_theology								
+work_5559	#subject_bible								
+work_15595	#subject_bible								
+work_7051	#subject_theology								
+work_5060	#subject_grammar								
+work_5061	#subject_hagiography								
+work_4140	#subject_philosophy								
+work_5065	#subject_christian_literature								
+work_5082	#subject_theology								
+work_5089	#subject_theology								
+work_5090	#subject_christian_literature								
+work_5091	#subject_theology								
+work_7028	#subject_theology								
+work_7375	#subject_philosophy								
+work_7376	#subject_philosophy								
+work_5956	#subject_theology								
+work_5038	#subject_theology	#subject_conduct							
+work_5039	#subject_theology	#subject_monasticism_and_religious_orders	#subject_conduct						
+work_5040	#subject_theology								
+work_5041	#subject_theology								
+work_5042	#subject_theology	#subject_conduct							
+work_7195	#subject_theology								
+work_5043	#subject_theology	#subject_conduct							
+work_7378	#subject_sermons								
+work_5104	#subject_theology								
+work_7004	#subject_theology								
+work_5785	#subject_bible								
+work_5046	#subject_bible								
+work_5047	#subject_theology								
+work_5048	#subject_theology								
+work_5049	#subject_theology								
+work_5050	#subject_theology								
+work_5051	#subject_theology								
+work_5052	#subject_liturgy	#subject_theology	#subject_clergy						
+work_5053	#subject_theology								
+work_5054	#subject_theology								
+work_5055	#subject_conduct								
+work_5056	#subject_rhetoric								
+work_7426	#subject_theology								
+work_5057	#subject_theology								
+work_5064	#subject_philosophy								
+work_5062	#subject_philosophy								
+work_5063	#subject_philosophy								
+work_5068	#subject_history								
+work_7096	#subject_bible								
+work_7097	#subject_bible								
+work_7098	#subject_bible								
+work_7099	#subject_bible								
+work_5070	#subject_bible								
+work_6168	#subject_history								
+work_5071	#subject_history								
+work_5072	#subject_history								
+work_5073	#subject_history								
+work_5074	#subject_hagiography								
+work_5106	#subject_medicine								
+work_5080	#subject_conduct								
+work_5081	#subject_history								
+work_5083	#subject_philosophy								
+work_7296	#subject_philosophy								
+work_5084	#subject_philosophy								
+work_7052	#subject_liturgy	#subject_theology	#subject_clergy						
+work_7029	#subject_philosophy								
+work_7026	#subject_theology								
+work_5085	#subject_philosophy								
+work_5086	#subject_theology	#subject_theology							
+work_7141	#subject_clergy								
+work_5087	#subject_theology								
+work_5095	#subject_hagiography								
+work_5094	#subject_theology								
+work_5100	#subject_theology								
+work_5101	#subject_theology								
+work_5102	#subject_monasticism_and_religious_orders								
+work_5098	#subject_hagiography								
+work_15517	#subject_documents								
+work_15518	#subject_documents								
+work_4835	#subject_sermons								
+work_15519	#subject_documents								
+work_15520	#subject_documents								
+work_3349	#subject_theology								
+work_15521	#subject_literature								
+work_5108	#subject_science								
+work_1998	#subject_liturgy	#subject_theology	#subject_clergy						
+work_15527	#subject_grammar								
+work_15529	#subject_medicine								
+work_15530	#subject_natural_history								
+work_15531	#subject_monasticism_and_religious_orders								
+work_15532	#subject_theology								
+work_15533	#subject_history	#subject_geography							
+work_15534	#subject_grammar								
+work_15536	#subject_monasticism_and_religious_orders								
+work_15537	#subject_literature								
+work_15540	#subject_grammar								
+work_15541	#subject_grammar								
+work_15542	#subject_grammar								
+work_15543	#subject_history								
+work_17114	#subject_law								
+work_15544	#subject_documents	#subject_law							
+work_15545	#subject_documents								
+work_15546	#subject_law								
+work_6443	#subject_law								
+work_6442	#subject_clergy								
+work_6440	#subject_sermons								
+work_6441	#subject_philosophy								
+work_5109	#subject_hagiography								
+work_5741	#subject_theology								
+work_2790	#subject_theology								
+work_6231	#subject_philosophy								
+work_2787	#subject_theology								
+work_2788	#subject_theology								
+work_5742	#subject_theology								
+work_5740	#subject_politics_and_government								
+work_2789	#subject_bible								
+work_7367	#subject_sermons								
+work_15551	#subject_theology								
+work_15548	#subject_theology	#subject_sermons							
+work_15550	#subject_theology								
+work_4852	#subject_monasticism_and_religious_orders								
+work_12872	#subject_hagiography								
+work_5110	#subject_philosophy								
+work_5111	#subject_classical_literature								
+work_5112	#subject_classical_literature								
+work_5113	#subject_classical_literature								
+work_5114	#subject_classical_literature								
+work_5115	#subject_classical_literature								
+work_5116	#subject_classical_literature								
+work_5117	#subject_classical_literature								
+work_2532	#subject_sermons								
+work_17139	#subject_law								
+work_15553	#subject_law								
+work_17142	#subject_law								
+work_15554	#subject_law								
+work_17143	#subject_law								
+work_15559	#subject_law								
+work_17141	#subject_law								
+work_15555	#subject_law								
+work_15556	#subject_law								
+work_15557	#subject_law								
+work_15558	#subject_law								
+work_15560	#subject_law								
+work_15562	#subject_law								
+work_15563	#subject_law								
+work_15561	#subject_law								
+work_15564	#subject_law								
+work_15565	#subject_law								
+work_15566	#subject_law								
+work_15567	#subject_law								
+work_15568	#subject_law	#subject_documents							
+work_15569	#subject_law								
+work_2797	#subject_politics_and_government								
+work_1561	#subject_law								
+work_1562	#subject_theology								
+work_1563	#subject_theology								
+work_2920	#subject_hagiography								
+work_5118	#subject_bible								
+work_1564	#subject_literature								
+work_1593	#subject_sermons								
+work_4600	#subject_sermons								
+work_2435	#subject_law								
+work_5124	#subject_law								
+work_1511	#subject_bible								
+work_1513	#subject_bible								
+work_1514	#subject_theology								
+work_15571	#subject_science	#subject_history							
+work_5044	#subject_bible								
+work_2533	#subject_theology								
+work_49	#subject_liturgy								
+work_2798	#subject_history								
+work_2216	#subject_liturgy								
+work_3378	#subject_science								
+work_15574	#subject_grammar								
+work_15575	#subject_theology								
+work_15593	#subject_theology								
+work_15588	#subject_grammar								
+work_15577	#subject_grammar								
+work_15585	#subject_grammar								
+work_15578	#subject_grammar								
+work_15579	#subject_grammar								
+work_15580	#subject_grammar								
+work_15581	#subject_grammar								
+work_15582	#subject_grammar								
+work_15583	#subject_grammar								
+work_15584	#subject_grammar								
+work_15587	#subject_grammar								
+work_15589	#subject_theology								


### PR DESCRIPTION
This pull request contains the result of inserting new subjects from the Google doc spreadsheet into works.xml. I've re-indexed QA if you want to see the effect on the subjects facet (which still only applies to works.)

Plus I've adjusted the Schematron rules to match the use to `term` instead of `note type="subject"` and check that each `term/@ref` points to an existing `category`.

Fix for #479.