### PR TITLE
ISNI Lookup November 2021

### DIFF
--- a/places.xml
+++ b/places.xml
@@ -15,6 +15,7 @@
             <note xml:id="VL1">Elements with source attributes of "#VL1" were retrieved from VIAF by lookup-viaf-info.xsl on 2020-06-30</note>
             <note xml:id="IL1">Elements with source attributes of "#IL1" were retrieved from ISNI and added by add-from-isni.xsl on 2020-08-18</note>
             <note xml:id="IL2">Elements with source attributes of "#IL2" were retrieved from ISNI and added by add-from-isni.xsl on 2021-05-20</note>
+            <note xml:id="IL3">Elements with source attributes of "#IL3" were retrieved from ISNI and added by add-from-isni.xsl on 2021-11-08</note>
          </notesStmt>
          <sourceDesc>
             <p>Information about the source</p>
@@ -10443,7 +10444,7 @@
                      <item><ref target="http://d-nb.info/gnd/4465326-8"><title>GND</title></ref></item>
                      <item><ref target="http://viaf.org/viaf/246947660"><title>VIAF</title></ref></item>
                      <item><ref target="http://klosterdatenbank.germania-sacra.de/gsn/60437"><title>Germania Sacra</title></ref></item>
-                     <!--No match found in ISNI for VIAF ID 246947660 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 246947660 on 2021-11-08-->
                   </list></note>
             </org>
             <org xml:id="org_128563333">
@@ -10476,7 +10477,7 @@
                            <title>BNF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 313181544 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 313181544 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -10495,7 +10496,7 @@
                            <title>Germania Sacra</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 133893958 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 133893958 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -10518,7 +10519,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 159512263 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 159512263 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -10541,7 +10542,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 17149233273676510291 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 17149233273676510291 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -10559,7 +10560,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--Provisional ISNI ID as of 2021-05-20: 000000009990646X-->
+                     <!--Provisional ISNI ID as of 2021-11-08: 000000009990646X-->
                   </list>
                </note>
             </org>
@@ -10640,7 +10641,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 272891581 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 272891581 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -10663,7 +10664,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 146831170 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 146831170 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -10686,7 +10687,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 126774004 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 126774004 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -10709,7 +10710,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 139803826 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 139803826 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -10819,7 +10820,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 295127444 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 295127444 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -10836,7 +10837,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 310514352 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 310514352 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -10894,7 +10895,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 124680895 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 124680895 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -10950,7 +10951,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 159672632 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 159672632 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -10968,7 +10969,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 246264651 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 246264651 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -11022,7 +11023,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 251338225 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 251338225 on 2021-11-08-->
                   </list>
                   <!--<list type="links">
                                <item><ref target="http://viaf.org/viaf/135337488"><title>VIAF</title></ref></item>
@@ -11113,7 +11114,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 135319659 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 135319659 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -11140,7 +11141,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 247467479 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 247467479 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -11200,7 +11201,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 241899093 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 241899093 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -11270,7 +11271,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 304919952 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 304919952 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -11353,7 +11354,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 243863172 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 243863172 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -11380,7 +11381,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 49145542365096640921 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 49145542365096640921 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -11423,7 +11424,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 132571192 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 132571192 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -11450,7 +11451,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 147596326 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 147596326 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -11532,7 +11533,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 304912099 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 304912099 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -11579,7 +11580,7 @@
                            <title>LC</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 123429486 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 123429486 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -11619,7 +11620,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 270753550 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 270753550 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -11654,7 +11655,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 313198488 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 313198488 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -11690,7 +11691,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 127077483 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 127077483 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -11775,7 +11776,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 217095146 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 217095146 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -11857,7 +11858,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 235558512 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 235558512 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -11881,7 +11882,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 239193232 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 239193232 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -11994,7 +11995,6 @@
                            <title>BNF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 148943477 on 2021-05-20-->
                      <item source="#IL2"><ref target="http://www.isni.org/isni/0000000099504209"><title>ISNI</title></ref></item>
                   </list>
                </note>
