### PR TITLE
Add facsimile links 2022 01 05

### DIFF
--- a/collections/Auct_D/MS_Auct_D_5_5.xml
+++ b/collections/Auct_D/MS_Auct_D_5_5.xml
@@ -66,6 +66,12 @@
                         </source>
                      </recordHist>
                   </adminInfo>
+                  <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/objects/fe1a61f6-555e-4c34-a049-1dd3c83d7837/">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>                     
+                     </bibl>
+                  </surrogates>
                </additional>
                <msPart xml:id="MS_Auct_D_5_5-part1">
                   <msIdentifier>

--- a/collections/Lat_bib/MS_Lat_bib_d_11.xml
+++ b/collections/Lat_bib/MS_Lat_bib_d_11.xml
@@ -157,6 +157,12 @@
                         <source>Description by Laura Light (2015) for Les Enluminures; revised by Andrew Dunning (July 2021).</source>
                      </recordHist>
                   </adminInfo>
+                  <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/objects/ca509624-5107-4486-83a3-d160d57ae64a/">
+                           <title>Digital Bodleian</title></ref> <note>(full digital facsimile)</note>                     
+                     </bibl>
+                  </surrogates>
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>


### PR DESCRIPTION
Add Digital Bodleian facsimile links for MS. Lat. bib. d. 11 and MS. Auct. D. 5. 5.