@@ -12017,7 +12017,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 292385856 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 292385856 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -12222,8 +12222,8 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 151430091 on 2021-05-20-->
-                     <!--No match found in ISNI for VIAF ID 202396473 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 151430091 on 2021-11-08-->
+                     <!--No match found in ISNI for VIAF ID 202396473 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -12356,7 +12356,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 313492968 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 313492968 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -12384,7 +12384,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 129471242 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 129471242 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -12462,7 +12462,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 129279786 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 129279786 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -12541,7 +12541,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 148042626 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 148042626 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -12581,7 +12581,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 172327788 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 172327788 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -12624,8 +12624,8 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 143145136 on 2021-05-20-->
-                     <!--No match found in ISNI for VIAF ID 173026705 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 143145136 on 2021-11-08-->
+                     <!--No match found in ISNI for VIAF ID 173026705 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -12654,7 +12654,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 155912077 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 155912077 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -12675,7 +12675,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 313493631 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 313493631 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -12711,7 +12711,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 205808165 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 205808165 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -12787,7 +12787,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 145388823 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 145388823 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -12807,7 +12807,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 134950157 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 134950157 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -12857,7 +12857,7 @@
                                     <title>Wikidata</title>
                                 </ref> this entry is odd
                             </item>-->
-                     <!--No match found in ISNI for VIAF ID 138242961 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 138242961 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -12895,7 +12895,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--Provisional ISNI ID as of 2021-05-20: 000000009111357X-->
+                     <!--Provisional ISNI ID as of 2021-11-08: 000000009111357X-->
                   </list>
                </note>
             </org>
@@ -12915,7 +12915,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 144397095 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 144397095 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -13068,7 +13068,7 @@
                            <title>BNF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 211447911 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 211447911 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -13097,7 +13097,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 315944440 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 315944440 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -13154,7 +13154,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 124540557 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 124540557 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -13180,7 +13180,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 147036231 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 147036231 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -13311,7 +13311,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 146807988 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 146807988 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -13330,7 +13330,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 126774688 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 126774688 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -13576,7 +13576,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 246265108 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 246265108 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -13619,7 +13619,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 125552867 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 125552867 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -13775,7 +13775,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 131409984 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 131409984 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -13791,7 +13791,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 138814996 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 138814996 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -13808,7 +13808,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 126047237 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 126047237 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -13854,9 +13854,9 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 415145858126223022295 on 2021-05-20-->
-                     <!--No match found in ISNI for VIAF ID 213945938 on 2021-05-20-->
-                     <!--No match found in ISNI for VIAF ID 141918870 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 415145858126223022295 on 2021-11-08-->
+                     <!--No match found in ISNI for VIAF ID 213945938 on 2021-11-08-->
+                     <!--No match found in ISNI for VIAF ID 141918870 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -13949,7 +13949,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 245287151 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 245287151 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -14010,7 +14010,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 129065993 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 129065993 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -14033,7 +14033,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 145804112 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 145804112 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -14058,7 +14058,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 243886719 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 243886719 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -14084,7 +14084,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 240542197 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 240542197 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -14112,7 +14112,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 245037741 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 245037741 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -14141,7 +14141,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 173532247 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 173532247 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -14205,7 +14205,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 173408842 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 173408842 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -14281,7 +14281,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 126666939 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 126666939 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -14351,7 +14351,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 241197056 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 241197056 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -14418,7 +14418,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 123624907 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 123624907 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -14482,7 +14482,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 123184663 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 123184663 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -14504,7 +14504,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 129111728 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 129111728 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -14557,7 +14557,7 @@
                            <title>Germania Sacra</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 135038090 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 135038090 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -14689,7 +14689,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 153715381 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 153715381 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -14717,7 +14717,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 172374812 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 172374812 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -14739,7 +14739,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 232929480 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 232929480 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -14771,7 +14771,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 249304112 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 249304112 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -14803,7 +14803,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 131824444 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 131824444 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -14858,7 +14858,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 247412105 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 247412105 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -14888,7 +14888,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 169654564 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 169654564 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -14909,7 +14909,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 154915206 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 154915206 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -14940,7 +14940,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 145941484 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 145941484 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -14961,7 +14961,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 316390117 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 316390117 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -14985,7 +14985,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 153848390 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 153848390 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -15011,7 +15011,7 @@
                      </item>
                      <!-- note that both these entries stricly relate to the church building rather than
                             the religous organization-->
-                     <!--No match found in ISNI for VIAF ID 238824653 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 238824653 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -15030,7 +15030,7 @@
                            <title>LC</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 143202638 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 143202638 on 2021-11-08-->
                   </list>
                   <list type="links">
                      <item>
@@ -15043,7 +15043,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 143202638 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 143202638 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -15078,7 +15078,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 315687992 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 315687992 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -15098,7 +15098,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 315686151 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 315686151 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -15136,7 +15136,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 168089114 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 168089114 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -15164,7 +15164,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 128793507 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 128793507 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -15194,7 +15194,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 313533333 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 313533333 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -15215,7 +15215,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--Provisional ISNI ID as of 2021-05-20: 0000000101296702-->
+                     <!--Provisional ISNI ID as of 2021-11-08: 0000000101296702-->
                   </list>
                </note>
             </org>
@@ -15235,7 +15235,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 310513586 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 310513586 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -15259,7 +15259,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 152531224 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 152531224 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -15287,7 +15287,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 159581566 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 159581566 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -15362,7 +15362,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 153760063 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 153760063 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -15387,7 +15387,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 140865145 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 140865145 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -15417,7 +15417,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 136179651 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 136179651 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -15457,7 +15457,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 135058831 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 135058831 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -15493,7 +15493,6 @@
                         </ref>
                      </item>
                      <item source="#IL2"><ref target="http://www.isni.org/isni/0000000123648457"><title>ISNI</title></ref></item>
-                     <!--No match found in ISNI for VIAF ID 156148995743759750417 on 2021-05-20-->
                   </list>
                </note>
             </org>
@@ -15571,7 +15570,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 139688379 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 139688379 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -15793,7 +15792,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 371144782732650928555 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 371144782732650928555 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -15821,7 +15820,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 128177579 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 128177579 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -15872,7 +15871,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 123537181 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 123537181 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -15932,7 +15931,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 158596637 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 158596637 on 2021-11-08-->
                   </list>
                </note>
                <bibl>Knowles &amp; Hadcock, pp. 112, 116</bibl>
@@ -16017,7 +16016,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 145707239 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 145707239 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -16045,7 +16044,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 140811075 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 140811075 on 2021-11-08-->
                   </list>
                </note>
                <note>Coordinates for the settlement of Trois-Fontaines, from the <ref target="http://www.getty.edu/research/tools/vocabularies/tgn/">Getty Thesaurus of Geographic Names</ref>, copyright 2017 the J. Paul Getty Trust, released under the <ref target="https://opendatacommons.org/licenses/by/1-0/">Open Data Commons Attribution License (ODC-By) 1.0</ref>.</note>
@@ -16069,7 +16068,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 294361980 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 294361980 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -16097,7 +16096,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 125513925 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 125513925 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -16171,7 +16170,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--Provisional ISNI ID as of 2021-05-20: 0000000091809403-->
+                     <!--Provisional ISNI ID as of 2021-11-08: 0000000091809403-->
                   </list>
                </note>
             </org>
@@ -16191,7 +16190,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 2142145857037522921207 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 2142145857037522921207 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -16215,7 +16214,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--Provisional ISNI ID as of 2021-05-20: 0000000090867249-->
+                     <!--Provisional ISNI ID as of 2021-11-08: 0000000090867249-->
                   </list>
                </note>
             </org>
@@ -16238,7 +16237,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 149286387 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 149286387 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -16361,7 +16360,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 148998848 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 148998848 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -16437,7 +16436,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 158720589 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 158720589 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -16493,7 +16492,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--Provisional ISNI ID as of 2021-05-20: 0000000085705202-->
+                     <!--Provisional ISNI ID as of 2021-11-08: 0000000085705202-->
                   </list>
                </note>
             </org>
@@ -16511,7 +16510,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 260127654 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 260127654 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -16602,7 +16601,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 442146997389818892504 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 442146997389818892504 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -16632,7 +16631,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 269197839 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 269197839 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -16655,7 +16654,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 124759589 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 124759589 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -16776,7 +16775,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 134946326 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 134946326 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -16804,7 +16803,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 313533276 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 313533276 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -16832,7 +16831,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 163769115 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 163769115 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -16862,7 +16861,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--Provisional ISNI ID as of 2021-05-20: 0000000123536244-->
+                     <!--Provisional ISNI ID as of 2021-11-08: 0000000123536244-->
                   </list>
                </note>
             </org>
@@ -16892,7 +16891,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 244595494 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 244595494 on 2021-11-08-->
                   </list>
                </note>
                <note type="source">Co-ordinates (for the island of Reichenau) from the <ref target="http://www.getty.edu/research/tools/vocabularies/tgn/">Getty Thesaurus of Geographic Names</ref>, copyright 2017 the J. Paul Getty Trust, released under the <ref target="https://opendatacommons.org/licenses/by/1-0/">Open Data Commons Attribution License (ODC-By) 1.0</ref>.</note>
@@ -16993,7 +16992,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 27148207842000341517 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 27148207842000341517 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -17024,7 +17023,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 152458362 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 152458362 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -17061,7 +17060,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 313222993 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 313222993 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -17133,7 +17132,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 135326103 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 135326103 on 2021-11-08-->
                   </list>
                </note>
                <!-- check the date? -->
@@ -17190,7 +17189,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 146685036 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 146685036 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -17222,7 +17221,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 132688628 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 132688628 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -17248,7 +17247,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 311465280 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 311465280 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -17281,7 +17280,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 144471224 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 144471224 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -17299,7 +17298,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 154868239 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 154868239 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -17317,7 +17316,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 127113314 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 127113314 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -17350,7 +17349,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 305126922 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 305126922 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -17392,7 +17391,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 152509582 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 152509582 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -17493,7 +17492,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 145549427 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 145549427 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -17511,7 +17510,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 145675476 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 145675476 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -17532,7 +17531,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 234338663 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 234338663 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -17565,7 +17564,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 136115337 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 136115337 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -17593,7 +17592,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--Provisional ISNI ID as of 2021-05-20: 0000000112766482-->
+                     <!--Provisional ISNI ID as of 2021-11-08: 0000000112766482-->
                   </list>
                </note>
             </org>
@@ -17616,7 +17615,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 124391636 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 124391636 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -17636,7 +17635,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 151723892 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 151723892 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -17664,7 +17663,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 142329853 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 142329853 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -17729,7 +17728,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 126805565 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 126805565 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -17809,7 +17808,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 239220402 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 239220402 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -17845,7 +17844,7 @@
                            <title>LC</title>
                         </ref>
                      </item>
-                     <!--Provisional ISNI ID as of 2021-05-20: 0000000090603892-->
+                     <!--Provisional ISNI ID as of 2021-11-08: 0000000090603892-->
                   </list>
                </note>
             </org>
@@ -17868,7 +17867,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 139886776 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 139886776 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -17886,7 +17885,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 119144647640953754712 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 119144647640953754712 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -17942,7 +17941,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 242823650 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 242823650 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -17960,7 +17959,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 267912669 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 267912669 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -17983,7 +17982,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 258918407 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 258918407 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -18007,7 +18006,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 248915895 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 248915895 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -18072,7 +18071,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 132788727 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 132788727 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -18090,7 +18089,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 175175470 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 175175470 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -18108,7 +18107,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 156111581 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 156111581 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -18260,7 +18259,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 156265118 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 156265118 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -18278,7 +18277,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 159826695 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 159826695 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -18347,7 +18346,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 244228863 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 244228863 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -18375,7 +18374,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 141420298 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 141420298 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -18466,7 +18465,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 133706555 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 133706555 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -18488,7 +18487,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 139999868 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 139999868 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -18519,7 +18518,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 267407979 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 267407979 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -18549,7 +18548,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 150071244 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 150071244 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -18585,7 +18584,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 157558711 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 157558711 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -18666,7 +18665,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 308185589 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 308185589 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -18711,8 +18710,8 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 248254900 on 2021-05-20-->
-                     <!--No match found in ISNI for VIAF ID 144687938 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 248254900 on 2021-11-08-->
+                     <!--No match found in ISNI for VIAF ID 144687938 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -18773,7 +18772,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 134239581 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 134239581 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -18794,7 +18793,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 240554317 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 240554317 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -18837,7 +18836,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--Provisional ISNI ID as of 2021-05-20: 0000000098746337-->
+                     <!--Provisional ISNI ID as of 2021-11-08: 0000000098746337-->
                   </list>
                </note>
             </org>
@@ -18950,7 +18949,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 140943552 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 140943552 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -18974,7 +18973,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 126334887 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 126334887 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -19003,7 +19002,7 @@
                            <title>LC</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 146323850 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 146323850 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -19029,7 +19028,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 152797746 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 152797746 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -19052,7 +19051,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 235700069 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 235700069 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -19093,7 +19092,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 156374852 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 156374852 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -19121,7 +19120,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 144600874 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 144600874 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -19154,7 +19153,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 242730887 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 242730887 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -19261,7 +19260,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 160939265 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 160939265 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -19283,7 +19282,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 125752208 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 125752208 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -19320,7 +19319,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 150190778 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 150190778 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -19448,8 +19447,8 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 175619750 on 2021-05-20-->
-                     <!--No match found in ISNI for VIAF ID 125561252 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 175619750 on 2021-11-08-->
+                     <!--No match found in ISNI for VIAF ID 125561252 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -19470,7 +19469,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 295377124 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 295377124 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -19492,7 +19491,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 147818232 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 147818232 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -19521,7 +19520,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 263208235 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 263208235 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -19605,7 +19604,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 295820821 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 295820821 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -19637,7 +19636,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 317069910 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 317069910 on 2021-11-08-->
                   </list>
                </note>
                <bibl>Cottineau II, col. 3062</bibl>
@@ -19716,7 +19715,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 145597689 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 145597689 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -19760,7 +19759,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 150912735 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 150912735 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -19792,7 +19791,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 150552322 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 150552322 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -19913,7 +19912,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--Provisional ISNI ID as of 2021-05-20: 0000000086396157-->
+                     <!--Provisional ISNI ID as of 2021-11-08: 0000000086396157-->
                   </list>
                </note>
             </org>
@@ -19988,7 +19987,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 240561051 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 240561051 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -20019,7 +20018,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 123233264 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 123233264 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -20060,7 +20059,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 212968081 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 212968081 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -20088,7 +20087,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 141000452 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 141000452 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -20104,7 +20103,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 254121248 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 254121248 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -20120,7 +20119,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 254633607 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 254633607 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -20187,7 +20186,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 266189883 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 266189883 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -20220,7 +20219,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 157389164 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 157389164 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -20240,7 +20239,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 250806462 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 250806462 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -20261,7 +20260,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 223669083 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 223669083 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -20288,7 +20287,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 254016085 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 254016085 on 2021-11-08-->
                   </list>
                </note>
                <!-- NB several apparent entries in VIAF not merged -->
@@ -20334,7 +20333,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 208896312 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 208896312 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -20408,7 +20407,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 158357258 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 158357258 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -20481,7 +20480,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 310746171 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 310746171 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -20544,7 +20543,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 128317513 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 128317513 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -20564,7 +20563,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 234315879 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 234315879 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -20585,7 +20584,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 145653569 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 145653569 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -20605,7 +20604,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 243910020 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 243910020 on 2021-11-08-->
                   </list>
                </note>
                <!-- not in cottineau -->
@@ -20654,7 +20653,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 138342928 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 138342928 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -20675,7 +20674,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 243166021 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 243166021 on 2021-11-08-->
                   </list>
                </note>
                <bibl>Knowles &amp; Hadcock, pp. 419, 443</bibl>
@@ -20696,7 +20695,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 1115145857069622921436 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 1115145857069622921436 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -20727,7 +20726,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 135655543 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 135655543 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -20756,7 +20755,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 266852074 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 266852074 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -20797,7 +20796,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 173376610 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 173376610 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -20821,7 +20820,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 240145542525596640761 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 240145542525596640761 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -20872,7 +20871,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 138512183 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 138512183 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -20903,7 +20902,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 246948936 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 246948936 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -20924,7 +20923,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 157113813 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 157113813 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -20977,7 +20976,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 125940881 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 125940881 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -21007,7 +21006,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 123598658 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 123598658 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -21085,7 +21084,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 312805416 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 312805416 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -21114,7 +21113,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 148097195 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 148097195 on 2021-11-08-->
                   </list>
                </note>
                <note>Co-ordinates from Wikipedia.</note>
@@ -21155,7 +21154,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 245815193 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 245815193 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -21208,7 +21207,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 126802421 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 126802421 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -21232,7 +21231,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 139637930 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 139637930 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -21269,7 +21268,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 139922418 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 139922418 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -21345,7 +21344,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 264519246 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 264519246 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -21388,7 +21387,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 136144523 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 136144523 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -21434,8 +21433,8 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 211935376 on 2021-05-20-->
-                     <!--No match found in ISNI for VIAF ID 158676805 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 211935376 on 2021-11-08-->
+                     <!--No match found in ISNI for VIAF ID 158676805 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -21502,7 +21501,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 237710601 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 237710601 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -21534,7 +21533,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--Provisional ISNI ID as of 2021-05-20: 0000000105366763-->
+                     <!--Provisional ISNI ID as of 2021-11-08: 0000000105366763-->
                   </list>
                </note>
             </org>
@@ -21565,7 +21564,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 298413710 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 298413710 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -21671,7 +21670,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 240455434 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 240455434 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -21698,7 +21697,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 198876802 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 198876802 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -21725,7 +21724,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 23151110643437060950 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 23151110643437060950 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -21749,7 +21748,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 239003182 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 239003182 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -21799,7 +21798,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 271051505 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 271051505 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -21844,7 +21843,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 152906198 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 152906198 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -21862,7 +21861,7 @@
                            <title>LC</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 132676429 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 132676429 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -21885,7 +21884,7 @@
                            <title>GND</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 308748070 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 308748070 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -21909,7 +21908,7 @@
                            <title>Wikidata</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 268217466 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 268217466 on 2021-11-08-->
                   </list>
                </note>
             </org>
@@ -21928,7 +21927,7 @@
                            <title>VIAF</title>
                         </ref>
                      </item>
-                     <!--No match found in ISNI for VIAF ID 124309014 on 2021-05-20-->
+                     <!--No match found in ISNI for VIAF ID 124309014 on 2021-11-08-->
                   </list>
                </note>
             </org>


### PR DESCRIPTION
I have queried the ISNI API for all the VIAF IDs of people and organizations in the Medieval authority files which have a VIAF ID but not an ISNI.

Only a few new "assigned" ISNIs were found. None of the "provisional" ones from last time seem to have been approved, or deleted. Some comments recording new provisional ones were added, but these are presumably for entries added to the authority files since the last time (in May.)

There are currently 3961 potential candidates for submission to ISNI.