### PR TITLE
University College manuscripts

### DIFF
--- a/collections/University_College/University_College_MS_10.xml
+++ b/collections/University_College/University_College_MS_10.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13006">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 10</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_10</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_10">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 10</idno>
+               </msIdentifier>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <p>Composite manuscript in 2 parts</p>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>18th-century calf gilt (lacking clasps)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1500" notAfter="1525">s. XVIin.</origDate>
+                     <origPlace>
+                        <country key="place_1000070">France</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>Printed in Paris by Philippe Pigouchet. Made for Guillaume Eustace, 15 June 1508. "olim Margaretæ Gallot." (Coxe) Note at f. 127 reads, 'Ce present livre appartient a Marguerite Gallot'.</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=22">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 4</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+               <msPart xml:id="University_College_MS_10-part1" n="1">
+                  <msIdentifier>
+                     <altIdentifier type="partial">
+                        <idno type="part">University College MS. 10 - Part 1</idno>
+                     </altIdentifier>
+                  </msIdentifier>
+                  <msContents>
+                     <msItem xml:id="University_College_MS_10-part1-item1" n="1">
+                        <title>Book of Hours, Use of Rome</title>
+                        <!--Possible work keys: work_10556 or work_10557 or work_10558 or work_10559 or work_10560 or work_10563 or work_10561 or work_10562 or work_10565-->
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                  </msContents>
+                  <physDesc>
+                     <objectDesc/>
+                  </physDesc>
+                  <history>
+                     <origin>
+                        <p>No date</p>
+                     </origin>
+                  </history>
+               </msPart>
+               <msPart xml:id="University_College_MS_10-part2" n="2">
+                  <msIdentifier>
+                     <altIdentifier type="partial">
+                        <idno type="part">University College MS. 10 - Part 2</idno>
+                     </altIdentifier>
+                  </msIdentifier>
+                  <msContents>
+                     <msItem xml:id="University_College_MS_10-part2-item1" n="1">
+                        <title>Les vepres de la sepmaine, avec complies, les hymnes, et proses de l'année</title>
+                        <textLang mainLang="la" otherLangs="fr">Latin ; French</textLang>
+                     </msItem>
+                  </msContents>
+                  <physDesc>
+                     <objectDesc/>
+                  </physDesc>
+                  <history>
+                     <origin>
+                        <p>No date</p>
+                     </origin>
+                  </history>
+               </msPart>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_100.xml
+++ b/collections/University_College/University_College_MS_100.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13081">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 100</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_100</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_100">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 100</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_100-item1" n="1">
+                     <title>Apocalypse of John</title>
+                     <textLang mainLang="fr">French</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_100-item2" n="2">
+                     <title>Carmen de vita et morte B. Mariæ Virginis</title>
+                     <textLang mainLang="fr">French</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Flourish initials. "Good miniatures (mainly coloured drawings). Good penwork initials." (IMOCL)</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Medieval trimmed chemise of white doeskin over wooden boards to page edges, strap.</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1250" notAfter="1300">s. XIIIex.</origDate>
+                  </origin>
+                  <provenance>"ex dono Gul. Rogers de Painswyck." (Coxe) "Given in 1669 by William Rogers of Painswyck, commoner, fols. 1, 98." (IMOCL)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=48">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 30</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 259 [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+                  <surrogates>
+                     <bibl type="digital-facsimile" subtype="full">
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/394b289e-2d1b-43b1-ba3c-d1c954c690de">
+                           <title>Digital Bodleian</title>
+                        </ref>
+                        <note>(full digital facsimile)</note>
+                     </bibl>
+                  </surrogates>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_101.xml
+++ b/collections/University_College/University_College_MS_101.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13082">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 101</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_101</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_101">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 101</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_101-item1" n="1">
+                     <title>Breviary (Cluny) with additional texts</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>17th- or 18th-century limp vellum</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1150" notAfter="1200">s. XIIex.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>; Monk Bretton; Pontefract</origPlace>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=48">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 30</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_102.xml
+++ b/collections/University_College/University_College_MS_102.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13083">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 102</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_102</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_102">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 102</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_102-item1" n="1">
+                     <author key="person_10428840">Mirk, John, active 1403?</author>
+                     <title>Festial (temporal section with two additional sermons)</title>
+                     <textLang mainLang="enm">Middle English</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="paper">
+                        <support>paper</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Initials touched red.</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary pink-stained leather (lacking clasp and catch)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=49">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 31</ref>
+                              </bibl>
+                              <bibl>
+                                 <title>IMEP</title>, p. 112-9</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_104.xml
+++ b/collections/University_College/University_College_MS_104.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13084">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 104</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_104</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_104">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 104</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_104-item1" n="1">
+                     <author key="person_54299000">Julian of Toledo, 0642?-0690</author>
+                     <title>Prognosticon futuri sæculi</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Green and red initials</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Original wooden boards and tabs at spine, early rebacking in tawed skin</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1000" notAfter="1100">s. XI</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>; Battle Abbey</origPlace>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=49">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 31</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_106.xml
+++ b/collections/University_College/University_College_MS_106.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13085">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 106</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_106</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_106">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 106</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_106-item1" n="1">
+                     <title>Pocket Bible (with the Prologues of St Jerome)</title>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Decorated, flourish initials throughout.</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Calf with gilt lettering (recording donation by William Percyval of Shenley in 1616)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1300" notAfter="1400">s. XIV</origDate>
+                  </origin>
+                  <provenance>"ex dono Gulielmi Percyval, de Shenlye, co. Buckingham. 1616." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=50">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 32</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_107.xml
+++ b/collections/University_College/University_College_MS_107.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13086">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 107</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_107</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_107">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 107</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_107-item1" n="1">
+                     <title>Statuta Angliæ</title>
+                     <textLang mainLang="la" otherLangs="fr">Latin and French</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>17th-century</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1300" notAfter="1400">s. XIV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>Thomas Parlysh (s. XVI) fol. 168 (DHC)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=50">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 32</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_108.xml
+++ b/collections/University_College/University_College_MS_108.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13087">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 108</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_108</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_108">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 108</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_108-item1" n="1">
+                     <author>Ogilvy of Boyne</author>
+                     <title>Cartulary</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="paper">
+                        <support>paper</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Original limp vellum with monogram "OB" on upper cover.</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1500" notAfter="1600">s. XVI</origDate>
+                     <origPlace>
+                        <country key="place_7002444">Scotland</country>
+                     </origPlace>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=50">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 32</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_109.xml
+++ b/collections/University_College/University_College_MS_109.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13088">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 109</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_109</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_109">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 109</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_109-item1" n="1">
+                     <author key="person_100198644">Jacobus, de Voragine, approximately 1229-1298</author>
+                     <title>Sermons</title>
+                     <!--Possible work keys: work_6226 or work_6215 or work_6157 or work_6101 or work_1465 or work_1467 or work_3263 or work_3372 or work_1846 or work_1068 or work_2194 or work_1899 or work_3540 or work_550 or work_3999 or work_4873 or work_3261 or work_1937 or work_2310 or work_1299 or work_3358 or work_3580 or work_3020 or work_2674 or work_2675 or work_3236 or work_1302 or work_1081 or work_2567 or work_3369 or work_4557 or work_3511 or work_1431 or work_1660 or work_4256 or work_2695 or work_1054 or work_3485 or work_1760 or work_3284 or work_1745 or work_403 or work_3907 or work_2172 or work_1309 or work_4384 or work_3147 or work_3148 or work_2142 or work_1423 or work_4600 or work_2939 or work_2942 or work_14583-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_109-item2" n="2">
+                     <author key="person_297475745">John Chrysostom, Saint, -407</author>
+                     <title>De compunctione cordis</title>
+                     <!--Possible work keys: work_2647-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_109-item3" n="3">
+                     <author key="person_297475745">John Chrysostom, Saint, -407</author>
+                     <title>De reparatione lapsi</title>
+                     <!--Possible work keys: work_2653-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_109-item4" n="4">
+                     <author key="person_297475745">John Chrysostom, Saint, -407</author>
+                     <title>Quod nemo læditur nisi Seipso</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_109-item5" n="5">
+                     <author>Grossteste, Robert, 1175?-1253</author>
+                     <title>Liber de confessione</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_109-item6" n="6">
+                     <author key="person_66806872">Augustine, Saint, Bishop of Hippo</author>
+                     <title>De vera et falsa pœnitentia</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_109-item7" n="7">
+                     <author key="person_66806872">Augustine, Saint, Bishop of Hippo</author>
+                     <title>De septem peccatis mortalibus &amp; De quinque sensibus</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Flourish initials in red and blue.</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary white leather over wooden boards</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim Thomæ Raynes, postea Ricardi Gosmore, deinde Thomæ Browne et denique coll. Univ. ex dono Thomæ Walker, magistri." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=51">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 33</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_11.xml
+++ b/collections/University_College/University_College_MS_11.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13007">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 11</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_11</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_11">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 11</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_11-item1" n="1">
+                     <title>Axiomata e jure civili præcipue collecta</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_11-item2" n="2">
+                     <title>Tabula contentorum secundæ partis Codicis</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_11-item3" n="3">
+                     <title>Axiomata philosophica juridicialia</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_11-item4" n="4">
+                     <title>Notabilia theologica</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_11-item5" n="5">
+                     <author key="person_2583890">Alexander, de Villa Dei</author>
+                     <title>Summarium Bibliæ</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_11-item6" n="6">
+                     <title>Tituli dierum Dominicalium</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_11-item7" n="7">
+                     <title>Versus ordinem SS. Bibliorum (taken from Genesis, Exodus, Leviticus, Numbers, Deuteronomy, Joshua, Judges, Ruth, and Kings).</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary brown leather over wooden boards</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1475" notAfter="1500">s. XVex.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=22">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 4</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_110.xml
+++ b/collections/University_College/University_College_MS_110.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13089">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 110</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_110</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_110">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 110</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_110-item1" n="1">
+                     <author key="person_120697851">Duns Scotus, Johannes, 1265-1308</author>
+                     <title>Quæstiones quodlibetales</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Flourish initials. Written M.J. Goold (Coxe, f. 134).</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>15th-century panelled calf, tooled, includes rabbit, agnus dei, dog and bird (restored)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim Galfridi Burdon." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=51">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 33</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_112.xml
+++ b/collections/University_College/University_College_MS_112.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13090">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 112</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_112</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_112">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 112</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_112-item1" n="1">
+                     <author key="person_40175167">Petrus, Comestor, active 12th century</author>
+                     <title>Historia Scholastica</title>
+                     <!--Possible work keys: work_3495-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Illuminated."Fine historiated and other initials. Good penwork initials." (IMOCL)</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>14th-century doeskin over wooden boards to text block, parallel raised bands.</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1200" notAfter="1250">s. XIIIin.</origDate>
+                     <origPlace>
+                        <country key="place_1000070">France.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"The will of Stephanus atte Roche, vicar of Fen Ditton, Cambs., 1381, formerly lining the upper cover of the binding, is now University College MS. 192, fol. 29." (IMOCL)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 655 [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_113.xml
+++ b/collections/University_College/University_College_MS_113.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13091">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 113</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_113</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_113">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 113</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_113-item1" n="1">
+                     <author key="person_51797933">Peter Lombard, Bishop of Paris, approximately 1100-1160</author>
+                     <title>Sentences</title>
+                     <!--Possible work keys: work_6593 or work_3510 or work_2268-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_113-item2" n="2">
+                     <author key="person_2070">Hugolinus de Urbe Veteri (c. 1380-c. 1457)</author>
+                     <title>Distinctiones</title>
+                     <!--Possible work keys: work_2626 or work_1086 or work_3616 or work_3549 or work_11564-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Loose in cardboard.</p>
+                     </binding>
+                  </bindingDesc>
+                  <accMat>List of contents in hand of Obadiah Walker.</accMat>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1200" notAfter="1300">s. XIII</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>; Dominican convent, <placeName key="place_7010350"> Beverley</placeName>
+                     </origPlace>
+                  </origin>
+                  <provenance>England. Beverley Dominicans (Ker). "olim ecclesiæ S. Mariæ Rievallensis, ex dono, ut videtur, Johannis de Elyngton, postea C. Hyldyard." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=52">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 34</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_114.xml
+++ b/collections/University_College/University_College_MS_114.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13092">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 114</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_114</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_114">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 114</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_114-item1" n="1">
+                     <author>Priscian</author>
+                     <title>Institutiones grammaticæ</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Opening initial in magenta with red flowerheads and green cusped leaves.</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>White leather over bevelled wooden boards.</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=52">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 34</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_115.xml
+++ b/collections/University_College/University_College_MS_115.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13093">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 115</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_115</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_115">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 115</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_115-item1" n="1">
+                     <title>Old Testament (containing Pentateuch, Joshua, Judges, Ruth, Kings, Isaiah, fragments of Jeremiah, Prologues of St Jerome)</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>"Fine and other initials (unfinished)." (IMOCL)</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Uncovered boards. "The first two quaternions of Deuteronomy may have been transposed in binding." (DHC)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1100" notAfter="1200">s. XII</origDate>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=52">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 34</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 85 [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_116.xml
+++ b/collections/University_College/University_College_MS_116.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13094">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 116</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_116</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_116">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 116</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_116-item1" n="1">
+                     <title>Old Testament</title>
+                     <!--Possible work keys: work_13610 or work_13611-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_116-item2" n="2">
+                     <title>New Testatment (with Prologues of St Jerome)</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Puzzle initials, penwork borders, manicules and faces in the margins. "Fine penwork borders, initials. Marginal scribbes [sic.]." (IMOCL)</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Uncovered board, rebacked. Foredge painting.</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1250" notAfter="1300">s. XIIIex.</origDate>
+                  </origin>
+                  <provenance>"olim Willelmi Wharton, postea Johannis Thorgott." (Coxe) "List of sermon subjects for the use of an order of Preachers, p. 306. John Thorgott, saec. xvi, pp. 1, 396." (IMOCL)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=52">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 34</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 237 [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_117.xml
+++ b/collections/University_College/University_College_MS_117.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13095">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 117</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_117</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_117">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 117</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_117-item1" n="1">
+                     <author key="person_66806872">Augustine, Saint, Bishop of Hippo</author>
+                     <title>Various works</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>19th-century half morocco</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1150" notAfter="1250">s. XIIex. or XIIIin.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim liber eccl. S. Augustini Cantuar." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=53">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 35</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_118.xml
+++ b/collections/University_College/University_College_MS_118.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13096">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 118</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_118</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_118">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 118</idno>
+               </msIdentifier>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <p>Composite manuscript in 2 parts</p>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>16th-century panelled calf ruled and roll tooled in blind (rebacked and restored)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1100" notAfter="1300">1100–1300</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim Willelmi Parkhous, postea coll. Univ. ex dono Tho. Walker, magistri." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=53">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 35</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+               <msPart xml:id="University_College_MS_118-part1" n="1">
+                  <msIdentifier>
+                     <altIdentifier type="partial">
+                        <idno type="part">University College MS. 118 - Part 1</idno>
+                     </altIdentifier>
+                  </msIdentifier>
+                  <msContents>
+                     <msItem xml:id="University_College_MS_118-part1-item1" n="1">
+                        <author key="person_803890">Isidore, of Seville, Saint -636</author>
+                        <title>Etymologiæ</title>
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                  </msContents>
+                  <physDesc>
+                     <objectDesc/>
+                  </physDesc>
+                  <history>
+                     <origin>
+                        <origDate calendar="Gregorian">s. XII</origDate>
+                     </origin>
+                  </history>
+               </msPart>
+               <msPart xml:id="University_College_MS_118-part2" n="2">
+                  <msIdentifier>
+                     <altIdentifier type="partial">
+                        <idno type="part">University College MS. 118 - Part 2</idno>
+                     </altIdentifier>
+                  </msIdentifier>
+                  <msContents>
+                     <msItem xml:id="University_College_MS_118-part2-item1" n="1">
+                        <author key="person_89770781">Avicenna, 980-1037</author>
+                        <title>Practica</title>
+                        <!--Possible work keys: work_629 or work_1934 or work_185 or work_2589 or work_2239 or work_4453 or work_5059 or work_419 or work_2614 or work_5096-->
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                  </msContents>
+                  <physDesc>
+                     <objectDesc/>
+                  </physDesc>
+                  <history>
+                     <origin>
+                        <origDate calendar="Gregorian">s. XIII</origDate>
+                     </origin>
+                  </history>
+               </msPart>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_119.xml
+++ b/collections/University_College/University_College_MS_119.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13097">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 119</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_119</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_119">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 119</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_119-item1" n="1">
+                     <author key="person_21990654">Thomas, de Chobham, active 1200-1233</author>
+                     <title>Summa pœnitentia</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>17th-century limp vellum</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1250" notAfter="1300">s. XIIIex.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim Thomæ de Billingham." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=53">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 35</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_12.xml
+++ b/collections/University_College/University_College_MS_12.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13008">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 12</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_12</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_12">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 12</idno>
+               </msIdentifier>
+               <msContents>
+                  <textLang mainLang="la">Latin</textLang>
+                  <msItem xml:id="University_College_MS_12-item1" n="1">
+                     <title>Psalter</title>
+                     <!--Possible work keys: work_14091 or work_14110 or work_14111 or work_14112 or work_14113 or work_14114 or work_14109 or work_14115-->
+                  </msItem>
+                  <msItem xml:id="University_College_MS_12-item2" n="2">
+                     <title>Cantica sacra Mosis</title>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_12-item3" n="3">
+                     <title>Symbolum Athanasianum, Litaniæ, et collectæ</title>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>"Good historiated and other initials. Related in style to Bodl. MS. Liturg. 396." (IMOCL)</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>16th-century panelled brown leather tooled with emperors’ heads-in-medallion (lacking clasps)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1275" notAfter="1300">s. XIIIex.</origDate>
+                     <origPlace>
+                        <country key="place_7016845">Netherlands</country>; <country key="place_7024097">Flanders</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>Given to the College by Thomas Walker, Master (d. 1665)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=22">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 4</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 804. [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_120.xml
+++ b/collections/University_College/University_College_MS_120.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13098">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 120</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_120</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_120">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 120</idno>
+               </msIdentifier>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <p>Composite manuscript in 2 parts</p>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary limp vellum.</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1200" notAfter="1450">1200–1450</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>William Rogers' name and year 1669 written on f. 1r.</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=54">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 36</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 267 [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+               <msPart xml:id="University_College_MS_120-part1" n="1">
+                  <msIdentifier>
+                     <altIdentifier type="partial">
+                        <idno type="part">University College MS. 120 - Part 1</idno>
+                     </altIdentifier>
+                  </msIdentifier>
+                  <msContents>
+                     <msItem xml:id="University_College_MS_120-part1-item1" n="1">
+                        <title>Bestiary</title>
+                        <!--Possible work keys: work_7188 or work_10447 or work_10448-->
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                  </msContents>
+                  <physDesc>
+                     <objectDesc/>
+                  </physDesc>
+                  <history>
+                     <origin>
+                        <origDate calendar="Gregorian">s. XIII</origDate>
+                     </origin>
+                  </history>
+               </msPart>
+               <msPart xml:id="University_College_MS_120-part2" n="2">
+                  <msIdentifier>
+                     <altIdentifier type="partial">
+                        <idno type="part">University College MS. 120 - Part 2</idno>
+                     </altIdentifier>
+                  </msIdentifier>
+                  <msContents>
+                     <msItem xml:id="University_College_MS_120-part2-item1" n="1">
+                        <author key="person_86734224">Burley, Walter, 1275-1345</author>
+                        <title>De universalibus</title>
+                        <!--Possible work keys: work_845-->
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                  </msContents>
+                  <physDesc>
+                     <objectDesc/>
+                  </physDesc>
+                  <history>
+                     <origin>
+                        <origDate calendar="Gregorian">s. XVex.</origDate>
+                     </origin>
+                  </history>
+               </msPart>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_122.xml
+++ b/collections/University_College/University_College_MS_122.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13099">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 122</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_122</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_122">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 122</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_122-item1" n="1">
+                     <author key="person_217200604">William, of Pagula, approximately 1290-1332</author>
+                     <title>Oculus sacerdotis (Part 1)</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="paper">
+                        <support>paper</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Reused 13th-century leaf (stained)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=54">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 36</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_123.xml
+++ b/collections/University_College/University_College_MS_123.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13100">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 123</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_123</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_123">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 123</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_123-item1" n="1">
+                     <author key="person_289681963">Bonaventure, Saint, Cardinal, approximately 1217-1274, pseudo</author>
+                     <title>Speculum vitæ Christi, trans. Love, Nicholas, active 1410</title>
+                     <textLang mainLang="enm">Middle English (Buckinghamshire dialect)</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_123-item2" n="2">
+                     <title>A shorte tretis of the heiest and moste worthi sacrament of Cristis body and the miraclis theroff</title>
+                     <textLang mainLang="enm">Middle English (Buckinghamshire dialect)</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_123-item3" n="3">
+                     <title>Two devotional texts</title>
+                     <textLang mainLang="enm">Middle English (Buckinghamshire dialect)</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>16th-century blind stamped calf, roll tooled vertically with standing woman dragon, hunter and deer</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"ex dono Gulielmi Rogers. (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=54">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 36</ref>
+                              </bibl>
+                              <bibl>
+                                 <title>IMEP</title>, p. 120</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_124.xml
+++ b/collections/University_College/University_College_MS_124.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13101">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 124</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_124</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_124">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 124</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_124-item1" n="1">
+                     <author key="person_264344179">Aquinas, Thomas, Saint, 1225-1274</author>
+                     <title>Quodlibeta</title>
+                     <!--Possible work keys: work_245-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Flourish initials in blue and red with extravagant marginal extensions</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Medieval white leather over wooden boards (restored)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1200" notAfter="1250">s. XIIIin.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>; <orgName key="org_143145136">Fountains Abbey</orgName>
+                     </origPlace>
+                  </origin>
+                  <provenance>"anno 1580 peculium Ricardi Tomsoni; deinde 1596 Willelmi Wraye, et denique coll. Univ. ex dono Tho. Walker, magistri." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=55">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 37</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_125.xml
+++ b/collections/University_College/University_College_MS_125.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13102">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 125</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_125</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_125">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 125</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_125-item1" n="1">
+                     <author>Melanchthon, Philipp, 1497-1560</author>
+                     <title>Compendium interdecreti</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="paper">
+                        <support>paper</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Vellum wrapper from 13th-century theological manuscript</p>
+                     </binding>
+                  </bindingDesc>
+                  <accMat>Index in Italian added in 1549.</accMat>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1500" notAfter="1600">s. XVI</origDate>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=55">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 37</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_129.xml
+++ b/collections/University_College/University_College_MS_129.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13103">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 129</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_129</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_129">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 129</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_129-item1" n="1">
+                     <author key="person_12505313">Balbi, Giovanni, -1298</author>
+                     <title>Catholicon</title>
+                     <!--Possible work keys: work_2542-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>"Fine border, initials, added to an Italian MS. with penwork initials, saec. xiii2. Mutilated." (IMOCL)</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary white leather over bevelled wooden boards (lacking clasps and pins).</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1300" notAfter="1400">s. XIV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>; <placeName key="place_7011375">Winchester</placeName>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim capellæ S. Elizabthæ juxta Winton. ex sono Joh. Pountoyse 'quondam ep. Winton.' postea Ricardi Neuport, et anno 1667 Gulielmi Shippen." (Coxe) "Given by John de Pontisarra (Pontoise), bp. of Winchester (d. 1304), to the Chapel of the Hospital of St. Elizabeth of Hungary, Winchester, fols. I, 378v. William Shippen, fellow, rector of Stockport, Cheshire (d. 1693), fol. i." (IMOCL)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=55">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 37</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 714 [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_13.xml
+++ b/collections/University_College/University_College_MS_13.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13009">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 13</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_13</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_13">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 13</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_13-item1" n="1">
+                     <title>Professio fidei.</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="paper">
+                        <support>paper</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Limp vellum (stained)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1550" notAfter="1600">s. XVIex.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>; <placeName key="place_7011781">London </placeName> (possibly)</origPlace>
+                  </origin>
+                  <provenance>Recusant manuscript. "ex dono Roberti Plot, LL. Doctoris et hujus collegii commensalis." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=22">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 4</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_130.xml
+++ b/collections/University_College/University_College_MS_130.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13104">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 130</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_130</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_130">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 130</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_130-item1" n="1">
+                     <title>Old Testament (The Octateuch, Job, Kings, Ezekiel, Prologues of St Jerome)</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>"Fine historiated and other initials. Fine arabesque initials. Marginal sketches, fols. 1v, 124v." (IMOCL)</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary tawed leather over boards with strap, pin and clasp.</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1100" notAfter="1200">s. XII</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"Ex libris of St. Neot's priory, Hunts., fol 171v, saec. xic." (IMOCL)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=56">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 38</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 140 [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_138.xml
+++ b/collections/University_College/University_College_MS_138.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13105">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 138</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_138</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_138">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 138</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_138-item1" n="1">
+                     <author key="person_78769600">Cicero, Marcus Tullius</author>
+                     <title>De amicitia</title>
+                     <!--Possible work keys: work_1241-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>19th-century half morocco</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1100" notAfter="1300">s. XII or XIII</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>; St Augustine's Abbey, <placeName key="place_7012044"> Canterbury</placeName>
+                     </origPlace>
+                  </origin>
+                  <provenance>Canterbury (St Augustine's), England "olim Gul. Rogers, ex hospit. Lincoln. 1669." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=56">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 38</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_14.xml
+++ b/collections/University_College/University_College_MS_14.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13010">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 14</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_14</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_14">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 14</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_14-item1" n="1">
+                     <author key="person_2597190">Hilton, Walter, -1396</author>
+                     <title>The cloud of Unknowing, or of Contemplation</title>
+                     <textLang mainLang="enm">Middle English (South central Norfolk dialect)</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_14-item2" n="2">
+                     <author key="person_24572572">Peter, of Blois, approximately 1135-approximately 1212</author>
+                     <title>Regula aurea</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_14-item3" n="3">
+                     <author>Catherine, of Sienna</author>
+                     <title>Doctrine</title>
+                     <textLang mainLang="enm">Middle English</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary white tawed leather (lacking clasps and catches)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>Once belonged to John Juel (1522-71), bishop of Salisbury. Given to University College Oxford by Thomas Walker, Master (d. 1665).</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=22">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 4</ref>
+                              </bibl>
+                              <bibl>
+                                 <title>IMEP</title>, p. 102</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_140.xml
+++ b/collections/University_College/University_College_MS_140.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13106">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 140</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_140</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_140">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 140</idno>
+               </msIdentifier>
+               <msContents>
+                  <textLang mainLang="el">Greek</textLang>
+                  <msItem xml:id="University_College_MS_140-item1" n="1">
+                     <author>Manuel Byrennius</author>
+                     <title>On harmonies</title>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_140-item2" n="2">
+                     <author key="person_64016141">Porphyry, approximately 234-approximately 305</author>
+                     <title>Commentary on Ptolemy's Harmonies</title>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_140-item3" n="3">
+                     <author key="person_54152998">Ptolemy, active 2nd century</author>
+                     <title>Harmonies (Book III)</title>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="paper">
+                        <support>paper</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Diagrams.</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>19th-century purple cloth</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1500" notAfter="1600">s. XVI</origDate>
+                  </origin>
+                  <provenance>Possibly given to Univ. by Mary Langbaine.</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=57">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 39</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_142.xml
+++ b/collections/University_College/University_College_MS_142.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13107">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 142</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_142</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_142">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 142</idno>
+               </msIdentifier>
+               <msContents>
+                  <textLang mainLang="enm">Middle English (South west Sussex dialect)</textLang>
+                  <msItem xml:id="University_College_MS_142-item1" n="1">
+                     <author>Rolle, Richard, 1290?-1349 (Richard Hampole)</author>
+                     <title>Pricke of conscience</title>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_142-item2" n="2">
+                     <title>Printed treatise</title>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_142-item3" n="3">
+                     <title>"Of seuen maystyrs of art"</title>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Medieval wooden boards, stripped and rebacked with maroon morocco</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim Johannis Ramsey." (Coxe) Previously owned by Ricardus Rauf P L, John and William Weston de Ocham. Belonged to Gerald Langbaine. Possibly given to Univ. by Mary Langbaine.</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=57">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 39</ref>
+                              </bibl>
+                              <bibl>
+                                 <title>IMEP</title>, p. 120-1</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_143.xml
+++ b/collections/University_College/University_College_MS_143.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13108">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 143</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_143</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_143">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 143</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_143-item1" n="1">
+                     <author>Peter Riga, approximately 1140-1209</author>
+                     <title>Aurora</title>
+                     <!--Possible work keys: work_3602 or work_3234-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>19th-century calf (rubbed)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1200" notAfter="1250">s. XIIIin.</origDate>
+                  </origin>
+                  <provenance>Sudbury, England. Possibly given to Univ. by Mary Langbaine.</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=57">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 39</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_145.xml
+++ b/collections/University_College/University_College_MS_145.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13109">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 145</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_145</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_145">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 145</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_145-item1" n="1">
+                     <title>Statutes of the Hospital at Ewelme</title>
+                     <textLang mainLang="en">English</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>19th-century purple cloth</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1500" notAfter="1600">s. XVI</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"Made by William de la Poole. Possibly given to Univ. by Mary Langbaine.</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=57">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 39</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_148.xml
+++ b/collections/University_College/University_College_MS_148.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13110">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 148</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_148</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_148">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 148</idno>
+               </msIdentifier>
+               <msContents>
+                  <textLang mainLang="la">Latin</textLang>
+                  <msItem xml:id="University_College_MS_148-item1" n="1">
+                     <title>Charters, rules, and liturgical texts relating to Chichester</title>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_148-item2" n="2">
+                     <title>Cartulary and rule St Mary's Hospital, Chichester</title>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Modern vellum</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1100" notAfter="1400">ss. XII to XIV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>; <placeName key="place_7011407">Chichester.</placeName>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim Gerardi Langbaine, [coll. Reg. præposto filii] postea coll. Univ. ex dono Mariæ Langbaine viduæ, in gratiam mariti sui Gerardi muper defuncti, olim per multos annos hujus colegii superioris ordinis commensalis; anno Domini 1692." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=58">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 40</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_15.xml
+++ b/collections/University_College/University_College_MS_15.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13011">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 15</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_15</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_15">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 15</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_15-item1" n="1">
+                     <author>Johannis Lugdunensi (or of Leyden)</author>
+                     <title>Sermones Dominicales Festivalesque</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary white leather over wooden boards (spine tabs cut off, lacking clasps and catches)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1200" notAfter="1240">s. XIIIin.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim ecclesiæ S. Mariæ de Holm-Cultram ex dono Ludovici monachi." (Coxe) Christopher Hudson, s. XVI (f. 181v).</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=23">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 5</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_154.xml
+++ b/collections/University_College/University_College_MS_154.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13111">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 154</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_154</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_154">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 154</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_154-item1" n="1">
+                     <title>Chronicle of England (Brut Chronicle)</title>
+                     <!--Possible work keys: work_10929-->
+                     <textLang mainLang="enm">Middle English</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Border and initial on opening folio, flourish initials throughout.</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Late 15th-century panelled brown leather (worn)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim, ut videtur, Willelmi Manyngham, Christophori Purpilli, W. Bendloues, et Willelmi Bere." (Coxe) "Christopher Purpillus, 1604, pp. i, 241. Possibly given to Univ. by Mary Langbaine, widow of Gerard Langbaine (d. 1692)." (IMOCL)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=60">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 42</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 551 [information on decoration and origin]</bibl>
+                              <bibl>
+                                 <title>IMEP</title>, p. 121</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_156.xml
+++ b/collections/University_College/University_College_MS_156.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13112">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 156</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_156</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_156">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 156</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_156-item1" n="1">
+                     <author key="person_147980">Netter, Thomas, approximately 1375-1430</author>
+                     <title>De sacramentalibus</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="paper">
+                        <support>paper</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>19th-century calf. Almost certainly a Beckford binding. Printed waste endleaves from Bacon's Nova Atlantis.</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1475" notAfter="1500">s. XVex.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>; <placeName key="place_7010723">Lincoln.</placeName>
+                     </origPlace>
+                  </origin>
+                  <provenance>Copied out by John Rusell, bishop of Lincoln, in 1491-2. Probably given to Univ. by Mary Langbaine.</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=61">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 43</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_158.xml
+++ b/collections/University_College/University_College_MS_158.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13113">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 158</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_158</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_158">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 158</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_158-item1" n="1">
+                     <title>Relationes casuum legalium</title>
+                     <textLang mainLang="fr" otherLangs="la">French and Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="mixed">
+                        <support>vellum and paper</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Speckled calf by Beckford</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1550" notAfter="1600">s. XVIex.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>Probably given to Univ. by Mary Langbaine.</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=61">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 43</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_16.xml
+++ b/collections/University_College/University_College_MS_16.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13012">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 16</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_16</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_16">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 16</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_16-item1" n="1">
+                     <title>Epistola beati Eusebii</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_16-item2" n="2">
+                     <title>Soliloquia sive meditationes sancti Augustini</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_16-item3" n="3">
+                     <title>Alloquia beati Augustini</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_16-item4" n="4">
+                     <title>Devota meitatio sive oratio ad proprium angelum</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_16-item5" n="5">
+                     <author>Anselm, Saint</author>
+                     <title>Ad Sanctum Johannem Baptistam</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_16-item6" n="6">
+                     <title>Ad S. Johannem evangelistam</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_16-item7" n="7">
+                     <title>Alia oratio ad eundem Sanctum Johannem</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary reversed red leather over wooden boards (lacking clasps and catches) with front endleaves from an English choirbook and rear endleaves with polyphonic music</p>
+                     </binding>
+                  </bindingDesc>
+                  <accMat>Black full mensural notation with black full black void and red black full coloration except one motet in black void mensural notation. (DIAMM) College bookplate of 1650? on inside of upper board; College bookplate of 1700? on f. 3v. Contents listed on f. 149r.</accMat>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>Incorporated into the college library in 1684; John Courteney mentioned in liminary text. (DIAMM) According to Coxe this manuscript belonged to Thomas Dackombe. This was probably Thomas Dackombe (1496-c.1572), petty canon of Winchester Cathedral.</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=23">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 5</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_165.xml
+++ b/collections/University_College/University_College_MS_165.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13114">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 165</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_165</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_165">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 165</idno>
+               </msIdentifier>
+               <msContents>
+                  <textLang mainLang="la">Latin</textLang>
+                  <msItem xml:id="University_College_MS_165-item1" n="1">
+                     <author key="person_61539765">Bede, the Venerable, Saint, 673-735</author>
+                     <title>Vita et miracula S. Cuthberti</title>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_165-item2" n="2">
+                     <title>Prayer to St Cuthbert</title>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>One miniature in full colour, colour washed drawings, historiated and decorated initials.</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Durham, c. 1120.</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1100" notAfter="1200">s. XII</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>; <placeName key="place_7010027">Durham.</placeName>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim M. Lelonde, Joh. Theyer de Cowpers Hill juxta Glouc., Fulconis Wallwyn, ex dono Danielis Bacheler, Willelmi et Thomæ Leigh, et denique coll. Univ. ex dono Gul. Rogers." (Coxe) Southwick (Ker)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=63">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 45</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 17. [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_166.xml
+++ b/collections/University_College/University_College_MS_166.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13115">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 166</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_166</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_166">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 166</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_166-item1" n="1">
+                     <title>Rental of Salisbury Cathedral</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1300" notAfter="1400">s. XIV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=63">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 45</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_167.xml
+++ b/collections/University_College/University_College_MS_167.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13116">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 167</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_167</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_167">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 167</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_167-item1" n="1">
+                     <title>Fountains Abbey, Cartulary, with Cistercian privileges to 1490</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>White leather over boards, chemise lacking pins and most of straps with clasps.</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1450" notAfter="1500">s. XVex.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>; <orgName key="org_143145136">Fountains Abbey</orgName>
+                     </origPlace>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=63">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 45</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_168.xml
+++ b/collections/University_College/University_College_MS_168.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13117">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 168</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_168</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_168">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 168</idno>
+               </msIdentifier>
+               <msContents>
+                  <textLang mainLang="la">Latin</textLang>
+                  <msItem xml:id="University_College_MS_168-item1" n="1">
+                     <title>Collection of commentaries on Song of Songs;</title>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_168-item2" n="2">
+                     <author key="person_61539765">Bede, the Venerable, Saint, 673-735</author>
+                     <title>Commentaries (Song of Songs, the Gospels of Mark and Luke)</title>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>"Good historiated initial. Fine borders in an unusual style, fine and other initials. Fine penwork initials. Marginal drawings (catchwords), later pencil sketches, saec. xvi." (IMOCL)</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary binding of white leather over bevelled wooden boards flush to page edge, strap trimmed from upper board.</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=64">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 46</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 419 [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_169.xml
+++ b/collections/University_College/University_College_MS_169.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13118">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 169</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_169</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_169">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 169</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_169-item1" n="1">
+                     <title>Barking Abbey, Ordinale</title>
+                     <textLang mainLang="la" otherLangs="enm">Latin &amp; Middle English</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Illuminated initials, penwork initials with faces. "Fine borders, initials. Fine penwork initials." (IMOCL)</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>"New Bound. 1731." (note on inside upper board) 1731 panelled reversed calf, lacking clasps</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1450">s. XVin.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>; Barking Abbey</origPlace>
+                  </origin>
+                  <provenance>Note of f. 6v: "Memorandum quod anno domini millesimo quadragintesimo quarto domina Sibilla . . . Abbatissa de Berkyng hunc librum ad usum Abbatissarum in dicta domo . . . concessit." "Commissioned and given to Barking abbey in 1404 by Sibilla de Felton, abbess 1394-1419, p. 2. Obits of Barking abbesses, fols. i-v, saec. xv. Obadiah Walker, master 1676-89. Sold at the sale of John Humphrey of Rothwell, 4 Dec., 1682, lot 20." (IMOCL)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=65">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 47</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 387 [information on decoration and origin]</bibl>
+                              <bibl>
+                                 <title>IMEP</title>, p. 121</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_170.xml
+++ b/collections/University_College/University_College_MS_170.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13119">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 170</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_170</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_170">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 170</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_170-item1" n="1">
+                     <title>Fountains Abbey, Cartulary</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>19th-century reversed calf</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1100" notAfter="1300">s. XII or XIII</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"ex dono Hugonis Todd socii, 1696." (DHC)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=65">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 47</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_172.xml
+++ b/collections/University_College/University_College_MS_172.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13120">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 172</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_172</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_172">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 172</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_172-item1" n="1">
+                     <author key="person_78778341">Gregory, X, Pope, -1276</author>
+                     <title>Constitutions of the Second Council of Lyon 1274</title>
+                     <!--Possible work keys: work_1842-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>19th-century cloth</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1300" notAfter="1400">s. XIV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim Gul. Rogers, 1669." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=65">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 47</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_177_A_B.xml
+++ b/collections/University_College/University_College_MS_177_A_B.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13121">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 177 A-B</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_177_A_B</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_177_A_B">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 177 A-B</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_177_A_B-item1" n="1">
+                     <author key="person_90633533">Higden, Ranulf, -1364</author>
+                     <title>Polychronicon (with prologue)</title>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Puzzle initials with grotesques in the margins. "Fine penwork borders, initials." (IMOCL)</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary white leather chemise over straight-edge wooden boards. Bookmarker in Vol. I</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1350" notAfter="1400">s. XIVex.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim Thomæ Sparchi ex dono Matthæi Piggotti." (Coxe) "Evidence for Barnwell priory, Cambridgeshire, from obits in the margin." (IMOCL)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=66">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 48</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 342 [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_178.xml
+++ b/collections/University_College/University_College_MS_178.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13122">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 178</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_178</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_178">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 178</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_178-item1" n="1">
+                     <title>Missal (fragments)</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Initials and borders.</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>19th-century hogskin.</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1350" notAfter="1400">s. XIVex.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"University College chapel. Obits in the calendar: magister Walker Skirlaw, bp. of Durham, 1406; Henry Percy, 1455. Note on the dedication of the Chapel to St. Cuthbert, 1476." (IMOCL)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=66">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 48</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 349 [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_179.xml
+++ b/collections/University_College/University_College_MS_179.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13123">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 179</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_179</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_179">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 179</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_179-item1" n="1">
+                     <title>Devotional book, including: Prayers, Hours of the Blessed Virgin Mary, Placebo, Seven Penitential Psalms, Litany</title>
+                     <textLang mainLang="la" otherLangs="enm">Latin &amp; Middle English</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>18th-century limp vellum.</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>Given by Francis Rockley (DHC).</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=67">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 49</ref>
+                              </bibl>
+                              <bibl>
+                                 <title>IMEP</title>, pp. 121-4; 132-5</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_18.xml
+++ b/collections/University_College/University_College_MS_18.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13013">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 18</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_18</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_18">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 18</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_18-item1" n="1">
+                     <author key="person_24572572">Peter, of Blois, approximately 1135-approximately 1212</author>
+                     <title>Duodecim utilitates tribulationis</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_18-item2" n="2">
+                     <author key="person_289681963">Bonaventure, Saint, Cardinal, approximately 1217-1274 pseudo,</author>
+                     <title>Meditationes vitae Christi</title>
+                     <!--Possible work keys: work_3963 or work_3964 or work_3965-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>English 15th-century panelled ‘cuir ciselé’ over wooden boards, border ruled and stamped in blind (rebacked, lacking clasps and catches)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1300" notAfter="1500">ss. XIV, XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>Belonged to Thomas Stokys, armiger, and given to University College by Thomas Staunton. (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=24">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 6</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_180.xml
+++ b/collections/University_College/University_College_MS_180.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13124">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 180</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_180</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_180">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 180</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_180-item1" n="1">
+                     <title>Gospels</title>
+                     <!--Possible work keys: work_12094 or work_12095 or work_12096 or work_12100 or work_12099-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_180-item2" n="2">
+                     <title>Glossing on Song of Songs</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_180-item3" n="3">
+                     <title>Sermon on Lucerna pedibus meis (Psalm 119.105)</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_180-item4" n="4">
+                     <title>Book of Job, glossed (fragment)</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_180-item5" n="5">
+                     <title>Catalogue, of works by Anselm and Augustine</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>19th-century cloth</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1100" notAfter="1300">ss. XII or s. XIII</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim Thomæ Ailesbury, clerici." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett.</p>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_181.xml
+++ b/collections/University_College/University_College_MS_181.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13125">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 181</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_181</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_181">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 181</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_181-item1" n="1">
+                     <author key="person_100226060">Guillaume, de Déguileville, 1295-1360</author>
+                     <title>The pilgrimage of the soul</title>
+                     <textLang mainLang="enm">Middle English</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_181-item2" n="2">
+                     <author key="person_9902409">Hoccleve, Thomas, 1370?-1450?</author>
+                     <title>Compleynte paramont</title>
+                     <textLang mainLang="enm">Middle English</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>"Fine borders, fine and other initials. Miniatures pasted in and removed." (IMOCL)</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Original leather over bevelled boards sewn into white leather chemise, lined with blue and white striped cloth, metal bosses on upper and lower covers (lacking clasps and pins).</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1450">s. XVin.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim, anno scilicet 1491, Henrici Percei de N. postea, anno 1577, Roberti Hedrington." (Coxe) "Given in 1490 to dominus Henry Percy, prior of Newnham, Bedfordshire, by his predecessor, Johannis Renhall, fol. 40v. Robert Hendrington, 1577, fol. 1." (IMOCL)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 560 [information on decoration and origin]</bibl>
+                              <bibl>
+                                 <title>IMEP</title>, p. 124</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_188.xml
+++ b/collections/University_College/University_College_MS_188.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13126">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 188</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_188</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_188">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 188</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_188-item1" n="1">
+                     <title>Romance of Parthenopex (lacking at beginning and end)</title>
+                     <textLang mainLang="enm">Middle English</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Some bastard secretary script.</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>19th-century morocco</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1375" notAfter="1450">s. XIVex.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=69">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 51</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_19.xml
+++ b/collections/University_College/University_College_MS_19.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13014">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 19</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_19</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_19">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 19</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_19-item1" n="1">
+                     <title>Canones evangelorium secundum novas capitulaciones Bibliae</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_19-item2" n="2">
+                     <title>Ordo omnium gestorum et miraculorum Domini nostri Jhesu Christi</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_19-item3" n="3">
+                     <author key="person_154144782727969775144">Clement, of Llanthony</author>
+                     <title>Unum ex quatuor</title>
+                     <!--Possible work keys: work_1293-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>16th-century panelled brown leather over wooden boards (lacking clasp)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1300" notAfter="1400">s. XIV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>; <placeName key="place_7012044">Canterbury</placeName>, St Augustine's Abbey</origPlace>
+                  </origin>
+                  <provenance>Formerly belonged to an abbot named Thomas; after 1669 it was owned by William Rogers. (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=24">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 6</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_190.xml
+++ b/collections/University_College/University_College_MS_190.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13127">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 190</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_190</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_190">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 190</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_190-item1" n="1">
+                     <author key="person_40175167">Petrus, Comestor, active 12th century</author>
+                     <title>Historia scholastica</title>
+                     <!--Possible work keys: work_3495-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Diagram of the Temple.</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>19th-century half morocco</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1175" notAfter="1250">s. XIIex./s. XIII</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>“Belonged to the Dominicans of Beverley in s. xv, if not in s. xiii: ‘Fratrium predicatorum’ at the head of f. 1 and ‘fratris Roberti de Eston’ at the foot, both probably in the same hand, s. xiii; ‘Conuentus Beuerlaci’ f. 137, s. xv, ‘C. Hyldyard’ MS 113, f. 169, s. xvi, may have been written before or after the last four leaves of art. 2 were transferred to MS. 113: the same name is on MS. 113, f. 1. Both manuscripts were the gift of Obadiah Walker, master 1676-9.” (Ker)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett.</p>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_191.xml
+++ b/collections/University_College/University_College_MS_191.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13128">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 191</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_191</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_191">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 191</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_191-item1" n="1">
+                     <author key="person_100184667">Gregory, I, Pope, approximately 540-604</author>
+                     <title>Homilies</title>
+                     <!--Possible work keys: work_5996 or work_5995 or work_5877 or work_1190 or work_1854 or work_1846 or work_249 or work_3923 or work_2674 or work_2675 or work_971 or work_929 or work_930 or work_3400 or work_12283 or work_12284 or work_12285 or work_12286-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Large green and red initials with foliate patterns, one blue initial with red pattern.</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Half-morocco over medieval boards (lacking clasps and catches)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1100" notAfter="1200">s. XII</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>Cistercian. "[Liber] sancta M[arie] d[e….] anathema sit." (f. 4v)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett.</p>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_192.xml
+++ b/collections/University_College/University_College_MS_192.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13129">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 192</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_192</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_192">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 192</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_192-item1" n="1">
+                     <title>Fragments, removed from bindings of other manuscripts.</title>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_192-item2" n="2">
+                     <title>Antiphonary</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_192-item3" n="3">
+                     <title>Gradual</title>
+                     <!--Possible work keys: work_12120 or work_12122 or work_12123-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_192-item4" n="4">
+                     <title>Will of Simon de Bredon</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_192-item5" n="5">
+                     <title>Will of Stephanus atte Roche</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_192-item6" n="6">
+                     <title>Musical fragments from a royal choirbook including Credo by Thomas Damett</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="guardbook">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Colour initials.</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>19th-century cloth</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1100" notAfter="1500">ss. XII - XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>Possibly copied for choirbook of King Henry VI.</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 655 [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_20.xml
+++ b/collections/University_College/University_College_MS_20.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13015">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 20</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_20</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_20">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 20</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_20-item1" n="1">
+                     <title>Bible (Vulgate) with prologue of St Jerome</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Decorated. Flourish initials throughout.</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Medieval white tawed leather over bevelled wooden boards (lacking one of two clasps)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1275" notAfter="1300">s. XIIIex.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim Radulphi Fawconere." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=24">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 6</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_208.xml
+++ b/collections/University_College/University_College_MS_208.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13130">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 208</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_208</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_208">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 208</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_208-item1" n="1">
+                     <title>Fragments, removed from the bindings of University College MS. 41</title>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc/>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1200" notAfter="1400">s. XIII - XIV</origDate>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett.</p>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_21.xml
+++ b/collections/University_College/University_College_MS_21.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13016">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 21</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_21</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_21">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 21</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_21-item1" n="1">
+                     <author key="person_79081365">Raymond, of Peñafort, Saint, 1175?-1275</author>
+                     <title>Summa theologiae</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Old brown leather over wooden boards</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1300" notAfter="1400">s. XIV</origDate>
+                     <origPlace>
+                        <country key="place_1000070">France</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim liber Simonis de Retlinge, de libraria Sancti Augustini Cantuar., postea Tho. Weaver." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=24">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 6</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_22.xml
+++ b/collections/University_College/University_College_MS_22.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13017">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 22</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_22</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_22">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 22</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_22-item1" n="1">
+                     <title>Breviary, Use of Salisbury (Sarum), inserted with readings and homilies by Venerable Bede and others</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Written in an informal English cursive hand.</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Brown leather over wooden boards (rebacked)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim Johannis Bristowe." (Coxe) Names mentioned in a note on f. 337v John Roly, George Dawne.</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=25">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 7</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_23.xml
+++ b/collections/University_College/University_College_MS_23.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13018">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 23</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_23</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_23">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 23</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_23-item1" n="1">
+                     <author>Facio, Bartolomeo, -1547</author>
+                     <title>De vitae felicitate</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_23-item2" n="2">
+                     <author>Facio, Bartolomeo, -1547</author>
+                     <title>Ad Robertum Strozzum epistola</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Written in a humanistic bookhand, initials not supplied.</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary blind-stamped goatskin (lacking one of the clasps)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_1000080">Italy</country>; <placeName key="place_7004474">Naples </placeName> (possibly)</origPlace>
+                  </origin>
+                  <provenance>"olim Johannis Lawrens, postea coll. Univ. ex dono Tho. Walker S.T.P., magistri." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=25">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 7</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_24.xml
+++ b/collections/University_College/University_College_MS_24.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13019">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 24</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_24</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_24">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 24</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_24-item1" n="1">
+                     <title>Summula controversiarum</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Limp vellum</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1500" notAfter="1600">s. XVI</origDate>
+                  </origin>
+                  <provenance>Collegii Anglici (note in Duke Humphrey's copy of Coxe).</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=25">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 7</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_25.xml
+++ b/collections/University_College/University_College_MS_25.xml
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13020">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 25</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_25</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_25">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 25</idno>
+               </msIdentifier>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <p>Composite manuscript in 3 parts</p>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>16th century blind-stamped calf (rebacked, lacking clasps and catches)</p>
+                     </binding>
+                  </bindingDesc>
+                  <accMat>College bookplate of 1700? on inside of upper board.</accMat>
+               </physDesc>
+               <history>
+                  <origin>
+                     <p>No date</p>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=25">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 7</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+               <msPart xml:id="University_College_MS_25-part1" n="1">
+                  <msIdentifier>
+                     <altIdentifier type="partial">
+                        <idno type="part">University College MS. 25 - Part 1</idno>
+                     </altIdentifier>
+                  </msIdentifier>
+                  <msContents>
+                     <msItem xml:id="University_College_MS_25-part1-item1" n="1">
+                        <title>Hours of the Holy Spirit</title>
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                  </msContents>
+                  <physDesc>
+                     <objectDesc>
+                        <supportDesc material="perg">
+                           <support>vellum</support>
+                        </supportDesc>
+                     </objectDesc>
+                  </physDesc>
+                  <history>
+                     <origin>
+                        <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                        <origPlace>
+                           <country key="place_7002445">England</country>
+                        </origPlace>
+                     </origin>
+                     <provenance>Formerly belonged to Elizabeth Yate. (Coxe and note on f. 4r)</provenance>
+                  </history>
+               </msPart>
+               <msPart xml:id="University_College_MS_25-part2" n="2">
+                  <msIdentifier>
+                     <altIdentifier type="partial">
+                        <idno type="part">University College MS. 25 - Part 2</idno>
+                     </altIdentifier>
+                  </msIdentifier>
+                  <msContents>
+                     <msItem xml:id="University_College_MS_25-part2-item1" n="1">
+                        <title>Psalter and Hymnal (Use of Sarum)</title>
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                  </msContents>
+                  <physDesc>
+                     <objectDesc>
+                        <supportDesc material="unknown">
+                           <support>printed on paper</support>
+                        </supportDesc>
+                     </objectDesc>
+                  </physDesc>
+                  <history>
+                     <origin>
+                        <origDate calendar="Gregorian" notBefore="1500" notAfter="1600">s. XVI</origDate>
+                        <origPlace>
+                           <country key="place_1000070">France</country>; <placeName key="place_7008038">Paris</placeName>
+                        </origPlace>
+                     </origin>
+                     <provenance>Printed by Franz Birckman, 1522.</provenance>
+                  </history>
+               </msPart>
+               <msPart xml:id="University_College_MS_25-part3" n="3">
+                  <msIdentifier>
+                     <altIdentifier type="partial">
+                        <idno type="part">University College MS. 25 - Part 3</idno>
+                     </altIdentifier>
+                  </msIdentifier>
+                  <msContents>
+                     <msItem xml:id="University_College_MS_25-part3-item1" n="1">
+                        <title>Lectionary, hymnal, prayers with Litany</title>
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                  </msContents>
+                  <physDesc>
+                     <objectDesc>
+                        <supportDesc material="perg">
+                           <support>vellum</support>
+                        </supportDesc>
+                     </objectDesc>
+                  </physDesc>
+                  <history>
+                     <origin>
+                        <origDate calendar="Gregorian" notBefore="1500" notAfter="1600">s. XVI</origDate>
+                        <origPlace>
+                           <country key="place_7002445">England</country>; Syon</origPlace>
+                     </origin>
+                  </history>
+               </msPart>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_26.xml
+++ b/collections/University_College/University_College_MS_26.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13021">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 26</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_26</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_26">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 26</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_26-item1" n="1">
+                     <author>Sacro Bosco, Joannes de, active 1230</author>
+                     <title>De algorismo sive de arte memorandi tractatulus</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_26-item2" n="2">
+                     <author>Sacro Bosco, Joannes de, active 1230 &amp; Grossteste, Robert, 1175?-1253,</author>
+                     <title>Liber de computo</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_26-item3" n="3">
+                     <author>Sacro Bosco, Joannes de, active 1230</author>
+                     <title>Liber de sphaera</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_26-item4" n="4">
+                     <author>Grossteste, Robert, 1175?-1253</author>
+                     <title>Theorica Planetarum, cum figuris</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_26-item5" n="5">
+                     <title>De vocibus animalium</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_26-item6" n="6">
+                     <title>Tractatus de proportione</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>"manu Johannis Hatfield plerumque exaratus" (Coxe): largely in the hand of John Hatfield. Sacrobosco texts signed by John Hatfield. Planetary and astrological diagrams on ff. 122r, 125v, 126v, 130r, 134v, 139r.</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary tawed leather over wooden boards with bevelled edges (worn, lacking clasps and catches)</p>
+                     </binding>
+                  </bindingDesc>
+                  <accMat>College bookplate of 1700? on f. 2v.</accMat>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1300" notAfter="1500">s. XIV or XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>In 1669 the manuscript was under the ownership of William Rogers of Lincoln's Inn. (Coxe; inscription on f. 91v) Inscription "Wm. Rogers" (ff. 4r &amp; 149v)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=25">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 7</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_28.xml
+++ b/collections/University_College/University_College_MS_28.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13022">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 28</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_28</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_28">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 28</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_28-item1" n="1">
+                     <author key="person_2597190">Hilton, Walter, -1396</author>
+                     <title>Scale of perfection</title>
+                     <!--Possible work keys: work_4960 or work_4961-->
+                     <textLang mainLang="enm">Middle English (West Riding of Yorkshire dialect)</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_28-item2" n="2">
+                     <title>Sequence of sermons for holy days</title>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_28-item3" n="3">
+                     <title>Tract on the seven deadly sins</title>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="paper">
+                        <support>paper</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>18th-century blind-stamped calf</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"ex dono M. Georgii Plaxton, de S. Hales, com. Staff. 1681." (Coxe) Probably George Plaxton (1647/8-1720), cler., of Sheriffhales, Shropshire 1673-1703, keen antiquary. (PTB) See ODNB.</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=26">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 8</ref>
+                              </bibl>
+                              <bibl>
+                                 <title>IMEP</title>, p. 102-5</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_29.xml
+++ b/collections/University_College/University_College_MS_29.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13023">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 29</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_29</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_29">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 29</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_29-item1" n="1">
+                     <author>Anon.</author>
+                     <title>Treatise on sin</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_29-item2" n="2">
+                     <author key="person_90634691">Hoveden, John, -1275</author>
+                     <title>Speculum laicorum</title>
+                     <!--Possible work keys: work_14681-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_29-item3" n="3">
+                     <title>A narration of the miracle of how St Augustine of the Apostle of England raised the dead bodies of two excommunicated persons</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_29-item4" n="4">
+                     <title>Tract on the virtue of Theology and the Articles of Faith</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_29-item5" n="5">
+                     <author key="person_7386286">Augustine, Saint, Bishop of Hippo, pseudo</author>
+                     <title>Speculum Peccatorum</title>
+                     <!--Possible work keys: work_14683-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_29-item6" n="6">
+                     <title>Soliloquium animae</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_29-item7" n="7">
+                     <title>Sermon on 1 Corinthians 7.29</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_29-item8" n="8">
+                     <title>Debate between the body and the mind</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_29-item9" n="9">
+                     <title>Excitatio necessaria ad peccatorem</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>17th-century brown leather</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim Thomæ Browne." (Coxe) "Given by [John] Bancroft [Master of University College Oxford, 1610-32]" (DHC)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=26">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 8</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_30.xml
+++ b/collections/University_College/University_College_MS_30.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13024">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 30</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_30</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_30">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 30</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_30-item1" n="1">
+                     <author key="person_100187025">Anselm, Saint, Archbishop of Canterbury, 1033-1109</author>
+                     <title>Ad Deum Patrem (prayer)</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_30-item2" n="2">
+                     <author>Augustine, Saint, Bishop of Hippo, 345 - 430</author>
+                     <title>Sermo de oratione dominica (serm. 58)</title>
+                     <!--Possible work keys: work_810-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_30-item3" n="3">
+                     <title>Meditations and Soliloquies</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_30-item4" n="4">
+                     <author key="person_100227669">Ambrose, Saint, Bishop of Milan, - 397</author>
+                     <title>Sermons and meditations</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Flourish initials.</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>18th-century speckled calf</p>
+                     </binding>
+                  </bindingDesc>
+                  <accMat>List of contents in hand of Obadiah Walker on upper flyleaf.</accMat>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=27">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 9</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_31.xml
+++ b/collections/University_College/University_College_MS_31.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13025">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 31</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_31</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_31">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 31</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_31-item1" n="1">
+                     <author>Clerke, Francis, fl. 1594</author>
+                     <title>Praxis in curiis ecclesiasticis Anglicanis</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="paper">
+                        <support>paper</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Liquid gold initials and acanthus borders on ff. 1 and 3.</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary calf gilt</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1500" notAfter="1600">s. XVI</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=27">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 9</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_33.xml
+++ b/collections/University_College/University_College_MS_33.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13026">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 33</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_33</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_33">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 33</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_33-item1" n="1">
+                     <title>De gestis et transaltionibus sanctorum Regum de Colonia</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_33-item2" n="2">
+                     <author>Anon</author>
+                     <title>"While thou hast Gode and geteste gode" (poem)</title>
+                     <textLang mainLang="enm">Middle English</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Flourish initials and manicoli.</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary tawed leather over bevelled boards, mark from chain hasp (lacking chain and clasp)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>Belonged to Thomas Browne, then to John Bancroft, Master of Univ. and later bishop of Oxford, who gave it to University College in 1632. (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=28">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 10</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_36.xml
+++ b/collections/University_College/University_College_MS_36.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13027">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 36</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_36</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_36">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 36</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_36-item1" n="1">
+                     <author key="person_90634691">Hoveden, John, -1275</author>
+                     <title>Speculum laicorum</title>
+                     <!--Possible work keys: work_14681-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_36-item2" n="2">
+                     <author key="person_90634691">Hoveden, John, -1275</author>
+                     <title>Eplicatio decalogi</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_36-item3" n="3">
+                     <author>John, of Wales, active 13th century (attrib.)</author>
+                     <title>Forma praedicandae</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_36-item4" n="4">
+                     <author key="person_86920837">Grosseteste, Robert, 1175?-1253</author>
+                     <title>De venenis</title>
+                     <!--Possible work keys: work_852 or work_3605 or work_3050-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_36-item5" n="5">
+                     <author key="person_196789494">Athanasius, Saint, Patriarch of Alexandria, -373, pseudo</author>
+                     <title>Sermo de imagine Salvatoris apud Berytum inventa</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Small flourish initials.</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Limp vellum</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1350" notAfter="1400">s. XIVex.</origDate>
+                  </origin>
+                  <provenance>"olim Thomæ Browne, postea coll. Univ. ex dono Tho. Walker, S.T.P. magistri." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=28">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 10</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_37.xml
+++ b/collections/University_College/University_College_MS_37.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13028">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 37</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_37</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_37">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 37</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_37-item1" n="1">
+                     <title>Catena SS. Patrum in psalmos septem pœnitentiales</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>"Fine borders, initials." (IMOCL)</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>18th-century brown leather</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1450">s. XVin.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=29">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 11</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 423 [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_4.xml
+++ b/collections/University_College/University_College_MS_4.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13000">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 4</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_4</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_4">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 4</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_4-item1" n="1">
+                     <author>Willelmi Burgenoun de Tempsford</author>
+                     <title>Fragmentum folio I &amp; II</title>
+                     <textLang mainLang="la" otherLangs="enm">Latin ; Middle English</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_4-item2" n="2">
+                     <title>Dialogus de arte moriendi</title>
+                     <!--Possible work keys: work_1972-->
+                  </msItem>
+                  <msItem xml:id="University_College_MS_4-item3" n="3">
+                     <title>An order for the visitation of the sick, with exhortations to the sick person</title>
+                     <textLang mainLang="en">English (Bedfordshire dialect)</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_4-item4" n="4">
+                     <title>Conturbacio animæ in extremis</title>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_4-item5" n="5">
+                     <title>Exhortatio de modo vivendi concorditer in anima et corpore</title>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_4-item6" n="6">
+                     <author key="person_66806872">Augustine, Saint, Bishop of Hippo</author>
+                     <title>Speculum peccatoris</title>
+                     <!--Possible work keys: work_3943 or work_3944 or work_3910-->
+                  </msItem>
+                  <msItem xml:id="University_College_MS_4-item7" n="7">
+                     <title>Sermons (fragments)</title>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary white leather over wooden boards</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"Once belonged to a monk of Warden, Bedfordshire. Dialect Bedfordshire." (IMEP). Possibly the Cistercian Abbey at Old Warden/Wardon, Bedfordshire. (PTB)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=19">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 1</ref>
+                              </bibl>
+                              <bibl>
+                                 <title>IMEP</title>, p. 102</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_40.xml
+++ b/collections/University_College/University_College_MS_40.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13029">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 40</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_40</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_40">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 40</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_40-item1" n="1">
+                     <author key="person_297475745">John Chrysostom, Saint, -407</author>
+                     <title>Homilies on the Gospel of St Matthew</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_40-item2" n="2">
+                     <author key="person_297475745">John Chrysostom, Saint, -407</author>
+                     <title>Homily</title>
+                     <!--Possible work keys: work_1872 or work_12294 or work_12295 or work_12296-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_40-item3" n="3">
+                     <author key="person_66806872">Augustine, Saint, Bishop of Hippo</author>
+                     <title>Sermon</title>
+                     <!--Possible work keys: work_540 or work_2194 or work_1960 or work_5028 or work_1669 or work_2477 or work_3501 or work_3270 or work_1660 or work_1046 or work_221 or work_1502 or work_872 or work_14543-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_40-item4" n="4">
+                     <author key="person_14773105">Luther, Martin, 1483-1546</author>
+                     <title>Two Sermons</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_40-item5" n="5">
+                     <author key="person_74117553">Savonarola, Girolamo, 1452-1498</author>
+                     <title>Meditation 'Infelix ego'</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_40-item6" n="6">
+                     <author key="person_74117553">Savonarola, Girolamo, 1452-1498</author>
+                     <title>Exposition on the 30th psalm</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>"Fine border, fine and other initials. Humanistic script by Peter Meghen." (IMOCL) Illuminated by a Flemish artist.</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>18th-century leather</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1500" notAfter="1600">s. XVI</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"in usum Christophori Urswyke, Henrici VII. Regis Angliæ ellemosinarii, nitide exaratus, et quoad pag. Primam pictus." (Coxe) "Written for Christopher Urswick, dean of Windsor (d. 1522), fol. 102." (IMOCL)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=29">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 11</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 824 [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_41.xml
+++ b/collections/University_College/University_College_MS_41.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13030">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 41</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_41</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_41">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 41</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_41-item1" n="1">
+                     <author>Anon</author>
+                     <title>Definitiones sphæræ</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_41-item2" n="2">
+                     <author key="person_86920837">Grosseteste, Robert, 1175?-1253</author>
+                     <title>Compotus (lacking opening)</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_41-item3" n="3">
+                     <author key="person_314797824">Profatius Judæus, approximately 1236-</author>
+                     <title>Tractatus quadrantis</title>
+                     <!--Possible work keys: work_1200-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_41-item4" n="4">
+                     <author>Sacro Bosco, Joannes de, active 1230</author>
+                     <title>De Algorismo</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_41-item5" n="5">
+                     <author>Sacro Bosco, Joannes de, active 1230</author>
+                     <title>De Sphaera</title>
+                     <!--Possible work keys: work_2592 or work_4373 or work_11457-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_41-item6" n="6">
+                     <author key="person_55563658">Thebit, ben Chorat, 836-901 [?]</author>
+                     <title>Liber … de hiis quae indigent expositione antequam legatur Almagestus</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_41-item7" n="7">
+                     <author>Grossteste, Robert, 1175?-1253 (attributed) &amp; Gerard of Cremona</author>
+                     <title>Theorica Planetarum</title>
+                     <!--Possible work keys: work_1202 or work_4458 or work_1711 or work_15343-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_41-item8" n="8">
+                     <title>De compositione Cylindri, cum tabulis altitudinem solis exhibentibus in civitate Oxon. London. et Exon</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_41-item9" n="9">
+                     <title>De compositione quandrantis</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_41-item10" n="10">
+                     <title>Ars et operacio novi quadrantis, edited by Petrus de Sancto Audemaro</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_41-item11" n="11">
+                     <title>Canones super Almanach Prophatii [Alphonsine table]</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_41-item12" n="12">
+                     <title>Tabula radicum planetarum super meridiem Oxonie cuius longituo ab occidente est 51 gradus [Alphonsine table]</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Astrological diagrams.</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Medieval white tawed leather over stiff vellum.</p>
+                     </binding>
+                  </bindingDesc>
+                  <accMat>College bookplates of 1650? and 1700? on inside of upper board. Leaves from binding now University College MS. 207 (note on flyleaf). List of contents on f. 2v.</accMat>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1300" notAfter="1400">s. XIV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"Iste liber pertinet comunitate Fratrum Salopiae" (f. 2v) Formerly belonged to a convent in Shrewsbury.</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=30">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 12</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_42.xml
+++ b/collections/University_College/University_College_MS_42.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13031">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 42</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_42</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_42">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 42</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_42-item1" n="1">
+                     <author>Anon.</author>
+                     <title>Liber de vera vite, Jhesu Christo</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_42-item2" n="2">
+                     <author>H. de Goriken</author>
+                     <title>Tractatus de Praedestinatione</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_42-item3" n="3">
+                     <author>Giles, of Assisi, -1262</author>
+                     <title>Verba aurea</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_42-item4" n="4">
+                     <author>Henrici Ramsen</author>
+                     <title>Responsiones de indulgentiis ad Johannem ep. Leodiensem</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_42-item5" n="5">
+                     <author key="person_100160310">Gerson, Jean, 1363-1429</author>
+                     <title>De pollutione nocturna</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_42-item6" n="6">
+                     <author>Anon.</author>
+                     <title>De vita</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_42-item7" n="7">
+                     <author>Anon.</author>
+                     <title>De vita Christi juxta Evangelistas</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_42-item8" n="8">
+                     <author>Beke, Johannes de</author>
+                     <title>Chronicle (excerpt)</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="paper">
+                        <support>paper</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Flourish initials. "haud una manu exaratus." (Coxe)</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary ruled brown leather over bevelled boards</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7016845">The Netherlands</country>; Zwolle; Gröningen</origPlace>
+                  </origin>
+                  <provenance>"olim domus clericorum de communi vita in Gröningen circa Sanctam Walburgam, postea an. 1639 Johannis Halei, Med. Doct." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=30">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 12</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_44.xml
+++ b/collections/University_College/University_College_MS_44.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13032">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 44</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_44</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_44">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 44</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_44-item1" n="1">
+                     <author key="person_39386818">Aelred, of Rievaulx, Saint, 1110-1167</author>
+                     <title>De vita Davis sive genealogia regum anglorum</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="paper">
+                        <support>paper</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Limp vellum</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1500" notAfter="1700">s. XVI or XVII</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=31">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 13</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_45.xml
+++ b/collections/University_College/University_College_MS_45.xml
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13033">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 45</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_45</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_45">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 45</idno>
+               </msIdentifier>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <p>Composite manuscript in 3 parts</p>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>15th-century reversed tawed leather over bevelled boards. Leaf from Early English Text Society publication (1867) used as flyleaf.</p>
+                     </binding>
+                  </bindingDesc>
+                  <accMat>List of contents in hand of Obadiah Walker on upper flyleaf. College bookplates of 1650? and 1700? on flyleaf.</accMat>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1100" notAfter="1500">1100–1500</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=31">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 13</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+               <msPart xml:id="University_College_MS_45-part1" n="1">
+                  <msIdentifier>
+                     <altIdentifier type="partial">
+                        <idno type="part">University College MS. 45 - Part 1</idno>
+                     </altIdentifier>
+                  </msIdentifier>
+                  <msContents>
+                     <msItem xml:id="University_College_MS_45-part1-item1" n="1">
+                        <author key="person_61560236">Langland, William, 1330?-1400?</author>
+                        <title>Piers Plowman (independent version)</title>
+                        <textLang mainLang="enm">Middle English</textLang>
+                     </msItem>
+                  </msContents>
+                  <physDesc>
+                     <objectDesc/>
+                  </physDesc>
+                  <history>
+                     <origin>
+                        <origDate calendar="Gregorian">s. XV</origDate>
+                     </origin>
+                  </history>
+               </msPart>
+               <msPart xml:id="University_College_MS_45-part2" n="2">
+                  <msIdentifier>
+                     <altIdentifier type="partial">
+                        <idno type="part">University College MS. 45 - Part 2</idno>
+                     </altIdentifier>
+                  </msIdentifier>
+                  <msContents>
+                     <msItem xml:id="University_College_MS_45-part2-item1" n="1">
+                        <author key="person_57425612">Henry, of Huntingdon, 1084?-1155</author>
+                        <title>Imago mundi</title>
+                        <!--Possible work keys: work_2085-->
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                  </msContents>
+                  <physDesc>
+                     <objectDesc/>
+                  </physDesc>
+                  <history>
+                     <origin>
+                        <origDate calendar="Gregorian">s. XII</origDate>
+                     </origin>
+                  </history>
+               </msPart>
+               <msPart xml:id="University_College_MS_45-part3" n="3">
+                  <msIdentifier>
+                     <altIdentifier type="partial">
+                        <idno type="part">University College MS. 45 - Part 3</idno>
+                     </altIdentifier>
+                  </msIdentifier>
+                  <msContents>
+                     <msItem xml:id="University_College_MS_45-part3-item1" n="1">
+                        <author key="person_154144782727969775144">Clement, of Llanthony</author>
+                        <title>Libellus</title>
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                     <msItem xml:id="University_College_MS_45-part3-item2" n="2">
+                        <author>Anon</author>
+                        <title>De quinque septenis in Scriptura</title>
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                     <msItem xml:id="University_College_MS_45-part3-item3" n="3">
+                        <author key="person_282035032">Hildebert, Archbishop of Tours, 1056?-1133</author>
+                        <title>Carmen de expositione missæ</title>
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                     <msItem xml:id="University_College_MS_45-part3-item4" n="4">
+                        <title>Versus xxii. de diversis</title>
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                     <msItem xml:id="University_College_MS_45-part3-item5" n="5">
+                        <title>Expositio brevis metrica orationis Dominicæ</title>
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                     <msItem xml:id="University_College_MS_45-part3-item6" n="6">
+                        <author key="person_282035032">Hildebert, Archbishop of Tours, 1056-1133</author>
+                        <title>Hymnus</title>
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                     <msItem xml:id="University_College_MS_45-part3-item7" n="7">
+                        <title>Hexæmeron</title>
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                     <msItem xml:id="University_College_MS_45-part3-item8" n="8">
+                        <title>Narrationes de fratribus sanctisque ex SS. Bibliis et Vitas Patrum</title>
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                     <msItem xml:id="University_College_MS_45-part3-item9" n="9">
+                        <author>Rolle, Richard, 1290?-1349 (Richard Hampole)</author>
+                        <title>Commentary on Job and the Psalms</title>
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                  </msContents>
+                  <physDesc>
+                     <objectDesc/>
+                  </physDesc>
+                  <history>
+                     <origin>
+                        <origDate calendar="Gregorian">s. XIV</origDate>
+                     </origin>
+                  </history>
+               </msPart>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_5.xml
+++ b/collections/University_College/University_College_MS_5.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13001">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 5</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_5</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_5">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 5</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_5-item1" n="1">
+                     <title>Horæ B. Mariæ Virginis (Use of Dominicans at Tréguier)</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>"Fine miniatures (partly defaced), close in style to Bodl. MS. Laud Lat. 15. Good borders, initials. (cf. no. 805 [Jesus College 32])." (IMOCL) Illustration of the Nativity, p. 56. (PTB)</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Limp vellum.</p>
+                     </binding>
+                  </bindingDesc>
+                  <accMat>“William Smith […] used galls to revive faded passages. In no. 5 he tried an experiment. He applied the galls to the two bottom lines of the text and wrote underneath; ‘Ultimae istae duae lineae (ceteris jam multo nigriores) gallis aqua macerates delinitae errant Aug 28 anno 1700. Notent posteri quamdiu ista coloris differentia permanebit; et quid commodi vel damni inde sequetur’. The two lines are still blacker than the rest, and the parchment is stained brown, but no worse effects have followed. But Smith tried his galls on an erased inscription at the top of the page in vain, and so made impossible the use of other methods of recovering it.” (Hunt, p. 13)</accMat>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1300" notAfter="1330">s. XIVin.</origDate>
+                  </origin>
+                  <provenance>Formerly belonged to Robert Young. (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=20">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 2</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 806. [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_52.xml
+++ b/collections/University_College/University_College_MS_52.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13034">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 52</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_52</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_52">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 52</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_52-item1" n="1">
+                     <author>Constantinus Sacerdotus</author>
+                     <title>Octateuchus</title>
+                     <textLang mainLang="el">Greek</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Red russia</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1100" notAfter="1200">s. XII</origDate>
+                  </origin>
+                  <provenance>"olim Thomæ Cayii deinde Johannis Brown, coll. Univ. socii, postea ejusdem coll. ex dono Joh. Bancroft." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=33">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 15</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_53.xml
+++ b/collections/University_College/University_College_MS_53.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13035">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 53</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_53</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_53">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 53</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_53-item1" n="1">
+                     <title>Theological tracts and letters.</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="paper">
+                        <support>paper</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary blind-stamped and ruled brown leather over boards</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_1000070">France</country>; <country key="place_7016845">The Netherlands</country>
+                     </origPlace>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=33">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 15</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_54.xml
+++ b/collections/University_College/University_College_MS_54.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13036">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 54</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_54</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_54">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 54</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_54-item1" n="1">
+                     <author key="person_297475745">John Chrysostom, Saint, -407</author>
+                     <title>Homilies on John, transl. Burgundio of Pisa</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>"Fine border (mutilated), historiated and other initials. By the same hand as Bodl. MS. Digby 231, Francesco d'Antonio del Cherico. Humanistic script." (IMOCL)</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>19th-century</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                  </origin>
+                  <provenance>"olim Francisci Clethero." (Coxe) "Thomas Clifford, Franc. Clethero, saec. xv (?), fol. 227." (IMOCL)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=34">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 16</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 956 [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_55.xml
+++ b/collections/University_College/University_College_MS_55.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13037">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 55</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_55</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_55">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 55</idno>
+               </msIdentifier>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <p>Composite manuscript in 2 parts</p>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>16th-century ruled brown leather over pasteboard</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1200" notAfter="1300">1200–1300</origDate>
+                  </origin>
+                  <provenance>"olim Thomæ Browne, postea coll. Univ., ex dono Johannis Bancroft." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=34">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 16</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+               <msPart xml:id="University_College_MS_55-part1" n="1">
+                  <msIdentifier>
+                     <altIdentifier type="partial">
+                        <idno type="part">University College MS. 55 - Part 1</idno>
+                     </altIdentifier>
+                  </msIdentifier>
+                  <msContents>
+                     <msItem xml:id="University_College_MS_55-part1-item1" n="1">
+                        <author key="person_51797933">Peter Lombard, Bishop of Paris, approximately 1100-1160</author>
+                        <title>Sentences</title>
+                        <!--Possible work keys: work_6593 or work_3510 or work_2268-->
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                  </msContents>
+                  <physDesc>
+                     <objectDesc/>
+                  </physDesc>
+                  <history>
+                     <origin>
+                        <origDate calendar="Gregorian">s. XIII</origDate>
+                        <origPlace>
+                           <country key="place_1000070">France</country>
+                        </origPlace>
+                     </origin>
+                  </history>
+               </msPart>
+               <msPart xml:id="University_College_MS_55-part2" n="2">
+                  <msIdentifier>
+                     <altIdentifier type="partial">
+                        <idno type="part">University College MS. 55 - Part 2</idno>
+                     </altIdentifier>
+                  </msIdentifier>
+                  <msContents>
+                     <msItem xml:id="University_College_MS_55-part2-item1" n="1">
+                        <author key="person_37045656">Henry, of Ghent, 1217?-1293</author>
+                        <title>Quodlibeta</title>
+                        <!--Possible work keys: work_7030 or work_245-->
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                     <msItem xml:id="University_College_MS_55-part2-item2" n="2">
+                        <title>Arbor consanguinitatis</title>
+                        <!--Possible work keys: work_17012-->
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                  </msContents>
+                  <physDesc>
+                     <objectDesc/>
+                  </physDesc>
+                  <history>
+                     <origin>
+                        <origDate calendar="Gregorian">s. XIII</origDate>
+                        <origPlace>
+                           <country key="place_7002445">England</country>
+                        </origPlace>
+                     </origin>
+                  </history>
+               </msPart>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_56.xml
+++ b/collections/University_College/University_College_MS_56.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13038">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 56</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_56</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_56">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 56</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_56-item1" n="1">
+                     <title>Kalendarium (Christ Church Canterbury)</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_56-item2" n="2">
+                     <author key="person_2465074">Rolle, Richard, 1290?-1349</author>
+                     <title>Commentary on the Psalms</title>
+                     <!--Possible work keys: work_1737 or work_1849 or work_1733 or work_4279 or work_3361 or work_790 or work_549 or work_1208 or work_11273 or work_11274-->
+                     <textLang mainLang="enm">Middle English</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_56-item3" n="3">
+                     <author key="person_2465074">Rolle, Richard, 1290?-1349</author>
+                     <title>Commentary on Cantica Sacra</title>
+                     <textLang mainLang="enm">Middle English</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_56-item4" n="4">
+                     <title>Te deum laudamus and Athanasian Creed</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Flourish initials and borders in red, blue, and purple. "Fine penwork borders, initials." (IMOCL)</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>16th-century leather panelled in blind, diapers with pineapple tool (rebacked, preserving original spine)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1450">s. XVin.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim cujusdam e familia de Hamptone, postea coll. Univ. e dono Samuelis Clerke, coll. Univ. commensalis, A.D. 1641." (Coxe) "Calendar of Christ Church, Canterbury, with obits of the Hampton family, 1413-22, fols. 1—5v. Given by Samuel Clarke, commoner 1641, fols. 1, 264v." (IMOCL)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=34">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 16</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 395 [information on decoration and origin]</bibl>
+                              <bibl>
+                                 <title>IMEP</title>, p. 105</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_57.xml
+++ b/collections/University_College/University_College_MS_57.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13039">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 57</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_57</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_57">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 57</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_57-item1" n="1">
+                     <author key="person_41951136">Guilelmus Peraldus, approximately 1190-1271</author>
+                     <title>Sermones Dominicales (Gospels)</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="paper">
+                        <support>paper</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Old leather over wooden boards (rebacked)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                  </origin>
+                  <provenance>“Companion volume to University College MS. 75 so probably presented by Master William Asplyon.” (Note in Duke Humphrey's copy of Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=35">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 17</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_58.xml
+++ b/collections/University_College/University_College_MS_58.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13040">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 58</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_58</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_58">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 58</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_58-item1" n="1">
+                     <title>Gospels, glossed</title>
+                     <!--Possible work keys: work_12104 or work_12105-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Flourish initials</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Medieval brown leather over bevelled wooden boards, possibly original</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1100" notAfter="1250">s. XII or XIIIin.</origDate>
+                     <origPlace>
+                        <country key="place_1000070">France</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"ex dono Gul. Green, armigeri nuper hujus collegii commensalis superioris ordinis 1683." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=35">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 17</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_59.xml
+++ b/collections/University_College/University_College_MS_59.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13041">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 59</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_59</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_59">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 59</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_59-item1" n="1">
+                     <author key="person_100187025">Anselm, Saint, Archbishop of Canterbury, 1033-1109</author>
+                     <title>Opera varia</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>17th-century calf</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1200" notAfter="1300">s. XIII</origDate>
+                     <origPlace>
+                        <country key="place_1000070">France</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>Early side notes in English hand. "olim Thomæ Browne, postea coll. Uinv. Ex dono Johannis Bancroft." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=35">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 17</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_6.xml
+++ b/collections/University_College/University_College_MS_6.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13002">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 6</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_6</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_6">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 6</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_6-item1" n="1">
+                     <author key="person_66806872">Augustine, Saint, Bishop of Hippo</author>
+                     <title>Sermons</title>
+                     <!--Possible work keys: work_6226 or work_6215 or work_6157 or work_6101 or work_1465 or work_1467 or work_3263 or work_3372 or work_1846 or work_1068 or work_2194 or work_1899 or work_3540 or work_550 or work_3999 or work_4873 or work_3261 or work_1937 or work_2310 or work_1299 or work_3358 or work_3580 or work_3020 or work_2674 or work_2675 or work_3236 or work_1302 or work_1081 or work_2567 or work_3369 or work_4557 or work_3511 or work_1431 or work_1660 or work_4256 or work_2695 or work_1054 or work_3485 or work_1760 or work_3284 or work_820 or work_1745 or work_403 or work_3907 or work_2172 or work_1309 or work_4384 or work_3147 or work_3148 or work_2142 or work_1423 or work_4600 or work_2939 or work_2942 or work_14583-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_6-item2" n="2">
+                     <title>Locutiones super heptateuchum</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_6-item3" n="3">
+                     <author>Anon.</author>
+                     <title>Quaestiones theologicae et de praedicamentis</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_6-item4" n="4">
+                     <author key="person_100184667">Gregory, I, Pope, approximately 540-604</author>
+                     <title>Cognomento Magni Dialogorum libri quatuor</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_6-item5" n="5">
+                     <author key="person_100184667">Gregory, I, Pope, approximately 540-604</author>
+                     <title>Pastoralis libri duo</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_6-item6" n="6">
+                     <author>Quintilian, Ps. [?]</author>
+                     <title>Declamationes</title>
+                     <!--Possible work keys: work_4098-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_6-item7" n="7">
+                     <title>Fragmentum dialogi inter Trismegistrum et Asclepium</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_6-item8" n="8">
+                     <author key="person_2191">William of Conches, pseudo</author>
+                     <title>Philosophiae compendium</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_6-item9" n="9">
+                     <author key="person_23497389">Seneca, Lucius Annaeus, the elder, approximately 55 B.C.-approximately 39 A.D.</author>
+                     <title>Opuscula varia</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>18th-century calf. Rebound c. 1700, William Smith's instructions to the binder on p. 368.</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1170" notAfter="1350">s. XIII or XIV</origDate>
+                     <origPlace>
+                        <country key="place_1000070">France</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>Formerly belonged to the Dominicans of Beverley. (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=20">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 2</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_60.xml
+++ b/collections/University_College/University_College_MS_60.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13042">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 60</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_60</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_60">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 60</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_60-item1" n="1">
+                     <author key="person_66805034">Haqueville, Nicolaus de</author>
+                     <title>Sermones dominicales</title>
+                     <!--Possible work keys: work_1936 or work_2694 or work_3283-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_60-item2" n="2">
+                     <author>Grossteste, Robert, 1175?-1253</author>
+                     <title>Liber de venenis</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_60-item3" n="3">
+                     <author key="person_89657091">Bonaventure, Saint, Cardinal, approximately 1217-1274</author>
+                     <title>Works</title>
+                     <!--Possible work keys: work_2377 or work_1468 or work_1344 or work_1204 or work_3687 or work_1880 or work_541 or work_4397 or work_2912 or work_2088 or work_3006 or work_1132 or work_1702 or work_2100 or work_485 or work_270 or work_4650 or work_3652 or work_4657 or work_1858 or work_726 or work_3990 or work_3993 or work_3158 or work_1818 or work_1839 or work_4436 or work_4224 or work_3354 or work_2771 or work_1823 or work_2187 or work_3289 or work_866 or work_3083 or work_1168 or work_1483 or work_4186 or work_3869 or work_853 or work_1572 or work_2005 or work_3212 or work_1315 or work_451 or work_1020 or work_3833 or work_2021 or work_1788 or work_4296 or work_1284 or work_575 or work_4782 or work_4783 or work_3721 or work_4737 or work_3096 or work_587 or work_1184 or work_2071 or work_2072 or work_4124 or work_4817 or work_2906 or work_4161 or work_3243 or work_2680 or work_2681 or work_3955 or work_4412 or work_1708 or work_2641 or work_3237 or work_1064 or work_3570 or work_2478 or work_2479 or work_4796 or work_1432 or work_4153 or work_686 or work_4254 or work_4674 or work_4879 or work_2880 or work_1519 or work_1057 or work_3249 or work_1193 or work_4552 or work_4553 or work_915 or work_824 or work_320 or work_1980 or work_2458 or work_3469 or work_3915 or work_1377 or work_678 or work_679 or work_1629 or work_2234 or work_1276 or work_1882 or work_2528 or work_1091 or work_3800 or work_1636 or work_2270 or work_4925 or work_347 or work_3428 or work_3128 or work_1548 or work_1563 or work_4735 or work_935 or work_936 or work_632 or work_574 or work_3084 or work_1149 or work_212 or work_3011 or work_3125 or work_5014 or work_703 or work_2433 or work_5057 or work_2964 or work_831 or work_4329 or work_1658 or work_3197 or work_2158 or work_389-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_60-item4" n="4">
+                     <author key="person_22158282">Lydgate, John, 1370?-1451?</author>
+                     <title>Verses</title>
+                     <!--Possible work keys: work_2009 or work_15430 or work_15431 or work_15432 or work_15433 or work_15434 or work_15435 or work_15437-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Written by Hugh Hall</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary white leather over bevelled boards</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim Thomæ, et Johannis Browne, deinde F. Drake, et denuo coll. Univ. ex dono Tho. Walker. Magistri." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=35">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 17</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_61.xml
+++ b/collections/University_College/University_College_MS_61.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13043">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 61</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_61</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_61">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 61</idno>
+               </msIdentifier>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <p>Composite manuscript in 3 parts</p>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary brown leather over boards.</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1200" notAfter="1400">1200–1400</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"Iste liber pertinet communitate Fratrum Solopiæ." (fol. 2v) "olim Thomæ Browne, postea coll. Univ. ex dono Tho. Walker, magistri." (Coxe) "Richard Gosmore, fellow of Magdalen College (d. 1547); Thomas Broune, Christ Church scholar, vicar of Kingsclere (d. 1587), fol. Iv. Given by Thomas Walker, master (d. 1665), fol. 2." (IMOCL)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=36">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 18</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 304 [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+               <msPart xml:id="University_College_MS_61-part1" n="1">
+                  <msIdentifier>
+                     <altIdentifier type="partial">
+                        <idno type="part">University College MS. 61 - Part 1</idno>
+                     </altIdentifier>
+                  </msIdentifier>
+                  <msContents>
+                     <msItem xml:id="University_College_MS_61-part1-item1" n="1">
+                        <author>Valerius</author>
+                        <title>Ad Ruffinam</title>
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                  </msContents>
+                  <physDesc>
+                     <objectDesc/>
+                  </physDesc>
+                  <history>
+                     <origin>
+                        <origDate calendar="Gregorian">s. XIVin.</origDate>
+                     </origin>
+                  </history>
+               </msPart>
+               <msPart xml:id="University_College_MS_61-part2" n="2">
+                  <msIdentifier>
+                     <altIdentifier type="partial">
+                        <idno type="part">University College MS. 61 - Part 2</idno>
+                     </altIdentifier>
+                  </msIdentifier>
+                  <msContents>
+                     <msItem xml:id="University_College_MS_61-part2-item1" n="1">
+                        <author key="person_100184667">Gregory, I, Pope, approximately 540-604</author>
+                        <title>Sermon on Ezekiel</title>
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                  </msContents>
+                  <physDesc>
+                     <objectDesc/>
+                  </physDesc>
+                  <history>
+                     <origin>
+                        <origDate calendar="Gregorian">s. XIII</origDate>
+                     </origin>
+                  </history>
+               </msPart>
+               <msPart xml:id="University_College_MS_61-part3" n="3">
+                  <msIdentifier>
+                     <altIdentifier type="partial">
+                        <idno type="part">University College MS. 61 - Part 3</idno>
+                     </altIdentifier>
+                  </msIdentifier>
+                  <msContents>
+                     <msItem xml:id="University_College_MS_61-part3-item1" n="1">
+                        <title>Meditation of St Bernard</title>
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                     <msItem xml:id="University_College_MS_61-part3-item2" n="2">
+                        <author>St Jerome</author>
+                        <title>Lives of the Desert Fathers</title>
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                     <msItem xml:id="University_College_MS_61-part3-item3" n="3">
+                        <author key="person_66806872">Augustine, Saint, Bishop of Hippo</author>
+                        <title>Edicta de animæ egressione a corpore</title>
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                     <msItem xml:id="University_College_MS_61-part3-item4" n="4">
+                        <title>Vita Fursei, ed. by Bede</title>
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                  </msContents>
+                  <physDesc>
+                     <objectDesc/>
+                  </physDesc>
+                  <history>
+                     <origin>
+                        <origDate calendar="Gregorian">s. XIV</origDate>
+                     </origin>
+                  </history>
+               </msPart>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_63_also_University_College_MS_62_.xml
+++ b/collections/University_College/University_College_MS_63_also_University_College_MS_62_.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13044">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 63 (also University College MS. 62)</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_63_also_University_College_MS_62_</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en"
+                    xml:id="University_College_MS_63_also_University_College_MS_62_">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 63 (also University College MS. 62)</idno>
+               </msIdentifier>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <p>Composite manuscript in 2 parts</p>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Early 16th-century blind-stamped leather over boards. "saec. xvi in., possibly A . Lysley, Eton." (IMOCL)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1200" notAfter="1500">1200–1500</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>; <country key="place_1000070">France</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"ex dono Mariæ Elmhurst, in gratiam unici sui nati Hereberti Elmhurst, collegii scholaris, et in collegio mortui." (Coxe) "Humphrey Gilbert, c. 1551, fol. 64v and on lower cover. Given by Maria Elmhurst in memory of Herbert Elmhurst, scholar (d. 1670), first pastedown." (IMOCL) Eton (Ker and Watson)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=37">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 19</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 409 [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+               <msPart xml:id="University_College_MS_63_also_University_College_MS_62_-part1"
+                       n="1">
+                  <msIdentifier>
+                     <altIdentifier type="partial">
+                        <idno type="part">University College MS. 63 (also University College MS. 62) - Part 1</idno>
+                     </altIdentifier>
+                  </msIdentifier>
+                  <msContents>
+                     <msItem xml:id="University_College_MS_63_also_University_College_MS_62_-part1-item1"
+                             n="1">
+                        <author>Grossteste, Robert, 1175?-1253</author>
+                        <title>De lingua et corde</title>
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                     <msItem xml:id="University_College_MS_63_also_University_College_MS_62_-part1-item2"
+                             n="2">
+                        <author key="person_67781845">Gilbert, of Hoyland</author>
+                        <title>Commentary on St Paul's Epistles</title>
+                        <!--Possible work keys: work_3542 or work_487 or work_1531 or work_4745 or work_1958 or work_4173 or work_3343-->
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                  </msContents>
+                  <physDesc>
+                     <objectDesc/>
+                  </physDesc>
+                  <history>
+                     <origin>
+                        <origDate calendar="Gregorian">s. XIII</origDate>
+                     </origin>
+                  </history>
+               </msPart>
+               <msPart xml:id="University_College_MS_63_also_University_College_MS_62_-part2"
+                       n="2">
+                  <msIdentifier>
+                     <altIdentifier type="partial">
+                        <idno type="part">University College MS. 63 (also University College MS. 62) - Part 2</idno>
+                     </altIdentifier>
+                  </msIdentifier>
+                  <msContents>
+                     <msItem xml:id="University_College_MS_63_also_University_College_MS_62_-part2-item1"
+                             n="1">
+                        <title>Postilla super librum Danielis</title>
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                  </msContents>
+                  <physDesc>
+                     <objectDesc/>
+                  </physDesc>
+                  <history>
+                     <origin>
+                        <origDate calendar="Gregorian">s. XV</origDate>
+                     </origin>
+                  </history>
+               </msPart>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_64.xml
+++ b/collections/University_College/University_College_MS_64.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13045">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 64</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_64</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_64">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 64</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_64-item1" n="1">
+                     <author key="person_2465074">Rolle, Richard, 1290?-1349</author>
+                     <title>Commentary on the Psalms</title>
+                     <!--Possible work keys: work_1737 or work_1849 or work_1733 or work_4279 or work_3361 or work_790 or work_549 or work_1208 or work_11273 or work_11274-->
+                     <textLang mainLang="enm">Middle English (Yorkshire dialect)</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_64-item2" n="2">
+                     <author key="person_2465074">Rolle, Richard, 1290?-1349</author>
+                     <title>Commentary on the Canticles</title>
+                     <textLang mainLang="enm">Middle English (Yorkshire dialect)</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="paper">
+                        <support>paper</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>12th-century white leather over square-cut boards (rebacked), head spine tab (lacking strap and pin)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim Tho. Walker, magistri." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=37">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 19</ref>
+                              </bibl>
+                              <bibl>
+                                 <title>IMEP</title>, pp. 107-8</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_65.xml
+++ b/collections/University_College/University_College_MS_65.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13046">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 65</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_65</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_65">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 65</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_65-item1" n="1">
+                     <title>Exhortationes canctorum patrum</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Initials in green and red, four large and patterned</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>19th-century half morocco</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1100" notAfter="1200">s. XII</origDate>
+                  </origin>
+                  <provenance>"olim W. Rogers de Paynswick." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=37">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 19</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_66.xml
+++ b/collections/University_College/University_College_MS_66.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13047">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 66</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_66</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_66">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 66</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_66-item1" n="1">
+                     <author key="person_100184667">Gregory, I, Pope, approximately 540-604</author>
+                     <title>Moralia in Job (from Book XXI, lacking end)</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Initials in green, red, and blue</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Later medieval brown leather over wooden boards (worn and rebacked)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1100" notAfter="1200">s. XII</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"ex dono Thomæ Walker, magistri." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=38">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 20</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_67.xml
+++ b/collections/University_College/University_College_MS_67.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13048">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 67</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_67</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_67">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 67</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_67-item1" n="1">
+                     <title>Alphabetum narrationum</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_67-item2" n="2">
+                     <title>In vitis patrum</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary white leather over bevelled wooden boards with strap (lacking pin)</p>
+                     </binding>
+                  </bindingDesc>
+                  <accMat>Preachers' aid from the Dominican convent at Beverley.</accMat>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1350" notAfter="1400">s. XIVex.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim libri de communitate fratrum Prædicatorum conventus Beverlaci; postea 'liber Thorgott, dono Nicolai Mell." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=38">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 20</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_68.xml
+++ b/collections/University_College/University_College_MS_68.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13049">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 68</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_68</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_68">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 68</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_68-item1" n="1">
+                     <author key="person_264344179">Aquinas, Thomas, Saint, 1225-1274</author>
+                     <title>Summa contra gentiles</title>
+                     <!--Possible work keys: work_4779-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Flourish initials</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>15th-century ruled calf over bevelled wooden boards (rebacked, lacking clasps). "Binding identical with Bodley MS 214." (DHC)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1200" notAfter="1300">s. XIII</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>; <placeName key="place_7012044">Canterbury</placeName>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim, ut videtur, Roberti de Wynchelsey, archiepiscopi Cantuarensis; postea H. Sutton." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=38">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 20</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_69.xml
+++ b/collections/University_College/University_College_MS_69.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13050">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 69</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_69</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_69">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 69</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_69-item1" n="1">
+                     <author>Roger, monk of Croyland</author>
+                     <title>Life of Thomas Beckett</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>19th-century pigskin</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1200" notAfter="1300">s. XIII</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim liber ecclesiæ ….. Wintoniæ, postea Johannis Theyer, de Copwers Hill juxta Gloucest." (Coxe) Given by W. Rogers (DHC)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett.</p>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_7.xml
+++ b/collections/University_College/University_College_MS_7.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13003">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 7</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_7</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_7">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 7</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_7-item1" n="1">
+                     <title>Psalter, with Sarum hymns</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Decorated initials and full-page bar-boarders with dragons at divisions</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>16th-century, purple velvet repaired with purple reversed calf.</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1370" notAfter="1400">s. XIVex.</origDate>
+                     <origPlace>
+                        <country key="place_1000070">France</country>; <placeName key="place_7008038">Paris</placeName>
+                     </origPlace>
+                  </origin>
+                  <provenance>"Note (largely erased), fol. 138v, saec. xv ed., 'Jehan …(diepp … enfant de … cathedralle) … de Rouen'." (IMOCL)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=21">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 3</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 742 [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_70.xml
+++ b/collections/University_College/University_College_MS_70.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13051">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 70</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_70</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_70">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 70</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_70-item1" n="1">
+                     <author key="person_57004795">Johannes, Felton, -1434</author>
+                     <title>Sermones dominicales</title>
+                     <!--Possible work keys: work_1936 or work_2694 or work_3283-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="paper">
+                        <support>paper</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Flourish initials</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary tawed skin over wooden boards (window fragment and nails on lower board)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>From the medieval library in University College Oxford (DHC)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=38">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 20</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_71.xml
+++ b/collections/University_College/University_College_MS_71.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13052">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 71</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_71</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_71">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 71</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_71-item1" n="1">
+                     <title>Septuplum</title>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>"Good initials. Penwork initials, cadels." (IMOCL)</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Trimmed chemise binding, tawed leather. "Contemporary binding of white leather on boards." (IMOCL)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1450">s. XVin.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim liber Magistri Hawkyns, ex dono Roberti Page, postea coll. Univ. ex dono Willelmi Hawkyns." (Coxe) "Given by William Hawkyns, fellow, 1527, fol. 14v." (IMOCL)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=39">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 21</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 479 [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_72.xml
+++ b/collections/University_College/University_College_MS_72.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13053">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 72</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_72</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_72">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 72</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_72-item1" n="1">
+                     <title>Britton (Operis juridicalis)</title>
+                     <textLang mainLang="fr">French</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Initials with leaves</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>19th-century pigskin</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1270" notAfter="1450">s. XIIIex. or XIV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=39">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 21</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_74.xml
+++ b/collections/University_College/University_College_MS_74.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13054">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 74</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_74</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_74">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 74</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_74-item1" n="1">
+                     <author key="person_2465074">Rolle, Richard, 1290?-1349</author>
+                     <title>Commentary on the Psalms</title>
+                     <!--Possible work keys: work_1737 or work_1849 or work_1733 or work_4279 or work_3361 or work_790 or work_549 or work_1208 or work_11273 or work_11274-->
+                     <textLang mainLang="enm">Middle English</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary leather over wooden boards</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>Given by Thomas Walker (DHC)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=40">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 22</ref>
+                              </bibl>
+                              <bibl>
+                                 <title>IMEP</title>, p. 108</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_75.xml
+++ b/collections/University_College/University_College_MS_75.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13055">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 75</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_75</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_75">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 75</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_75-item1" n="1">
+                     <author key="person_41951136">Guilelmus Peraldus, approximately 1190-1271</author>
+                     <title>Sermones Dominicales (Epistles)</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="paper">
+                        <support>paper</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>small flourish initials.</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary white tawed skin over wooden boards</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>“fol 44r John Dowetyng. Ex dono Magr Willi As[plyon] (label on back cover)” (DHC) See University College MS. 57 (companion volume)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=40">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 22</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_76.xml
+++ b/collections/University_College/University_College_MS_76.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13056">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 76</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_76</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_76">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 76</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_76-item1" n="1">
+                     <title>Repertorium de re theologica philosophicaque</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="paper">
+                        <support>paper</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary white leather over wooden boards</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim Johannis Castell." (Coxe). Commonplace book of John Castell, Master of Univ., 1410-20.</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=40">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 22</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_77.xml
+++ b/collections/University_College/University_College_MS_77.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13057">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 77</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_77</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_77">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 77</idno>
+               </msIdentifier>
+               <msContents>
+                  <textLang mainLang="la">Latin</textLang>
+                  <msItem xml:id="University_College_MS_77-item1" n="1">
+                     <title>Gospel of Matthew, glossed</title>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_77-item2" n="2">
+                     <title>Treatise on the Mass</title>
+                     <!--Possible work keys: work_15090 or work_15091-->
+                  </msItem>
+                  <msItem xml:id="University_College_MS_77-item3" n="3">
+                     <title>Gospel of Luke, glossed</title>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>White leather over square ended wooden boards</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1200" notAfter="1300">s. XIII</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"de communitate fratrum minorum Salopie [Shrewsbury, Franciscans]." (f. 2r) "olim liber de communitate fratrum minorum Salopiæ, postea ex librario monasterii de Hangmod [Haughmond] sumptus et Ricardo Fowler præsentatus a Johanne Shelrock, rectore de Smethcott, 4 Aug. 1606." (Coxe) Label of gift to college, 1606, behind horn window on spine.</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=40">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 22</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_78A.xml
+++ b/collections/University_College/University_College_MS_78A.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13058">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 78A</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_78A</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_78A">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 78A</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_78A-item1" n="1">
+                     <title>Missal, use of Hereford</title>
+                     <textLang mainLang="la" otherLangs="enm">Latin ; Middle English</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>"Fine borders, fine and other initials." (IMOCL)</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Leather spine, exposed wooden boards (rebacked).</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1450">s. XVin.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim Gul. Rogers, ex hospit. Lincoln. 1668." (Coxe) "Dedication of Hereford Cathedral in the calendar. Dedication of St Dubricius, Whitchurch, Monmouthshire, probably a contemporary addition. Given in 1668 by William Rogers of Painswyck, commoner, fols. 1,7, 227v." (IMOCL) Parish of Whitchurch, Herefordshire (Ker, p. 389).</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=41">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 23</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 422 [information on decoration and origin]</bibl>
+                              <bibl>
+                                 <title>IMEP</title>, pp. 108-9</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_78B.xml
+++ b/collections/University_College/University_College_MS_78B.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13059">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 78B</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_78B</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_78B">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 78B</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_78B-item1" n="1">
+                     <title>Missal, use of York</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Illuminated, flourish initials. "Sketch of a figure, fol. 184v." (IMOCL)</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary trimmed chemise binding</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1430" notAfter="1470">s. XVmed.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim ecclesiæ de Cocknay ex dono Willelmi Sheppard." (Coxe) "Calendar (feast of relics 19 Oct.) suggests York Minster. Obit of Margaret Haverham, 1532. Given to Cuckney church by William Sheppard. Fols. 1, 184v. Given to the College by Thomas Walker, master (d. 1665)." (IMOCL)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=41">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 23</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 509 [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_79.xml
+++ b/collections/University_College/University_College_MS_79.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13060">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 79</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_79</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_79">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 79</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_79-item1" n="1">
+                     <author key="person_89410360">Rainerius, de Pisis, -approximately 1348</author>
+                     <title>Summæ Theologiæ (pars prima, A-E)</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="paper">
+                        <support>paper</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary white leather over wooden boards. Nail and chain marks.</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"ex dono Will. Asplyon, unius e xij. Sacerdotibus monast. S. Salvatoris in Sion; 1473." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=41">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 23</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_8.xml
+++ b/collections/University_College/University_College_MS_8.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13004">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 8</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_8</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_8">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 8</idno>
+               </msIdentifier>
+               <msContents>
+                  <textLang mainLang="la">Latin</textLang>
+                  <msItem xml:id="University_College_MS_8-item1" n="1">
+                     <title>Tabula ad inveniendum Pascha</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_8-item2" n="2">
+                     <title>Kalendarium, monostichis instructum</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_8-item3" n="3">
+                     <title>Book of Hours, Use of Sarum</title>
+                     <!--Possible work keys: work_10575 or work_10576 or work_10577 or work_10579-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_8-item4" n="4">
+                     <title>Prayers to St Osith</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>"Miniatures (unfinished) in Flemish style inserted on separate leaves. Good penwork initials." (IMOCL)</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary leather over bevelled wooden boards.</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1440" notAfter="1470">s. XVmed.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim, ut videtur ex insignibus gentilis in fronte depictis, eujusdam e familia de Percy, postea Roberti Lover, e dono dominæ Greete de Midhurst, viduæ x. Jul. 1549." (Coxe) "Arms of the Percy family on an added leaf, cut down, fol. 4v. Given to Robert Lover, 10 July 1549, by Greete de Medhurst in Sussex, fol. 107." (IMOCL) Ownership inscription at f. 107 possibly enhanced by William Smith: "Robert Lovehers booke geuen of gentle maistres Greete wydowe at Medhurst the x of Julye, anno Domini 1549, Sussex, clearke there in Medhurst predict." (PTB)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett.</p>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_80.xml
+++ b/collections/University_College/University_College_MS_80.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13061">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 80</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_80</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_80">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 80</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_80-item1" n="1">
+                     <author key="person_89410360">Rainerius, de Pisis, -approximately 1348</author>
+                     <title>Summæ Theologiæ (pars altera, E-I)</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="paper">
+                        <support>paper</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary white leather over wooden boards</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=41">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 23</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_81A.xml
+++ b/collections/University_College/University_College_MS_81A.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13062">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 81A</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_81A</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_81A">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 81A</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_81A-item1" n="1">
+                     <author key="person_89410360">Rainerius, de Pisis, -approximately 1348</author>
+                     <title>Summæ Theologiæ (volumen quarta, P-R)</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="paper">
+                        <support>paper</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary white leather over wooden boards</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=41">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 23</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_81B.xml
+++ b/collections/University_College/University_College_MS_81B.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13063">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 81B</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_81B</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_81B">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 81B</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_81B-item1" n="1">
+                     <title>Alphabetum narrationum, In vitis patrum</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="paper">
+                        <support>paper</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary white leather over wooden boards</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=41">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 23</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_82.xml
+++ b/collections/University_College/University_College_MS_82.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13064">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 82</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_82</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_82">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 82</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_82-item1" n="1">
+                     <title>Cartulary of St John's Beverley (Beverley Minster)</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>"Fine historiated initials (drawings). Calligraphic interlace initials." (IMOCL) Late fourtheenth century drawing of Athelstan and St John of Beverley (f. 7r).</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>"Metal cross, a roundel with a distich under horn cover on more recent binding of brown leather on pasteboard." (IMOCL)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"St. John's, Beverley, Yorks." (IMOCL)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=42">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 24</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 548 [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_84.xml
+++ b/collections/University_College/University_College_MS_84.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13065">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 84</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_84</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_84">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 84</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_84-item1" n="1">
+                     <author>Justinian</author>
+                     <title>Codex, glossed by Franciscus Accurius</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>English 15th-century white leather over wooden boards (lacking clasps)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1200" notAfter="1300">s. XIII</origDate>
+                  </origin>
+                  <provenance>"ex dono Thomæ Walker, S.T.P. magistri." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=43">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 25</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_85.xml
+++ b/collections/University_College/University_College_MS_85.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13066">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 85</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_85</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_85">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 85</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_85-item1" n="1">
+                     <author>Alain Chartier</author>
+                     <title>Quadrilogue invectif</title>
+                     <textLang mainLang="enm">Middle English</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_85-item2" n="2">
+                     <author>Pseudo-Aristotle (trans. John Lydgate)</author>
+                     <title>Secreet of Secreets</title>
+                     <textLang mainLang="enm">Middle English</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_85-item3" n="3">
+                     <title>Three consideracions right necessarye to the good gouernaunce of a prince</title>
+                     <textLang mainLang="enm">Middle English</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Two half-page miniatures , borders (including two full bar borders) and text decoration</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>19th-century brown leather</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1430" notAfter="1500">s. XVmed.-ex.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>; <placeName key="place_7011781">London</placeName>
+                     </origPlace>
+                  </origin>
+                  <provenance>"Crest, two arms embossed vested azure, holding between the hands proper a garb or and the motto 'Oublier ne doit', pp. 1, 70. Verses in French by Michel Otheu [Otthen], physician of Emperor Maxmilian II addressed to Anne, duchess of Somerset, added pp. 2, 18, 180, 1585." (IMOCL) Possibly given by Obadiah Walker, s. VXII.</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=43">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 25</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 549 [information on decoration and origin]</bibl>
+                              <bibl>
+                                 <title>IMEP</title>, p. 108-9</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_86.xml
+++ b/collections/University_College/University_College_MS_86.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13067">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 86</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_86</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_86">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 86</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_86-item1" n="1">
+                     <author key="person_33242385">Gratian, active 12th century</author>
+                     <title>Decretum</title>
+                     <!--Possible work keys: work_1806-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>"Good miniature. Fine initials. Fine penwork initials. Marginal sketch, fol. 267. Fols. 189-243 an insertion of saec. xiii in. with fine penwork initials." (IMOCL)</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>14th-century tawed leather over wooden boards to page edge. Originally had seven clasps.</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1260" notAfter="1300">s. XIIIex.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>; <placeName key="place_7010027">Durham </placeName> (?)</origPlace>
+                  </origin>
+                  <provenance>"olim armarioli communis Dunelmensis, postea Johannis de Kelton." (Coxe) Give by Charles Hales. (DHC) "Ex libris of Durham cathedral and pressmark 'Q', saec. xv. fol. 1. (IMOCL)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=44">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 26</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 265 [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_87.xml
+++ b/collections/University_College/University_College_MS_87.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13068">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 87</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_87</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_87">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 87</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_87-item1" n="1">
+                     <author key="person_66806872">Augustine, Saint, Bishop of Hippo</author>
+                     <title>Contra Faustum manichaeum</title>
+                     <!--Possible work keys: work_742-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Interlace initial with faces, initials in red, blue, and green.</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>19th-century reversed leather</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1100" notAfter="1150">s. XIIin.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=44">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 26</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 12 [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_88.xml
+++ b/collections/University_College/University_College_MS_88.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13069">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 88</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_88</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_88">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 88</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_88-item1" n="1">
+                     <author key="person_17133283">Forrest, William, 1530-1581</author>
+                     <title>The history of Joseph</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary gilt-stamped calf with arabesque corner pieces, lion mask brass bosses at corners (one lacking, binding restored).</p>
+                     </binding>
+                  </bindingDesc>
+                  <accMat>This is volume I. Volume II is British Library, MS Royal 18.C.XIII</accMat>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1500" notAfter="1600">s. XVI</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>Autograph manuscript and presentation copy. Gift of C. Theyer (DHC).</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=44">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 26</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_89.xml
+++ b/collections/University_College/University_College_MS_89.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13070">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 89</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_89</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_89">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 89</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_89-item1" n="1">
+                     <author key="person_44299175">Galen</author>
+                     <title>Microtechnon</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_89-item2" n="2">
+                     <author key="person_287984736">Hippocrates, v460-v370</author>
+                     <title>Aphorisms</title>
+                     <!--Possible work keys: work_6662 or work_6093 or work_2065-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_89-item3" n="3">
+                     <author key="person_287984736">Hippocrates, v460-v370</author>
+                     <title>Prognostica</title>
+                     <!--Possible work keys: work_7204 or work_6319 or work_2069-->
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_89-item4" n="4">
+                     <author key="person_287984736">Hippocrates, v460-v370</author>
+                     <title>Regimen acutorum</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Illuminated and flourish initials</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>16th-century blind-tooled calf ruled and tooled with diamonds containing sprays decorated with petals (upper joint split, lacking clasps and catches)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1300" notAfter="1400">s. XIV</origDate>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=44">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 26</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_9.xml
+++ b/collections/University_College/University_College_MS_9.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13005">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 9</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_9</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_9">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 9</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_9-item1" n="1">
+                     <title>Breviary (Carmelite)</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>"Fine borders, initials. Fine penwork initials." (IMOCL)</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>English blind-stamped leather with panels showing Martin and the beggar bordered with scenes of the hunt.</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1500" notAfter="1525">s. XVIin.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"Made for English use. More English saints added in the calendar, saec. xv. Obits 'matris mee', 1585. Ann Mansfield, Ann Conyers, saec. xvi." (IMOCL)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=21">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 3</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 745 [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_90.xml
+++ b/collections/University_College/University_College_MS_90.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13071">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 90</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_90</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_90">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 90</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_90-item1" n="1">
+                     <title>Lands of the earl of Ormonde</title>
+                     <textLang mainLang="en">English</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="paper">
+                        <support>paper</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>17th-century gilt stamped with Carew arms</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England</country>; <country key="place_1000078">Ireland.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>Copied from the Red Book by William White, 1480, from the collection of Sir George Carew, earl of Totnes (1555-1629).</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=45">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 27</ref>
+                              </bibl>
+                              <bibl>
+                                 <title>IMEP</title>, p. 109</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_91.xml
+++ b/collections/University_College/University_College_MS_91.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13072">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 91</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_91</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_91">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 91</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_91-item1" n="1">
+                     <author key="person_41951136">Guilelmus Peraldus, approximately 1190-1271</author>
+                     <title>De vitiis septem</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Flourish initials</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary doeskin over wooden boards (lacking clasps)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1200" notAfter="1300">s. XIII</origDate>
+                     <origPlace>
+                        <country key="place_1000070">France.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>"olim decani de Crediton, ex legatione W. Palmer, postea Gulielmi Muggi ex dono Georgii Mason." Bequeathed to Crediton church by William Palmer who had bought it from the London stationer Thomas Veysey in 1433</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=45">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 27</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_92.xml
+++ b/collections/University_College/University_College_MS_92.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13073">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 92</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_92</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_92">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 92</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_92-item1" n="1">
+                     <author key="person_7131397">Robert Cowton, active 1302-1340</author>
+                     <title>Commentarius in Sententiarum (librum primum)</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Flourish initials</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary, perhaps original, white leather over wooden boards, straps with brass clasps and catches</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1300" notAfter="1400">s. XIV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=45">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 27</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_93.xml
+++ b/collections/University_College/University_College_MS_93.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13074">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 93</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_93</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_93">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 93</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_93-item1" n="1">
+                     <author>Anon</author>
+                     <title>Lecturæ de controversiis inter reformatos et ecclesiam romanam, 1586-1588</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="paper">
+                        <support>paper</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary blind-stamped brown leather (very worn), 12th-century parchment folios as lifted endleaves</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1500" notAfter="1600">s. XVI</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=45">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 27</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_94.xml
+++ b/collections/University_College/University_College_MS_94.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13075">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 94</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_94</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_94">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 94</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_94-item1" n="1">
+                     <author key="person_41839141">Diogenes Laertius</author>
+                     <title>De vitis philosophorum, trans. by Ambrogio Traversari</title>
+                     <textLang mainLang="it">Italian</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc>
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Fine humanist script, white vine border and initials, coat of arms. "manu Italica optime exaratus et quoad literas initiales ornatus." (Coxe)</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary blind-stamped knotwork binding (slightly rubbed, lacking clasps and catches)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_1000080">Italy</country>; <placeName key="place_7004264">Ferrara</placeName>
+                     </origPlace>
+                  </origin>
+                  <provenance>Ferrara. "olim Thomæ Kech ex dono M. Thomæ Gandy." (Coxe) Given by John Hales (DHC)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=45">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 27</ref>
+                              </bibl>
+                              <bibl>
+                                 <ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref>, Cat. No. 988 [information on decoration and origin]</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_95.xml
+++ b/collections/University_College/University_College_MS_95.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13076">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 95</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_95</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_95">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 95</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_95-item1" n="1">
+                     <title>Liber dictus Rosarium</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_95-item2" n="2">
+                     <title>List of Gospels and Epistles for the year</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+                  <msItem xml:id="University_College_MS_95-item3" n="3">
+                     <author key="person_9865788">Hugh, of Saint-Victor, 1096?-1141</author>
+                     <title>De archa Noe (fragment)</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Flourish initials</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>17th-century limp vellum (leaf from upper cover now University College MS. 192)</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1500">s. XV</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>Once belonged to Edington Priory. "olim Johannis Naylor, coll. Univ. socii." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=46">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 28</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_96.xml
+++ b/collections/University_College/University_College_MS_96.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13077">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 96</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_96</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_96">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 96</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_96-item1" n="1">
+                     <title>Wycliffite Summary of the Old Testament with Interpretations of Scripture (including the General Prologue to the Wycliffite Bible); Gospel lections in Middle English for Easter and Palm Sunday</title>
+                     <textLang mainLang="enm">Middle English</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>Red initials. Spaces left for initials. Script is Anglican showing Secretary influence.</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Unbound</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1470">s. XVin./med.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>; Printed; <placeName key="place_7011781">London</placeName>, 1550 (Coxe)</origPlace>
+                  </origin>
+                  <provenance>"This book seemeth to have been made by John Wickliffe." "I take this note to be of Mr Obad. Walker’s handwriting. Teste Guil. Smith, Aug. 26, 1700." (Notes on the flyleaf) "List of contents in the hand of O. Walker." (anonymous note in Duke Humphrey copy of Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=46">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 28</ref>
+                              </bibl>
+                              <bibl>
+                                 <title>IMEP</title>, p. 109</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_97.xml
+++ b/collections/University_College/University_College_MS_97.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13078">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 97</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_97</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_97">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 97</idno>
+               </msIdentifier>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <p>Composite manuscript in 2 parts</p>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1350" notAfter="1500">1350–1500</origDate>
+                  </origin>
+                  <provenance>"olim ecclesiæ [S. Petri] de [Westmonasertio?] in qua Blanchia ducissa Lancastriæ an. 1368 sepulta; postea coll. Univ e dono Th. Walker, magistri." (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=46">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 28</ref>
+                              </bibl>
+                              <bibl>
+                                 <title>IMEP</title>, p. 109-12</bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+               <msPart xml:id="University_College_MS_97-part1" n="1">
+                  <msIdentifier>
+                     <altIdentifier type="partial">
+                        <idno type="part">University College MS. 97 - Part 1</idno>
+                     </altIdentifier>
+                  </msIdentifier>
+                  <msContents>
+                     <msItem xml:id="University_College_MS_97-part1-item1" n="1">
+                        <title>Prophecies of St Thomas of Canterbury</title>
+                        <textLang mainLang="enm">Middle English</textLang>
+                     </msItem>
+                     <msItem xml:id="University_College_MS_97-part1-item2" n="2">
+                        <title>Gesta romanorum moralista</title>
+                        <textLang mainLang="la">Latin</textLang>
+                     </msItem>
+                     <msItem xml:id="University_College_MS_97-part1-item3" n="3">
+                        <title>Papal Bull (to Thomas Bourchier, archbishop of Canterbury, dated 1456)</title>
+                     </msItem>
+                  </msContents>
+                  <physDesc>
+                     <objectDesc>
+                        <supportDesc material="mixed">
+                           <support>vellum and paper</support>
+                        </supportDesc>
+                     </objectDesc>
+                  </physDesc>
+                  <history>
+                     <origin>
+                        <origDate calendar="Gregorian">s. XIVex.</origDate>
+                     </origin>
+                     <provenance>England.</provenance>
+                  </history>
+               </msPart>
+               <msPart xml:id="University_College_MS_97-part2" n="2">
+                  <msIdentifier>
+                     <altIdentifier type="partial">
+                        <idno type="part">University College MS. 97 - Part 2</idno>
+                     </altIdentifier>
+                  </msIdentifier>
+                  <msContents>
+                     <msItem xml:id="University_College_MS_97-part2-item1" n="1">
+                        <title>Devotional treatises</title>
+                        <!--Possible work keys: work_2358 or work_11525-->
+                        <textLang mainLang="enm">Middle English</textLang>
+                     </msItem>
+                     <msItem xml:id="University_College_MS_97-part2-item2" n="2">
+                        <title>Wycliffite version of Visitatio infirmorum</title>
+                     </msItem>
+                     <msItem xml:id="University_College_MS_97-part2-item3" n="3">
+                        <title>Short chronicles</title>
+                     </msItem>
+                     <msItem xml:id="University_College_MS_97-part2-item4" n="4">
+                        <author>Sir Johne Clanvowe</author>
+                        <title>Treatise</title>
+                     </msItem>
+                     <msItem xml:id="University_College_MS_97-part2-item5" n="5">
+                        <title>Documents and chronicles relating to St Paul's Cathedral, London</title>
+                     </msItem>
+                  </msContents>
+                  <physDesc>
+                     <objectDesc>
+                        <supportDesc material="perg">
+                           <support>vellum</support>
+                        </supportDesc>
+                     </objectDesc>
+                  </physDesc>
+                  <history>
+                     <origin>
+                        <origDate calendar="Gregorian">s. XV</origDate>
+                     </origin>
+                  </history>
+               </msPart>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_98.xml
+++ b/collections/University_College/University_College_MS_98.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13079">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 98</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_98</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_98">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 98</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_98-item1" n="1">
+                     <author key="person_100184667">Gregory, I, Pope, approximately 540-604</author>
+                     <title>Pastoralis curæ</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>vellum</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <decoDesc>
+                     <decoNote>One large patterned initial, initials &amp; ampersands in green and red</decoNote>
+                  </decoDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>19th-century half morocco</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1100" notAfter="1200">s. XII</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=47">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 29</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/collections/University_College/University_College_MS_99.xml
+++ b/collections/University_College/University_College_MS_99.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_13080">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>University College MS. 99</title>
+            <title type="collection">University College MSS.</title>
+            <respStmt xml:id="PB">
+               <resp when="2021">Summary description</resp>
+               <persName>Philip Burnett</persName>
+            </respStmt>
+            <respStmt xml:id="AM">
+               <resp when="2022">Markup and encoding</resp>
+               <persName>Andrew Morrison</persName>
+               <note>TEI encoding programmatically created using spreadsheet data</note>
+            </respStmt>
+         </titleStmt>
+         <editionStmt>
+            <edition>TEI P5</edition>
+         </editionStmt>
+         <publicationStmt>
+            <publisher>Special Collections, Bodleian Libraries</publisher>
+            <address>
+               <orgName type="department">Special Collections</orgName>
+               <orgName type="unit">Bodleian Libraries</orgName>
+               <orgName type="institution">University of Oxford</orgName>
+               <street>Weston Library, Broad Street</street>
+               <settlement>Oxford</settlement>
+               <postCode>OX1 3BG</postCode>
+               <country>United Kingdom</country>
+            </address>
+            <distributor>
+               <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+            </distributor>
+            <availability>
+               <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+               <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+            </availability>
+            <idno type="msID">University_College_MS_99</idno>
+            <idno type="collection">University_College_MSS</idno>
+            <idno type="catalogue">Western</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc xml:lang="en" xml:id="University_College_MS_99">
+               <msIdentifier>
+                  <settlement>Oxford</settlement>
+                  <repository>University College</repository>
+                  <idno type="shelfmark">University College MS. 99</idno>
+               </msIdentifier>
+               <msContents>
+                  <msItem xml:id="University_College_MS_99-item1" n="1">
+                     <title>Collection of nine treastises, incl. Gregory the Great (Pastoralis curæ), Augustine of Hippo (De conflictu vitiorum, De disciplina christiana), Pseudo-Aritstotle (De pomo)</title>
+                     <textLang mainLang="la">Latin</textLang>
+                  </msItem>
+               </msContents>
+               <physDesc>
+                  <objectDesc form="codex">
+                     <supportDesc material="paper">
+                        <support>paper</support>
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <binding>
+                        <p>Contemporary tawed skin over bevelled wooden boards with two catches (lacking straps and clasps). Papal bull of 1380 in favour of Patrick Asseburne as endleaves.</p>
+                     </binding>
+                  </bindingDesc>
+               </physDesc>
+               <history>
+                  <origin>
+                     <origDate calendar="Gregorian" notBefore="1400" notAfter="1450">s. XVin.</origDate>
+                     <origPlace>
+                        <country key="place_7002445">England.</country>
+                     </origPlace>
+                  </origin>
+                  <provenance>“manu M.T. de Ashburne scriptus; olim Roberti Halytreholme” (Coxe)</provenance>
+               </history>
+               <additional>
+                  <adminInfo>
+                     <recordHist>
+                        <source>
+                           <p>Summary description by Philip Burnett, based on the following sources.</p>
+                           <listBibl>
+                              <bibl>
+                                 <ref target="https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=48">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. 30</ref>
+                              </bibl>
+                           </listBibl>
+                        </source>
+                     </recordHist>
+                     <availability>
+                        <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email>
+                        </p>
+                     </availability>
+                  </adminInfo>
+               </additional>
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <change when="2022-01-13">Record created.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/processing/batch_conversion/tei-from-complex-spreadsheet.xsl
+++ b/processing/batch_conversion/tei-from-complex-spreadsheet.xsl
@@ -1,0 +1,601 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet 
+    xmlns="http://www.tei-c.org/ns/1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:tei="http://www.tei-c.org/ns/1.0"
+    xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+    xmlns:local="/"
+    exclude-result-prefixes="xs local tei map"
+    version="3.0">
+
+    <!-- Created for University College records, which are more complex than Jesus ones.
+         
+         To run, convert the spreadsheet to a tab-separated-value text file and specify that as a parameter, along with the next available manuscript_ number, e.g.:
+    
+         java -Xmx1G -cp ../saxon/saxon9he.jar net.sf.saxon.Transform -it:Main -xsl:tei-from-complex-spreadsheet.xsl infile=./university_college_metadata.tsv nextmsid=13000
+          
+         Optionally, you can also specify the Solr server for a Digital Bodleian instance to attempt to lookup 
+         shelfmarks against UUIDs, and create surrogates links for any it finds.
+    -->
+    
+    <!-- Parameters -->
+    <xsl:param name="infile" as="xs:string" required="yes"/>
+    <xsl:param name="nextmsid" as="xs:integer" required="yes"/>
+    <xsl:param name="digbodsolr" as="xs:anyURI?" required="no"/>
+    
+    <!-- Lookup languages (tailor list to what is in each spreadsheet) -->
+    <xsl:variable name="iso639codes" as="map(xs:string, xs:string)">
+        <xsl:map>
+            <xsl:map-entry key="'Latin'" select="'la'"/>
+            <xsl:map-entry key="'Middle English'" select="'enm'"/>
+            <xsl:map-entry key="'French'" select="'fr'"/>
+            <xsl:map-entry key="'Greek'" select="'el'"/>
+            <xsl:map-entry key="'English'" select="'en'"/>
+            <xsl:map-entry key="'Italian'" select="'it'"/>
+            <!-- Add more if using for another college -->
+        </xsl:map>
+    </xsl:variable>
+    
+    <xsl:variable name="digbodquery" as="xs:string">/solr/digital_bodleian_production/select?fl=full_shelfmark_s,object_id,completeness_s&amp;fq=institution_collections_id_sm:university&amp;q=*:*&amp;wt=xml&amp;rows=1000</xsl:variable>
+    
+    <!-- Query Digital Bodleian's Solr for UUIDs -->
+    <xsl:variable name="digbodresults" as="element(result)?" select="if ($digbodsolr) then document(concat($digbodsolr, $digbodquery))/response/result else ()"/>
+
+    <!-- Load the local authority files -->
+    <xsl:variable name="authorityworks" as="element(tei:bibl)*" select="document('../../works.xml')//tei:bibl[@xml:id]"/>
+    <xsl:variable name="authoritypersons" as="element(tei:person)*" select="document('../../persons.xml')//tei:person[@xml:id]"/>
+    <xsl:variable name="authorityplaces" as="element(tei:place)*" select="document('../../places.xml')//tei:place[@xml:id]"/>
+    <xsl:variable name="authorityorgs" as="element(tei:org)*" select="document('../../places.xml')//tei:org[@xml:id]"/>
+
+    <!-- Call this template to loop thru records to be created. Each record can have one or more lines, but the first line
+         of each records starts with the shelfmark, which for University College all begin "University College MS..." -->
+    <xsl:template name="Main">
+        <xsl:for-each select="tokenize(unparsed-text($infile, 'utf-8'), '\r?\nUniversity College MS')">
+            <xsl:if test="position() gt 1 and string-length(normalize-space(.)) gt 0">
+                <!-- After skipping the header or any blank lines, split into manuscripts (can be a single line containing info on both the manuscript
+                     and its only work, or multiple lines with the first line starting with the shelfmark containing the manuscript information, 
+                     and parts/works on subsequent lines) -->
+                <xsl:variable name="lines" as="xs:string*" select="tokenize(., '\r?\n')[string-length(normalize-space(.)) gt 0]"/>
+                <xsl:call-template name="CreateTEI">
+                    <xsl:with-param name="msfields" as="xs:string*" select="for $f in tokenize($lines[1], '\t') return normalize-space($f)"/>
+                    <xsl:with-param name="subrecords" as="map(xs:integer, xs:string*)">
+                        <xsl:map>
+                            <xsl:choose>
+                                <xsl:when test="count($lines) eq 1">
+                                    <!-- This is a single-work manuscript -->
+                                    <xsl:map-entry key="1" select="for $f in tokenize($lines[1], '\t') return normalize-space($f)"/>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <!-- This is a multi-work and/or multi-part manuscript -->
+                                    <xsl:for-each select="$lines[some $f in tokenize(., '\t')[position() = (2,3,4)] satisfies string-length(normalize-space($f)) gt 0]">
+                                        <!-- Sometimes there is work/part in the first line of the manuscript, sometimes not.
+                                             If columns 2, 3, or 4 have values (partno, author, or title) then this it does. -->
+                                        <xsl:map-entry key="position()" select="for $f in tokenize(., '\t') return normalize-space($f)"/>
+                                    </xsl:for-each>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                        </xsl:map>
+                    </xsl:with-param>
+                    <xsl:with-param name="msid" select="$nextmsid + position() - 2"/>
+                </xsl:call-template>
+            </xsl:if>
+        </xsl:for-each>
+    </xsl:template>
+    
+    <!-- The template for the TEI file -->
+    <xsl:template name="CreateTEI">
+        <xsl:param name="msfields" as="xs:string*" required="yes"/>
+        <xsl:param name="subrecords" as="map(xs:integer, xs:string*)" required="yes"/>
+        <xsl:param name="msid" as="xs:integer" required="yes"/>
+        
+        <!-- Manuscript fields -->
+        <xsl:variable name="shelfmark" as="xs:string" select="concat('University College MS', $msfields[1])"/>
+        <xsl:variable name="languages" as="xs:string" select="$msfields[5]"/>
+        <xsl:variable name="format" as="xs:string" select="$msfields[6]"/>
+        <xsl:variable name="support" as="xs:string" select="$msfields[7]"/>
+        <xsl:variable name="binding" as="xs:string" select="$msfields[8]"/>
+        <xsl:variable name="decoration" as="xs:string" select="$msfields[9]"/>
+        <xsl:variable name="datestr" as="xs:string" select="$msfields[10]"/>
+        <xsl:variable name="notbefore" as="xs:string" select="$msfields[11]"/>
+        <xsl:variable name="notafter" as="xs:string" select="$msfields[12]"/>
+        <xsl:variable name="origin1" as="xs:string" select="$msfields[13]"/>
+        <xsl:variable name="origin2" as="xs:string" select="$msfields[14]"/>
+        <xsl:variable name="provenance" as="xs:string" select="$msfields[15]"/>
+        <xsl:variable name="coxe" as="xs:string" select="$msfields[16]"/>
+        <xsl:variable name="imocl" as="xs:string" select="$msfields[17]"/>
+        <xsl:variable name="imep" as="xs:string" select="$msfields[18]"/>
+        <xsl:variable name="notes" as="xs:string" select="$msfields[19]"/>
+        <xsl:variable name="bibliography" as="xs:string" select="$msfields[20]"/>
+        
+        <xsl:variable name="filename" as="xs:string" select="replace(replace($shelfmark, '\*' ,'_star'), '[^A-Za-z0-9_]+', '_')"/>
+        <xsl:variable name="shelfmarknum" as="xs:integer" select="replace($shelfmark, '\D', '') cast as xs:integer"/>
+        
+        <xsl:variable name="parts" as="xs:string*" select="distinct-values(for $key in map:keys($subrecords) return map:get($subrecords, $key)[2])[string-length() gt 0]"/>
+        <xsl:variable name="hasparts" as="xs:boolean" select="some $part in $parts satisfies string-length($part) gt 0"/>
+        
+        <xsl:result-document href="../../collections/University_College/{$filename}.xml" method="xml" encoding="UTF-8" indent="yes">
+            
+            <xsl:processing-instruction name="xml-model">href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"</xsl:processing-instruction>
+            <xsl:processing-instruction name="xml-model">href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"</xsl:processing-instruction>
+            <TEI xmlns="http://www.tei-c.org/ns/1.0"
+                xmlns:tei="http://www.tei-c.org/ns/1.0"
+                xml:id="manuscript_{ $msid }">
+                <teiHeader>
+                    <fileDesc>
+                        <titleStmt>
+                            <title>
+                                <xsl:value-of select="$shelfmark"/>
+                            </title>
+                            <title type="collection">University College MSS.</title>
+                            <respStmt xml:id="PB">
+                                <resp when="2021">Summary description</resp>
+                                <persName>Philip Burnett</persName>
+                            </respStmt>
+                            <respStmt xml:id="AM">
+                                <resp when="2022">Markup and encoding</resp>
+                                <persName>Andrew Morrison</persName>
+                                <note>TEI encoding programmatically created using spreadsheet data</note>
+                            </respStmt>
+                        </titleStmt>
+                        <editionStmt>
+                            <edition>TEI P5</edition>
+                        </editionStmt>
+                        <publicationStmt>
+                            <publisher>Special Collections, Bodleian Libraries</publisher>
+                            <address>
+                                <orgName type="department">Special Collections</orgName>
+                                <orgName type="unit">Bodleian Libraries</orgName>
+                                <orgName type="institution">University of Oxford</orgName>
+                                <street>Weston Library, Broad Street</street>
+                                <settlement>Oxford</settlement>
+                                <postCode>OX1 3BG</postCode>
+                                <country>United Kingdom</country>
+                            </address>
+                            <distributor>
+                                <email>specialcollections.enquiries@bodleian.ox.ac.uk</email>
+                            </distributor>
+                            <availability>
+                                <licence target="https://creativecommons.org/publicdomain/zero/1.0/">This summary description is released under a CC0 licence.</licence>
+                                <licence target="https://creativecommons.org/share-your-work/public-domain/pdm/">The text of H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title>, is free of known copyright restrictions.</licence>
+                            </availability>
+                            <idno type="msID">
+                                <xsl:value-of select="$filename"/>
+                            </idno>
+                            <idno type="collection">University_College_MSS</idno>
+                            <idno type="catalogue">Western</idno>
+                        </publicationStmt>
+                        <sourceDesc>
+                            <msDesc xml:lang="en" xml:id="{ $filename }">
+                                <msIdentifier>
+                                    <settlement>Oxford</settlement>
+                                    <repository>University College</repository>
+                                    <idno type="shelfmark">
+                                        <xsl:value-of select="$shelfmark"/>
+                                    </idno>
+                                </msIdentifier>
+                                <xsl:choose>
+                                    <xsl:when test="not($hasparts)">
+                                        <!-- This manuscript is not split into parts, so msContents comes first -->
+                                        <msContents>
+                                            <xsl:if test="string-length($languages) gt 0 and count(map:keys($subrecords)) gt 1">
+                                                <xsl:call-template name="AddTextLang">
+                                                    <xsl:with-param name="languages" select="$languages"/>
+                                                </xsl:call-template>
+                                            </xsl:if>
+                                            <xsl:variable name="works" as="xs:string*" select="tokenize($parts[1], ';')"/>
+                                            <xsl:for-each select="map:keys($subrecords)">
+                                                <xsl:variable name="key" as="xs:integer" select="."/>
+                                                <xsl:call-template name="AddWork">
+                                                    <xsl:with-param name="worknum" select="position()"/>
+                                                    <xsl:with-param name="workdetails" select="map:get($subrecords, $key)"/>
+                                                    <xsl:with-param name="idprefix" select="$filename"/>
+                                                </xsl:call-template>
+                                            </xsl:for-each>
+                                        </msContents>
+                                        <xsl:call-template name="AddPhysDesc">
+                                            <xsl:with-param name="format" select="$format"/>
+                                            <xsl:with-param name="support" select="$support"/>
+                                            <xsl:with-param name="decoration" select="$decoration"/>
+                                            <xsl:with-param name="binding" select="$binding"/>
+                                            <xsl:with-param name="notes" select="$notes"/>
+                                        </xsl:call-template>
+                                        <xsl:call-template name="AddHistory">
+                                            <xsl:with-param name="datestr" select="$datestr"/>
+                                            <xsl:with-param name="notbefore" select="$notbefore"/>
+                                            <xsl:with-param name="notafter" select="$notafter"/>
+                                            <xsl:with-param name="origins" select="($origin1, $origin2)"/>
+                                            <xsl:with-param name="provenance" select="$provenance"/>
+                                        </xsl:call-template>
+                                        <xsl:call-template name="InsertAdditional">
+                                            <xsl:with-param name="shelfmark" select="$shelfmark"/>
+                                            <xsl:with-param name="coxe" select="$coxe"/>                                        
+                                            <xsl:with-param name="imocl" select="$imocl"/>
+                                            <xsl:with-param name="imep" select="$imep"/>
+                                        </xsl:call-template>
+                                    </xsl:when>
+                                    <xsl:otherwise>
+                                        <!-- This is a composite manuscript and the TEI schema requires physDesc, history, and additional
+                                             sections relating to the whole manuscript come before the first msPart -->
+                                        <xsl:call-template name="AddPhysDesc">
+                                            <xsl:with-param name="format" select="$format"/>
+                                            <xsl:with-param name="binding" select="$binding"/>
+                                            <xsl:with-param name="numparts" select="count($parts)"/>
+                                            <xsl:with-param name="notes" select="$notes"/>
+                                        </xsl:call-template>
+                                        <xsl:call-template name="AddHistory">
+                                            <xsl:with-param name="datestr" select="$datestr"/>
+                                            <xsl:with-param name="notbefore" select="$notbefore"/>
+                                            <xsl:with-param name="notafter" select="$notafter"/>
+                                            <xsl:with-param name="origins" select="($origin1, $origin2)"/>
+                                            <xsl:with-param name="provenance" select="$provenance"/>
+                                        </xsl:call-template>
+                                        <xsl:call-template name="InsertAdditional">
+                                            <xsl:with-param name="shelfmark" select="$shelfmark"/>
+                                            <xsl:with-param name="coxe" select="$coxe"/>
+                                            <xsl:with-param name="imocl" select="$imocl"/>
+                                            <xsl:with-param name="imep" select="$imep"/>
+                                        </xsl:call-template>
+                                        <!-- Now the msPart elements -->
+                                        <xsl:for-each select="$parts">
+                                            <xsl:variable name="partlabel" as="xs:string" select="."/>
+                                            <xsl:variable name="partnum" as="xs:integer" select="position()"/>
+                                            <xsl:variable name="partrecord" as="xs:string*" select="(for $key in map:keys($subrecords) return if(map:get($subrecords, $key)[2] eq $partlabel) then map:get($subrecords, $key) else ())"/>
+                                            <xsl:variable name="partsupport" as="xs:string?" select="$partrecord[7]"/>
+                                            <xsl:variable name="partdecoration" as="xs:string?" select="$partrecord[8]"/>
+                                            <xsl:variable name="partdatestr" as="xs:string?" select="$partrecord[10]"/>
+                                            <xsl:variable name="partnotbefore" as="xs:string?" select="$partrecord[11]"/>
+                                            <xsl:variable name="partnoafter" as="xs:string?" select="$partrecord[12]"/>
+                                            <xsl:variable name="partorigin1" as="xs:string?" select="$partrecord[13]"/>
+                                            <xsl:variable name="partorigin2" as="xs:string?" select="$partrecord[14]"/>
+                                            <xsl:variable name="partprovenance" as="xs:string?" select="$partrecord[15]"/>
+
+                                            <msPart xml:id="{ $filename }-part{ $partnum }" n="{ $partnum }">
+                                                <msIdentifier>
+                                                    <altIdentifier type="partial">
+                                                        <idno type="part">
+                                                            <xsl:value-of select="$shelfmark"/>
+                                                            <xsl:text> - Part </xsl:text>
+                                                            <xsl:value-of select="$partlabel"/>
+                                                        </idno>
+                                                    </altIdentifier>
+                                                </msIdentifier>
+                                                <msContents>
+                                                    <xsl:call-template name="AddWorks">
+                                                        <xsl:with-param name="partlabel" select="$partlabel"/>
+                                                        <xsl:with-param name="subrecords" select="$subrecords"/>
+                                                        <xsl:with-param name="idprefix" select="concat($filename, '-part', $partnum)"/>
+                                                    </xsl:call-template>
+                                                </msContents>
+                                                <xsl:call-template name="AddPhysDesc">
+                                                    <xsl:with-param name="support" select="$partsupport"/>
+                                                    <xsl:with-param name="decoration" select="$partdecoration"/>
+                                                </xsl:call-template>
+                                                <xsl:call-template name="AddHistory">
+                                                    <xsl:with-param name="datestr" select="$partdatestr"/>
+                                                    <xsl:with-param name="notbefore" select="$partnotbefore"/>
+                                                    <xsl:with-param name="notafter" select="$partnoafter"/>
+                                                    <xsl:with-param name="origins" select="($partorigin1, $partorigin2)"/>
+                                                    <xsl:with-param name="provenance" select="$partprovenance"/>
+                                                </xsl:call-template>
+                                            </msPart>
+                                        </xsl:for-each>
+                                    </xsl:otherwise>
+                                </xsl:choose>
+                            </msDesc>
+                        </sourceDesc>
+                    </fileDesc>
+                    <revisionDesc>
+                        <change when="{ substring(string(current-date()), 0, 11) }">Record created.</change>
+                    </revisionDesc>
+                </teiHeader>
+                <text>
+                    <body>
+                        <p><!--Body paragraph provided for validation and future transcription--></p>
+                    </body>
+                </text>
+            </TEI>
+        </xsl:result-document>
+    </xsl:template>
+    
+    <xsl:template name="AddWorks" as="element(tei:msItem)*">
+        <xsl:param name="partlabel" as="xs:string" required="yes"/>
+        <xsl:param name="subrecords" as="map(xs:integer, xs:string*)" required="yes"/>
+        <xsl:param name="idprefix" as="xs:string" required="yes"/>
+        <xsl:param name="key" as="xs:integer" select="1"/>
+        <xsl:param name="worknum" as="xs:integer" select="1"/>
+        <xsl:param name="doit" as="xs:boolean" select="false()"/>
+        <xsl:choose>
+            <xsl:when test="map:get($subrecords, $key)[2] eq $partlabel or ($doit and map:get($subrecords, $key)[2] eq '')">
+                <xsl:call-template name="AddWork">
+                    <xsl:with-param name="worknum" select="$worknum"/>
+                    <xsl:with-param name="workdetails" select="map:get($subrecords, $key)"/>
+                    <xsl:with-param name="idprefix" select="$idprefix"/>
+                </xsl:call-template>
+                <xsl:call-template name="AddWorks">
+                    <xsl:with-param name="partlabel" select="$partlabel"/>
+                    <xsl:with-param name="subrecords" select="$subrecords"/>
+                    <xsl:with-param name="idprefix" select="$idprefix"/>
+                    <xsl:with-param name="key" select="$key + 1"/>
+                    <xsl:with-param name="worknum" select="$worknum + 1"/>
+                    <xsl:with-param name="doit" select="true()"/>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:when test="$key le count(map:keys($subrecords))">
+                <xsl:call-template name="AddWorks">
+                    <xsl:with-param name="partlabel" select="$partlabel"/>
+                    <xsl:with-param name="subrecords" select="$subrecords"/>
+                    <xsl:with-param name="idprefix" select="$idprefix"/>
+                    <xsl:with-param name="key" select="$key + 1"/>
+                    <xsl:with-param name="worknum" select="$worknum"/>
+                </xsl:call-template>
+            </xsl:when>
+        </xsl:choose>
+    </xsl:template>
+    
+    <xsl:template name="AddWork" as="element(tei:msItem)">
+        <xsl:param name="worknum" as="xs:integer" required="yes"/>
+        <xsl:param name="workdetails" as="xs:string*" required="yes"/>
+        <xsl:param name="idprefix" as="xs:string" required="yes"/>
+        <xsl:variable name="author" as="xs:string?" select="$workdetails[3]"/>
+        <xsl:variable name="title" as="xs:string?" select="$workdetails[4]"/>
+        <xsl:variable name="languages" as="xs:string?" select="$workdetails[5]"/>
+        <xsl:variable name="normalizedauthor" as="xs:string" select="local:normalizeName($author)"/>
+        <xsl:variable name="personauthorities" as="element(tei:person)*" select="$authoritypersons[some $p in tei:persName/string() satisfies local:normalizeName($p) = $normalizedauthor]"/>
+        <msItem xml:id="{ $idprefix }-item{ $worknum }" n="{ $worknum }">
+            <xsl:if test="string-length($author) gt 0">
+                <author>
+                    <xsl:if test="count($personauthorities) eq 1">
+                        <xsl:attribute name="key" select="$personauthorities[1]/@xml:id"/>
+                    </xsl:if>
+                    <xsl:value-of select="normalize-space($author)"/>
+                </author>
+                <xsl:if test="count($personauthorities) gt 1">
+                    <xsl:comment>Possible person keys: <xsl:value-of select="string-join(for $p in $personauthorities return $p/@xml:id, ' or ')"/></xsl:comment>
+                </xsl:if>
+            </xsl:if>
+            <xsl:if test="string-length($title) gt 0">
+                <xsl:variable name="titlevariants" as="xs:string*" select="local:getTitleVariants($title, $author, $languages)"/>
+                <xsl:variable name="workauthorities" as="element(tei:bibl)*" select="$authorityworks[some $t in tei:title/string() satisfies local:normalizeTitle($t) = $titlevariants]"/>
+                <title>
+                    <xsl:if test="count($workauthorities) eq 1 and $workauthorities[1]/author/@key = $personauthorities/@xml:id">
+                        <!-- Only add work key attributes if the author is known, as there are works with the same title by different authors -->
+                        <xsl:attribute name="key" select="$workauthorities[1]/@xml:id"/>
+                    </xsl:if>
+                    <xsl:value-of select="normalize-space($title)"/>
+                </title>
+                <xsl:if test="count($workauthorities) gt 1 or (count($workauthorities) eq 1 and not($workauthorities[1]/author/@key = $personauthorities/@xml:id))">
+                    <xsl:comment>Possible work keys: <xsl:value-of select="string-join(for $w in $workauthorities return $w/@xml:id, ' or ')"/></xsl:comment>
+                </xsl:if>
+            </xsl:if>
+            <xsl:if test="string-length($languages) gt 0">
+                <xsl:call-template name="AddTextLang">
+                    <xsl:with-param name="languages" select="$languages"/>
+                </xsl:call-template>
+            </xsl:if>
+        </msItem>
+    </xsl:template>
+    
+    <xsl:template name="AddTextLang" as="element(tei:textLang)">
+        <xsl:param name="languages" as="xs:string" required="yes"/>
+        <xsl:variable name="langcodes" as="xs:string*" select="local:lookupLanguages($languages)"/>
+        <textLang mainLang="{ $langcodes[1] }">
+            <xsl:if test="count($langcodes) gt 1">
+                <xsl:attribute name="otherLangs" select="string-join($langcodes[position() gt 1], ' ')"/>
+            </xsl:if>
+            <xsl:value-of select="$languages"/>
+        </textLang>
+    </xsl:template>
+    
+    <xsl:template name="AddPhysDesc" as="element(tei:physDesc)">
+        <xsl:param name="format" as="xs:string?"/>
+        <xsl:param name="support" as="xs:string?"/>
+        <xsl:param name="decoration" as="xs:string?"/>
+        <xsl:param name="binding" as="xs:string?"/>
+        <xsl:param name="numparts" as="xs:integer?" select="0"/>
+        <xsl:param name="notes" as="xs:string?"/>
+        <physDesc>
+            <objectDesc>
+                <xsl:if test="string-length($format) gt 0">
+                    <xsl:attribute name="form" select="$format"/>
+                </xsl:if>
+                <xsl:if test="$numparts gt 1">
+                    <p>Composite manuscript in <xsl:value-of select="$numparts"/> parts</p>
+                </xsl:if>
+                <xsl:if test="string-length($support) gt 0">
+                    <xsl:variable name="material" as="xs:string">
+                        <xsl:choose>
+                            <xsl:when test="contains($support, ';') or contains($support, ',') or contains($support, ' and ')">mixed</xsl:when>
+                            <xsl:when test="$support eq 'parchment'">perg</xsl:when>
+                            <xsl:when test="$support eq 'vellum'">perg</xsl:when>
+                            <xsl:when test="$support eq 'paper'">paper</xsl:when>
+                            <xsl:when test="$support eq 'chart'">chart</xsl:when>
+                            <xsl:otherwise>unknown</xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:variable>
+                    <supportDesc material="{ $material }">
+                        <support>
+                            <xsl:value-of select="$support"/>
+                        </support>
+                    </supportDesc>
+                </xsl:if>
+            </objectDesc>
+            <xsl:if test="string-length($decoration) gt 0">
+                <decoDesc>
+                    <decoNote>
+                        <xsl:value-of select="$decoration"/>
+                    </decoNote>
+                </decoDesc>
+            </xsl:if>
+            <xsl:if test="string-length($binding) gt 0">
+                <bindingDesc>
+                    <binding>
+                        <p>
+                            <xsl:value-of select="$binding"/>
+                        </p>
+                    </binding>
+                </bindingDesc>
+            </xsl:if>
+            <xsl:if test="string-length($notes) gt 0">
+                <!-- Most notes in the University College spreadsheet seem to be describing accompanying material -->
+                <accMat>
+                    <xsl:value-of select="$notes"/>
+                </accMat>
+            </xsl:if>
+        </physDesc>
+    </xsl:template>
+    
+    <xsl:template name="AddHistory" as="element(tei:history)">
+        <xsl:param name="datestr" as="xs:string?"/>
+        <xsl:param name="notbefore" as="xs:string?"/>
+        <xsl:param name="notafter" as="xs:string?"/>
+        <xsl:param name="origins" as="xs:string*"/>
+        <xsl:param name="provenance" as="xs:string?"/>
+        <history>
+            <origin>
+                <xsl:choose>
+                    <xsl:when test="string-length($datestr) gt 0 or string-length($notbefore) gt 0 or string-length($notbefore) gt 0">
+                        <origDate calendar="Gregorian">
+                            <xsl:if test="string-length($notbefore) gt 0"><xsl:attribute name="notBefore" select="$notbefore"/></xsl:if>
+                            <xsl:if test="string-length($notafter) gt 0"><xsl:attribute name="notAfter" select="$notafter"/></xsl:if>
+                            <xsl:value-of select="($datestr, concat($notbefore, '–', $notafter))[string-length(.) gt 0][1]"/>
+                        </origDate>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <p>No date</p>
+                    </xsl:otherwise>
+                </xsl:choose>
+                <xsl:if test="some $origin in $origins satisfies string-length($origin) gt 0">
+                    <origPlace>
+                        <xsl:for-each select="(for $origin in $origins return tokenize($origin, '\s+(and|or|in|;)\s+'))[string-length(.) gt 0]">
+                            <xsl:variable name="origin" as="xs:string" select="."/>
+                            <xsl:analyze-string select="$origin" regex="[\w\-'\.\s]+">
+                                <xsl:matching-substring>
+                                    <xsl:variable name="placename" as="xs:string" select="replace(normalize-space(.), '\.$', '')"/>
+                                    <xsl:variable name="placeauthority" as="element(tei:place)*" select="$authorityplaces[tei:placeName/string() = $placename][1]"/>
+                                    <xsl:variable name="orgauthority" as="element(tei:org)*" select="$authorityorgs[tei:orgName/string() = $placename][1]"/>
+                                    <xsl:choose>
+                                        <xsl:when test="$placeauthority">
+                                            <xsl:if test="matches(., '^\s')"><xsl:text> </xsl:text></xsl:if>
+                                            <xsl:choose>
+                                                <xsl:when test="$placeauthority/@type = 'country'">
+                                                    <country key="{ $placeauthority/@xml:id }">
+                                                        <xsl:value-of select="."/>
+                                                    </country>
+                                                </xsl:when>
+                                                <xsl:when test="$placeauthority/@type = 'region'">
+                                                    <region key="{ $placeauthority/@xml:id }">
+                                                        <xsl:value-of select="."/>
+                                                    </region>
+                                                </xsl:when>
+                                                <xsl:otherwise>
+                                                    <placeName key="{ $placeauthority/@xml:id }">
+                                                        <xsl:value-of select="."/>
+                                                    </placeName>
+                                                </xsl:otherwise>
+                                            </xsl:choose>
+                                            <xsl:if test="matches(., '\s$')"><xsl:text> </xsl:text></xsl:if>
+                                        </xsl:when>
+                                        <xsl:when test="$orgauthority">
+                                            <orgName key="{ $orgauthority/@xml:id }">
+                                                <xsl:value-of select="."/>
+                                            </orgName>
+                                            <xsl:if test="matches(., '\s$')"><xsl:text> </xsl:text></xsl:if>
+                                        </xsl:when>
+                                        <xsl:otherwise>
+                                            <xsl:value-of select="."/>
+                                        </xsl:otherwise>
+                                    </xsl:choose>
+                                </xsl:matching-substring>
+                                <xsl:non-matching-substring>
+                                    <xsl:value-of select="."/>
+                                </xsl:non-matching-substring>
+                            </xsl:analyze-string>
+                            <xsl:if test="position() ne last()">
+                                <xsl:text>; </xsl:text>
+                            </xsl:if>
+                        </xsl:for-each>
+                    </origPlace>
+                </xsl:if>
+            </origin>
+            <xsl:if test="string-length($provenance) gt 0">
+                <provenance>
+                    <xsl:value-of select="$provenance"/>
+                </provenance>
+            </xsl:if>
+        </history>
+    </xsl:template>
+
+    <xsl:template name="InsertAdditional" as="element(tei:additional)">
+        <xsl:param name="shelfmark" as="xs:string" required="yes"/>
+        <xsl:param name="coxe" as="xs:string?"/>
+        <xsl:param name="imocl" as="xs:string?"/>
+        <xsl:param name="imep" as="xs:string?"/>
+        <xsl:variable name="hassources" as="xs:boolean" select="some $s in ($coxe, $imocl, $imep) satisfies string-length($s) gt 0"/>
+        <additional>
+            <adminInfo>
+                <recordHist>
+                    <source>
+                        <p>Summary description by Philip Burnett<xsl:if test="$hassources">, based on the following sources</xsl:if>.</p>
+                        <xsl:if test="$hassources">
+                            <listBibl>
+                                <xsl:if test="string-length($coxe) gt 0">
+                                    <xsl:variable name="catalogueurl" as="xs:string?" select="if ($coxe castable as xs:integer) then concat('https://babel.hathitrust.org/cgi/pt?id=uc1.c3083855&amp;view=1up&amp;seq=', 18 + xs:integer($coxe)) else ()"/>
+                                    <bibl><ref target="{ $catalogueurl }">H. O. Coxe, <title>Catalogus codicum mss. qui in collegiis aulisque Oxoniensibus hodie adservantur</title> (1852), p. <xsl:value-of select="$coxe"/></ref></bibl>
+                                </xsl:if>
+                                <xsl:if test="string-length($imocl) gt 0">
+                                    <bibl><ref target="https://catalog.hathitrust.org/Record/000387352">J. J. G. Alexander and Elzbieta Temple, <title>Illuminated manuscripts in Oxford college libraries, the University Archives and the Taylor Institution</title> (Oxford, 1985)</ref><xsl:if test="string-length($imocl) gt 0">, <xsl:value-of select="$imocl"/></xsl:if> [information on decoration and origin]</bibl>
+                                </xsl:if>
+                                <xsl:if test="string-length($imep) gt 0">
+                                    <bibl><title>IMEP</title>, <xsl:value-of select="$imep"/></bibl>
+                                </xsl:if>
+                            </listBibl>
+                        </xsl:if>
+                    </source>
+                </recordHist>
+                <availability>
+                    <p>For enquiries about this manuscript, please contact University College Library: <email>library@univ.ox.ac.uk</email></p>
+                </availability>
+            </adminInfo>
+            <xsl:variable name="digbods" as="element(doc)*" select="$digbodresults/doc[str[@name='full_shelfmark_s']/text() = translate($shelfmark, '.', '')]"/>
+            <xsl:for-each select="$digbods">
+                <surrogates>
+                    <bibl type="digital-facsimile">
+                        <xsl:attribute name="subtype" select="if (str[@name='completeness_s']/text() = 'complete') then 'full' else 'partial'"/>
+                        <ref target="https://digital.bodleian.ox.ac.uk/inquire/p/{ str[@name='object_id']/text() }">
+                            <title>Digital Bodleian</title>
+                        </ref>
+                        <note>(<xsl:value-of select="if (str[@name='completeness_s']/text() = 'complete') then 'full digital facsimile' else 'selected images only'"/>)</note>
+                    </bibl>
+                </surrogates>
+            </xsl:for-each>
+        </additional>
+    </xsl:template>
+
+    <xsl:function name="local:lookupLanguages" as="xs:string*">
+        <xsl:param name="languages" as="xs:string"/>
+        <xsl:for-each select="for $l in tokenize($languages, '(\s*[;&amp;]\s*|\s+and\s+)') return normalize-space(tokenize($l, '\(')[1])">
+            <xsl:value-of select="map:get($iso639codes, .)"/>
+        </xsl:for-each>
+    </xsl:function>
+
+    <xsl:function name="local:normalizeName" as="xs:string">
+        <xsl:param name="persname" as="xs:string"/>
+        <xsl:value-of select="lower-case(replace(normalize-space($persname), '[\.,\-–—\? \(\[\]\):;]+', ''))"/>
+    </xsl:function>
+    
+    <xsl:function name="local:normalizeTitle" as="xs:string">
+        <xsl:param name="title" as="xs:string"/>
+        <xsl:value-of select="lower-case(replace(normalize-space($title), '[\.,\-–—\? \(\[\]\):;]+', ''))"/>
+    </xsl:function>
+    
+    <xsl:function name="local:getTitleVariants" as="xs:string*">
+        <xsl:param name="title" as="xs:string"/>
+        <xsl:param name="author" as="xs:string?"/>
+        <xsl:param name="languages" as="xs:string?"/>
+        <xsl:variable name="withandwithoutauthors" as="xs:string*" select="($title, concat($author, ': ', $title))"/>
+        <xsl:variable name="withandwithoutlanguages" as="xs:string*" select="for $t in $withandwithoutauthors return for $l in tokenize($languages, '(\s*[;&amp;]\s*|\s+and\s+)') return ($t, concat($t, ' [', $l, ']')) "/>
+        <xsl:copy-of select="distinct-values(for $t in ($withandwithoutlanguages, $withandwithoutauthors)[count(.) gt 0] return local:normalizeTitle($t))"/>
+    </xsl:function>
+
+</xsl:stylesheet>

--- a/processing/batch_conversion/tei-from-simple-spreadsheet.xsl
+++ b/processing/batch_conversion/tei-from-simple-spreadsheet.xsl
@@ -20,7 +20,7 @@
                   
          To run, convert the spreadsheet to a tab-separated-value text file, and specify that as a parameter, e.g.:
     
-         java -Xmx1G -cp ../saxon/saxon9he.jar net.sf.saxon.Transform -it:Main -xsl:tei-from-spreadsheet.xsl infile=./jesus_college_metadata.tsv nextmsid=10550
+         java -Xmx1G -cp ../saxon/saxon9he.jar net.sf.saxon.Transform -it:Main -xsl:tei-from-simple-spreadsheet.xsl infile=./jesus_college_metadata.tsv nextmsid=10550
           
          Optionally, you can also specify the Solr server for a Digital Bodleian instance to attempt to lookup 
          shelfmarks against UUIDs, and create surrogates links for any it finds.
@@ -31,7 +31,7 @@
     <xsl:param name="nextmsid" as="xs:integer" required="yes"/>
     <xsl:param name="digbodsolr" as="xs:anyURI?" required="no"/>
     
-    <!-- Lookups -->
+    <!-- Lookup languages (tailor list to what is in each spreadsheet) -->
     <xsl:variable name="iso639codes" as="map(xs:string, xs:string)">
         <xsl:map>
             <xsl:map-entry key="'Latin'" select="'la'"/>

--- a/processing/batch_conversion/university_college_metadata.tsv
+++ b/processing/batch_conversion/university_college_metadata.tsv
@@ -1,0 +1,339 @@
+1. Shelfmark	2. Part	3. Author	4. Works	5. Language(s)	6. Format	7. Support	8. Binding	9. Decoration, Illustrations	10. Date	11. Not before (year)	12. Not after (year)	13.Origin 1	14.Origin 2	15. Provenance	16. Page number in Coxe	17. IMOCL	18. IMEP page number	19. Notes	20. Bibliography
+University College MS. 4					codex	vellum	Contemporary white leather over wooden boards		s. XV	1400	1500	England		"Once belonged to a monk of Warden, Bedfordshire. Dialect Bedfordshire." (IMEP). Possibly the Cistercian Abbey at Old Warden/Wardon, Bedfordshire. (PTB)	1		p. 102		
+		Willelmi Burgenoun de Tempsford	Fragmentum folio I & II	Latin ; Middle English															
+			Dialogus de arte moriendi																
+			An order for the visitation of the sick, with exhortations to the sick person	English (Bedfordshire dialect)															
+			Conturbacio animæ in extremis																
+			Exhortatio de modo vivendi concorditer in anima et corpore																
+		Augustine, Saint, Bishop of Hippo	Speculum peccatoris																
+			Sermons (fragments)																
+University College MS. 5			Horæ B. Mariæ Virginis (Use of Dominicans at Tréguier)	Latin	codex	vellum	Limp vellum. 	"Fine miniatures (partly defaced), close in style to Bodl. MS. Laud Lat. 15. Good borders, initials. (cf. no. 805 [Jesus College 32])." (IMOCL) Illustration of the Nativity, p. 56. (PTB)	s. XIVin.	1300	1330			Formerly belonged to Robert Young. (Coxe)	2	Cat. No. 806.		“William Smith […] used galls to revive faded passages.  In no. 5 he tried an experiment.  He applied the galls to the two bottom lines of the text and wrote underneath; ‘Ultimae istae duae lineae (ceteris jam multo nigriores) gallis aqua macerates delinitae errant Aug 28 anno 1700.  Notent posteri quamdiu ista coloris differentia permanebit; et quid commodi vel damni inde sequetur’.  The two lines are still blacker than the rest, and the parchment is stained brown, but no worse effects have followed.  But Smith tried his galls on an erased inscription at the top of the page in vain, and so made impossible the use of other methods of recovering it.” (Hunt, p. 13)	
+University College MS. 6					codex	vellum	18th-century calf. Rebound c. 1700, William Smith's instructions to the binder on p. 368.		s. XIII or XIV	1170	1350	France		Formerly belonged to the Dominicans of Beverley. (Coxe)	2				
+		Augustine, Saint, Bishop of Hippo	Sermons	Latin															
+			Locutiones super heptateuchum	Latin					s. XIII or XIV										
+		Anon.	Quaestiones theologicae et de praedicamentis	Latin					s. XIII or XIV										
+		Gregory, I, Pope, approximately 540-604	Cognomento Magni Dialogorum libri quatuor	Latin					s. XIII										
+		Gregory, I, Pope, approximately 540-604	Pastoralis libri duo	Latin					s. XIII										
+		Quintilian, Ps. [?]	Declamationes	Latin					s. XIII or XIV										
+			Fragmentum dialogi inter Trismegistrum et Asclepium	Latin					s. XIII or XIV										
+		William of Conches, pseudo	Philosophiae compendium	Latin				11 diagrams and 2 world maps	s. XIIex.										
+		Seneca, Lucius Annaeus, the elder, approximately 55 B.C.-approximately 39 A.D.	Opuscula varia	Latin															
+University College MS. 7			Psalter, with Sarum hymns	Latin	codex	vellum	16th-century, purple velvet repaired with purple reversed calf.	Decorated initials and full-page bar-boarders with dragons at divisions	s. XIVex.	1370	1400	France	Paris	 "Note (largely erased), fol. 138v, saec. xv ed., 'Jehan …(diepp … enfant de … cathedralle) … de Rouen'." (IMOCL)	3	Cat. No. 742			
+University College MS. 8				Latin	codex	vellum	Contemporary leather over bevelled wooden boards.	 "Miniatures (unfinished) in Flemish style inserted on separate leaves. Good penwork initials." (IMOCL)	s. XVmed.	1440	1470	England		"olim, ut videtur ex insignibus gentilis in fronte depictis, eujusdam e familia de Percy, postea Roberti Lover, e dono dominæ Greete de Midhurst, viduæ x. Jul. 1549." (Coxe) "Arms of the Percy family on an added leaf, cut down, fol. 4v. Given to Robert Lover, 10 July 1549, by Greete de Medhurst in Sussex, fol. 107." (IMOCL) Ownership inscription at f. 107 possibly enhanced by William Smith: "Robert Lovehers booke geuen of gentle maistres Greete wydowe at Medhurst the x of Julye, anno Domini 1549, Sussex, clearke there in Medhurst predict." (PTB)					
+			Tabula ad inveniendum Pascha	Latin															
+			Kalendarium, monostichis instructum	Latin															
+			Book of Hours, Use of Sarum	Latin															
+			Prayers to St Osith	Latin															
+University College MS. 9			Breviary (Carmelite)	Latin	codex	vellum	English blind-stamped leather with panels showing Martin and the beggar bordered with scenes of the hunt.	"Fine borders, initials. Fine penwork initials." (IMOCL)	s. XVIin.	1500	1525	England		"Made for English use. More English saints added in the calendar, saec. xv. Obits 'matris mee', 1585. Ann Mansfield, Ann Conyers, saec. xvi." (IMOCL)	3	Cat. No. 745			
+University College MS. 10					codex	vellum	18th-century calf gilt (lacking clasps)	Painted cuts. 	s. XVIin.	1500	1525	France		Printed in Paris by Philippe Pigouchet. Made for Guillaume Eustace, 15 June 1508. "olim Margaretæ Gallot." (Coxe) Note at f. 127 reads, 'Ce present livre appartient a Marguerite Gallot'. 	4				
+	1		Book of Hours, Use of Rome	Latin															
+	2		Les vepres de la sepmaine, avec complies, les hymnes, et proses de l'année	Latin ; French															
+University College MS. 11					codex	vellum	Contemporary brown leather over wooden boards		s. XVex.	1475	1500	England			4				
+			Axiomata e jure civili præcipue collecta	Latin															
+			Tabula contentorum secundæ partis Codicis	Latin															
+			Axiomata philosophica juridicialia	Latin															
+			Notabilia theologica	Latin															
+		Alexander, de Villa Dei	Summarium Bibliæ	Latin															
+			Tituli dierum Dominicalium	Latin															
+			Versus ordinem SS. Bibliorum (taken from Genesis, Exodus, Leviticus, Numbers, Deuteronomy, Joshua, Judges, Ruth, and Kings).	Latin															
+University College MS. 12				Latin	codex	vellum	16th-century panelled brown leather tooled with emperors’ heads-in-medallion (lacking clasps)	"Good historiated and other initials. Related in style to Bodl. MS. Liturg. 396." (IMOCL)	s. XIIIex.	1275	1300	Netherlands or Flanders		Given to the College by Thomas Walker, Master (d. 1665)	4	Cat. No. 804.			
+			Psalter																
+			Cantica sacra Mosis																
+			Symbolum Athanasianum, Litaniæ, et collectæ																
+University College MS. 13			Professio fidei.	Latin	codex	paper	Limp vellum (stained)		s. XVIex.	1550	1600	England	London (possibly)	 Recusant manuscript. "ex dono Roberti Plot, LL. Doctoris et hujus collegii commensalis." (Coxe)	4				
+University College MS. 14					codex	vellum	Contemporary white tawed leather (lacking clasps and catches)		s. XV	1400	1500	England		Once belonged to John Juel (1522-71), bishop of Salisbury. Given to University College Oxford by Thomas Walker, Master (d. 1665).	4		p. 102		
+		Hilton, Walter, -1396	The cloud of Unknowing, or of Contemplation	Middle English (South central Norfolk dialect)															
+		Peter, of Blois, approximately 1135-approximately 1212	Regula aurea	Latin															
+		Catherine, of Sienna	Doctrine	Middle English															
+University College MS. 15		Johannis Lugdunensi (or of Leyden)	Sermones Dominicales Festivalesque	Latin	codex	vellum	Contemporary white leather over wooden boards (spine tabs cut off, lacking clasps and catches)		s. XIIIin.	1200	1240	England		"olim ecclesiæ S. Mariæ de Holm-Cultram ex dono Ludovici monachi." (Coxe) Christopher Hudson, s. XVI (f. 181v).	5				
+University College MS. 16					codex	vellum	Contemporary reversed red leather over wooden boards (lacking clasps and catches) with front endleaves from an English choirbook and rear endleaves with polyphonic music		s. XV	1400	1500	England		Incorporated into the college library in 1684; John Courteney mentioned in liminary text. (DIAMM) According to Coxe this manuscript belonged to Thomas Dackombe. This was probably Thomas Dackombe (1496-c.1572), petty canon of Winchester Cathedral.	5			Black full mensural notation with black full black void and red black full coloration except one motet in black void mensural notation. (DIAMM) College bookplate of 1650? on inside of upper board; College bookplate of 1700? on f. 3v. Contents listed on f. 149r.	
+			Epistola beati Eusebii	Latin															
+			Soliloquia sive meditationes sancti Augustini	Latin															
+			Alloquia beati Augustini	Latin															
+			Devota meitatio sive oratio ad proprium angelum	Latin															
+		Anselm, Saint	Ad Sanctum Johannem Baptistam	Latin															
+			Ad S. Johannem evangelistam	Latin															
+			Alia oratio ad eundem Sanctum Johannem	Latin															
+University College MS. 18					codex	vellum	English 15th-century panelled ‘cuir ciselé’ over wooden boards, border ruled and stamped in  blind (rebacked, lacking clasps and catches)		ss. XIV, XV	1300	1500	England		Belonged to Thomas Stokys, armiger, and given to University College by Thomas Staunton. (Coxe)	6				
+		Peter, of Blois, approximately 1135-approximately 1212	Duodecim utilitates tribulationis	Latin															
+		Bonaventure, Saint, Cardinal, approximately 1217-1274 pseudo,	Meditationes vitae Christi	Latin															
+University College MS. 19					codex	vellum	16th-century panelled brown leather over wooden boards (lacking clasp)		s. XIV	1300	1400	England	Canterbury, St Augustine's Abbey	 Formerly belonged to an abbot named Thomas; after 1669 it was owned by William Rogers. (Coxe)	6				
+			Canones evangelorium secundum novas capitulaciones Bibliae	Latin															
+			Ordo omnium gestorum et miraculorum Domini nostri Jhesu Christi	Latin															
+		Clement, of Llanthony	Unum ex quatuor	Latin															
+University College MS. 20			Bible (Vulgate) with prologue of St Jerome	Latin	codex	vellum	Medieval white tawed leather over bevelled wooden boards (lacking one of two clasps)	Decorated. Flourish initials throughout.	s. XIIIex.	1275	1300	England		"olim Radulphi Fawconere." (Coxe)	6				
+University College MS. 21		Raymond, of Peñafort, Saint, 1175?-1275	Summa theologiae	Latin	codex	vellum	Old brown leather over wooden boards		s. XIV	1300	1400	France		"olim liber Simonis de Retlinge, de libraria Sancti Augustini Cantuar., postea Tho. Weaver." (Coxe)	6				
+University College MS. 22			Breviary, Use of Salisbury (Sarum), inserted with readings and homilies by Venerable Bede and others	Latin	codex	vellum	Brown leather over wooden boards (rebacked)	Written in an informal English cursive hand.	s. XV	1400	1500	England		"olim Johannis Bristowe." (Coxe) Names mentioned in a note on f. 337v John Roly, George Dawne.	7				
+University College MS. 23					codex	vellum	Contemporary blind-stamped goatskin (lacking one of the clasps)	Written in a humanistic bookhand, initials not supplied.	s. XV	1400	1500	Italy	Naples (possibly)	"olim Johannis Lawrens, postea coll. Univ. ex dono Tho. Walker S.T.P., magistri." (Coxe)	7				
+		Facio, Bartolomeo, -1547	De vitae felicitate	Latin															
+		Facio, Bartolomeo, -1547	Ad Robertum Strozzum epistola	Latin															
+University College MS. 24			Summula controversiarum	Latin	codex	vellum	Limp vellum		s. XVI	1500	1600			Collegii Anglici (note in Duke Humphrey's copy of Coxe).	7				
+University College MS. 25					codex		16th century blind-stamped calf (rebacked, lacking clasps and catches)								7			College bookplate of 1700? on inside of upper board.	
+	1		Hours of the Holy Spirit	Latin		vellum		Flourish initials, border decorations	s. XV	1400	1500	England		Formerly belonged to Elizabeth Yate. (Coxe and note on f. 4r)					
+	2		Psalter and Hymnal (Use of Sarum)	Latin		printed on paper		Woodcut of Franciso Birckman on title page	s. XVI	1500	1600	France	Paris	 Printed by Franz Birckman, 1522.					
+	3		Lectionary, hymnal, prayers with Litany	Latin		vellum		Initials and border	s. XVI	1500	1600	England	Syon						
+University College MS. 26					codex	vellum	Contemporary tawed leather over wooden boards with bevelled edges (worn, lacking clasps and catches)	"manu Johannis Hatfield plerumque exaratus" (Coxe): largely in the hand of John Hatfield. Sacrobosco texts signed by John Hatfield. Planetary and astrological diagrams on ff. 122r, 125v, 126v, 130r, 134v, 139r.	s. XIV or XV	1300	1500	England		In 1669 the manuscript was under the ownership of William Rogers of Lincoln's Inn. (Coxe; inscription on f. 91v) Inscription "Wm. Rogers" (ff. 4r & 149v)	7			College bookplate of 1700? on f. 2v.	
+		Sacro Bosco, Joannes de, active 1230	De algorismo sive de arte memorandi tractatulus	Latin															
+		Sacro Bosco, Joannes de, active 1230 & Grossteste, Robert, 1175?-1253,	Liber de computo	Latin															
+		Sacro Bosco, Joannes de, active 1230	Liber de sphaera	Latin															
+		Grossteste, Robert, 1175?-1253	Theorica Planetarum, cum figuris	Latin															
+			De vocibus animalium	Latin															
+			Tractatus de proportione	Latin															
+University College MS. 28					codex	paper	18th-century blind-stamped calf		s. XV	1400	1500	England		"ex dono M. Georgii Plaxton, de S. Hales, com. Staff. 1681." (Coxe) Probably George Plaxton (1647/8-1720), cler., of Sheriffhales, Shropshire 1673-1703, keen antiquary. (PTB) See ODNB.	8		p. 102-5		
+		Hilton, Walter, -1396	Scale of perfection	Middle English (West Riding of Yorkshire dialect)															
+			Sequence of sermons for holy days																
+			Tract on the seven deadly sins																
+University College MS. 29					codex	vellum	17th-century brown leather 		s. XV	1400	1500	England		"olim Thomæ Browne." (Coxe) "Given by [John] Bancroft [Master of University College Oxford, 1610-32]" (DHC)	8				
+		Anon.	Treatise on sin	Latin															
+		Hoveden, John, -1275	Speculum laicorum	Latin 															
+			A narration of the miracle of how St Augustine of the Apostle of England raised the dead bodies of two excommunicated persons	Latin 															
+			Tract on the virtue of Theology and the Articles of Faith	Latin 															
+		Augustine, Saint, Bishop of Hippo, pseudo	Speculum Peccatorum	Latin 															
+			Soliloquium animae	Latin 															
+			Sermon on 1 Corinthians 7.29	Latin 															
+			Debate between the body and the mind	Latin 															
+			Excitatio necessaria ad peccatorem	Latin 															
+University College MS. 30					codex	vellum	18th-century speckled calf	Flourish initials.	s. XV	1400	1500	England			9			List of contents in hand of Obadiah Walker on upper flyleaf.	
+		Anselm, Saint, Archbishop of Canterbury, 1033-1109	Ad Deum Patrem (prayer)	Latin															
+		Augustine, Saint, Bishop of Hippo, 345 - 430	Sermo de oratione dominica (serm. 58)	Latin															
+			Meditations and Soliloquies	Latin															
+		Ambrose, Saint, Bishop of Milan, - 397	Sermons and meditations	Latin															
+University College MS. 31		Clerke, Francis, fl. 1594	Praxis in curiis ecclesiasticis Anglicanis	Latin	codex	paper	Contemporary calf gilt	Liquid gold initials and acanthus borders on ff. 1 and 3.	s. XVI	1500	1600	England			9				
+University College MS. 33					codex	vellum	Contemporary tawed leather over bevelled boards, mark from chain hasp (lacking chain and clasp)	Flourish initials and manicoli.	s. XV	1400	1500	England		Belonged to Thomas Browne, then to John Bancroft, Master of Univ. and later bishop of Oxford, who gave it to University College in 1632. (Coxe)	10				
+			De gestis et transaltionibus sanctorum Regum de Colonia	Latin															
+		Anon	"While thou hast Gode and geteste gode" (poem)	Middle English															
+University College MS. 36					codex	vellum	Limp vellum	Small flourish initials.	s. XIVex.	1350	1400			"olim Thomæ Browne, postea coll. Univ. ex dono Tho. Walker, S.T.P. magistri." (Coxe)	10				
+		Hoveden, John, -1275	Speculum laicorum	Latin															
+		Hoveden, John, -1275	Eplicatio decalogi	Latin															
+		John, of Wales, active 13th century (attrib.)	Forma praedicandae	Latin															
+		Grosseteste, Robert, 1175?-1253	De venenis	Latin															
+		Athanasius, Saint, Patriarch of Alexandria, -373, pseudo	Sermo de imagine Salvatoris apud Berytum inventa	Latin															
+University College MS. 37			Catena SS. Patrum in psalmos septem pœnitentiales	Latin	codex	vellum	18th-century brown leather	"Fine borders, initials." (IMOCL)	s. XVin.	1400	1450	England			11	Cat. No. 423			
+University College MS. 40					codex	vellum	18th-century leather	"Fine border, fine and other initials. Humanistic script by Peter Meghen." (IMOCL) Illuminated by a Flemish artist.	s. XVI	1500	1600	England		"in usum Christophori Urswyke, Henrici VII. Regis Angliæ ellemosinarii, nitide exaratus, et quoad pag. Primam pictus." (Coxe) "Written for Christopher Urswick, dean of Windsor (d. 1522), fol. 102." (IMOCL)	11	Cat. No. 824			
+		John Chrysostom, Saint, -407	Homilies on the Gospel of St Matthew	Latin															
+		John Chrysostom, Saint, -407	Homily	Latin															
+		Augustine, Saint, Bishop of Hippo	Sermon	Latin															
+		Luther, Martin, 1483-1546	Two Sermons	Latin															
+		Savonarola, Girolamo, 1452-1498	Meditation 'Infelix ego'	Latin															
+		Savonarola, Girolamo, 1452-1498	Exposition on the 30th psalm	Latin															
+University College MS. 41					codex	vellum	Medieval white tawed leather over stiff vellum.	Astrological diagrams.	s. XIV	1300	1400	England		 "Iste liber pertinet comunitate Fratrum Salopiae" (f. 2v) Formerly belonged to a convent in Shrewsbury.	12			College bookplates of 1650? and 1700? on inside of upper board. Leaves from binding now University College MS. 207 (note on flyleaf). List of contents on f. 2v.	
+		Anon	Definitiones sphæræ	Latin															
+		Grosseteste, Robert, 1175?-1253	Compotus (lacking opening)	Latin															
+		Profatius Judæus, approximately 1236-	Tractatus quadrantis	Latin															
+		Sacro Bosco, Joannes de, active 1230	De Algorismo	Latin															
+		Sacro Bosco, Joannes de, active 1230	De Sphaera	Latin															
+		Thebit, ben Chorat, 836-901 [?]	Liber … de hiis quae indigent expositione antequam legatur Almagestus	Latin															
+		Grossteste, Robert, 1175?-1253 (attributed) & Gerard of Cremona	Theorica Planetarum	Latin															
+			De compositione Cylindri, cum tabulis altitudinem solis exhibentibus in civitate Oxon. London. et Exon	Latin															
+			De compositione quandrantis	Latin															
+			Ars et operacio novi quadrantis, edited by Petrus de Sancto Audemaro 	Latin															
+			Canones super Almanach Prophatii [Alphonsine table]	Latin															
+			Tabula radicum planetarum super meridiem Oxonie cuius longituo ab occidente est 51 gradus [Alphonsine table]	Latin															
+University College MS. 42					codex	paper	Contemporary ruled brown leather over bevelled boards	Flourish initials. "haud una manu exaratus." (Coxe)	s. XV	1400	1500	The Netherlands	Zwolle or Gröningen	 "olim domus clericorum de communi vita in Gröningen circa Sanctam Walburgam, postea an. 1639 Johannis Halei, Med. Doct." (Coxe)	12				
+		Anon.	Liber de vera vite, Jhesu Christo 	Latin															
+		H. de Goriken	Tractatus de Praedestinatione	Latin															
+		Giles, of Assisi, -1262	Verba aurea	Latin															
+		Henrici Ramsen	Responsiones de indulgentiis ad Johannem ep. Leodiensem	Latin															
+		Gerson, Jean, 1363-1429	De pollutione nocturna	Latin															
+		Anon.	De vita	Latin															
+		Anon.	De vita Christi juxta Evangelistas	Latin															
+		Beke, Johannes de	Chronicle (excerpt)	Latin															
+University College MS. 44		Aelred, of Rievaulx, Saint, 1110-1167	De vita Davis sive genealogia regum anglorum	Latin		paper	Limp vellum		s. XVI or XVII	1500	1700	England			13				
+University College MS. 45					codex	vellum; paper	15th-century reversed tawed leather over bevelled boards. Leaf from Early English Text Society publication (1867) used as flyleaf. 			1100	1500	England			13			List of contents in hand of Obadiah Walker on upper flyleaf. College bookplates of 1650? and 1700? on flyleaf.	
+	1	Langland, William, 1330?-1400?	Piers Plowman (independent version)	Middle English					s. XV										
+	2	Henry, of Huntingdon, 1084?-1155 	Imago mundi	Latin					s. XII										
+	3	Clement, of Llanthony	Libellus	Latin					s. XIV										
+		Anon	De quinque septenis in Scriptura	Latin															
+		Hildebert, Archbishop of Tours, 1056?-1133 	Carmen de expositione missæ	Latin															
+			Versus xxii. de diversis	Latin															
+			Expositio brevis metrica orationis Dominicæ	Latin															
+		Hildebert, Archbishop  of Tours, 1056-1133	Hymnus	Latin															
+			Hexæmeron	Latin															
+			Narrationes de fratribus sanctisque ex SS. Bibliis et Vitas Patrum	Latin															
+		Rolle, Richard, 1290?-1349 (Richard Hampole)	Commentary on Job and the Psalms	Latin															
+University College MS. 52		Constantinus Sacerdotus	Octateuchus	Greek		vellum	Red russia 		s. XII	1100	1200			"olim Thomæ Cayii deinde Johannis Brown, coll. Univ. socii, postea ejusdem coll. ex dono Joh. Bancroft." (Coxe)	15				
+University College MS. 53			Theological tracts and letters.	Latin	codex	paper	Contemporary blind-stamped and ruled brown leather over boards		s. XV	1400	1500	France or The Netherlands			15				
+University College MS. 54		John Chrysostom, Saint, -407	Homilies on John, transl. Burgundio of Pisa	Latin	codex	vellum	19th-century	"Fine border (mutilated), historiated and other initials. By the same hand as Bodl. MS. Digby 231, Francesco d'Antonio del Cherico. Humanistic script." (IMOCL)	s. XV	1400	1500			"olim Francisci Clethero." (Coxe) "Thomas Clifford, Franc. Clethero, saec. xv (?), fol. 227." (IMOCL)	16	Cat. No. 956			
+University College MS. 55					codex	vellum	16th-century ruled brown leather over pasteboard			1200	1300			 "olim Thomæ Browne, postea coll. Univ., ex dono Johannis Bancroft." (Coxe)	16				
+	1	Peter Lombard, Bishop of Paris, approximately 1100-1160	Sentences	Latin				Two large flourish initials (one excised)	s. XIII			France							
+	2	Henry, of Ghent, 1217?-1293	Quodlibeta	Latin					s. XIII			England							
+			Arbor consanguinitatis	Latin															
+University College MS. 56						vellum	16th-century leather panelled in blind, diapers with pineapple tool (rebacked, preserving original spine)	Flourish initials and borders in red, blue, and purple. "Fine penwork borders, initials." (IMOCL)	s. XVin.	1400	1450	England		"olim cujusdam e familia de Hamptone, postea coll. Univ. e dono Samuelis Clerke, coll. Univ. commensalis, A.D. 1641." (Coxe) "Calendar of Christ Church, Canterbury, with obits of the Hampton family, 1413-22, fols. 1—5v. Given by Samuel Clarke, commoner 1641, fols. 1, 264v." (IMOCL)	16	Cat. No. 395	p. 105		
+			Kalendarium (Christ Church Canterbury)	Latin															
+		Rolle, Richard, 1290?-1349	Commentary on the Psalms	Middle English															
+		Rolle, Richard, 1290?-1349	Commentary on Cantica Sacra	Middle English															
+			Te deum laudamus and Athanasian Creed	Latin															
+University College MS. 57		Guilelmus Peraldus, approximately 1190-1271	Sermones Dominicales (Gospels)	Latin	codex	paper	Old leather over wooden boards (rebacked)		s. XV	1400	1500			“Companion volume to University College MS. 75 so probably presented by Master William Asplyon.” (Note in Duke Humphrey's copy of Coxe)	17				
+University College MS. 58			Gospels, glossed	Latin		vellum	Medieval brown leather over bevelled wooden boards, possibly original	Flourish initials	s. XII or XIIIin.	1100	1250	France		"ex dono Gul. Green, armigeri nuper hujus collegii commensalis superioris ordinis 1683." (Coxe)	17				
+University College MS. 59		Anselm, Saint, Archbishop of Canterbury, 1033-1109	Opera varia	Latin	codex	vellum	17th-century calf		s. XIII	1200	1300	France		 Early side notes in English hand. "olim Thomæ Browne, postea coll. Uinv. Ex dono Johannis Bancroft." (Coxe)	17				
+University College MS. 60						vellum	Contemporary white leather over bevelled boards	Written by Hugh Hall	s. XV	1400	1500	England		"olim Thomæ, et Johannis Browne, deinde F. Drake, et denuo coll. Univ. ex dono Tho. Walker. Magistri." (Coxe)	17				
+		Haqueville, Nicolaus de	Sermones dominicales	Latin															
+		Grossteste, Robert, 1175?-1253	Liber de venenis	Latin															
+		Bonaventure, Saint, Cardinal, approximately 1217-1274	Works	Latin															
+		Lydgate, John, 1370?-1451?	Verses	Latin															
+University College MS. 61					codex	vellum	Contemporary brown leather over boards.	Initial and border		1200	1400	England		"Iste liber pertinet communitate Fratrum Solopiæ." (fol. 2v) "olim Thomæ Browne, postea coll. Univ. ex dono Tho. Walker, magistri." (Coxe) "Richard Gosmore, fellow of Magdalen College (d. 1547); Thomas Broune, Christ Church scholar, vicar of Kingsclere (d. 1587), fol. Iv. Given by Thomas Walker, master (d. 1665), fol. 2." (IMOCL)	18	Cat. No. 304			
+	1	Valerius 	Ad Ruffinam	Latin					s. XIVin.										
+	2	Gregory, I, Pope, approximately 540-604	Sermon on Ezekiel	Latin					s. XIII										
+	3		Meditation of St Bernard 	Latin					s. XIV										
+		St Jerome	Lives of the Desert Fathers	Latin															
+		Augustine, Saint, Bishop of Hippo	Edicta de animæ egressione a corpore	Latin															
+			Vita Fursei, ed. by Bede	Latin															
+University College MS. 63 (also University College MS. 62)					codex	vellum	Early 16th-century blind-stamped leather over boards. "saec. xvi in., possibly A . Lysley, Eton." (IMOCL)	Border, flourish initials		1200	1500	England and France		 "ex dono Mariæ Elmhurst, in gratiam unici sui nati Hereberti Elmhurst, collegii scholaris, et in collegio mortui." (Coxe) "Humphrey Gilbert, c. 1551, fol. 64v and on lower cover. Given by Maria Elmhurst in memory of Herbert Elmhurst, scholar (d. 1670), first pastedown." (IMOCL) Eton (Ker and Watson)	19	Cat. No. 409			
+	1	Grossteste, Robert, 1175?-1253	De lingua et corde	Latin					s. XIII										
+		Gilbert, of Hoyland	Commentary on St Paul's Epistles	Latin															
+	2		Postilla super librum Danielis	Latin					s. XV										
+University College MS. 64					codex	paper	12th-century white leather over square-cut boards (rebacked), head spine tab (lacking strap and pin)		s. XV	1400	1500	England		"olim Tho. Walker, magistri." (Coxe)	19		pp. 107-8		
+		Rolle, Richard, 1290?-1349	Commentary on the Psalms	Middle English (Yorkshire dialect)															
+		Rolle, Richard, 1290?-1349	Commentary on the Canticles	Middle English (Yorkshire dialect)															
+University College MS. 65			Exhortationes canctorum patrum	Latin		vellum	19th-century half morocco	Initials in green and red, four large and patterned	s. XII	1100	1200			"olim W. Rogers de Paynswick." (Coxe)	19				
+University College MS. 66		Gregory, I, Pope, approximately 540-604	Moralia in Job (from Book XXI, lacking end)	Latin	codex	vellum	Later medieval brown leather over wooden boards (worn and rebacked)	Initials in green, red, and blue	s. XII	1100	1200	England		"ex dono Thomæ Walker, magistri." (Coxe)	20				
+University College MS. 67					codex	vellum	Contemporary white leather over bevelled wooden boards with strap (lacking pin)		s. XIVex.	1350	1400	England		"olim libri de communitate fratrum Prædicatorum conventus Beverlaci; postea 'liber Thorgott, dono Nicolai Mell." (Coxe)	20			Preachers' aid from the Dominican convent at Beverley.	
+			Alphabetum narrationum	Latin															
+			In vitis patrum	Latin															
+University College MS. 68		Aquinas, Thomas, Saint, 1225-1274	Summa contra gentiles	Latin	codex	vellum	15th-century ruled calf over bevelled wooden boards (rebacked, lacking clasps). "Binding identical with Bodley MS 214." (DHC)	Flourish initials	s. XIII	1200	1300	England	Canterbury	"olim, ut videtur, Roberti de Wynchelsey, archiepiscopi Cantuarensis; postea H. Sutton." (Coxe)	20				
+University College MS. 69		Roger, monk of Croyland	Life of Thomas Beckett	Latin		vellum	19th-century pigskin		s. XIII	1200	1300	England		"olim liber ecclesiæ ….. Wintoniæ, postea Johannis Theyer, de Copwers Hill juxta Gloucest." (Coxe) Given by W. Rogers (DHC)					
+University College MS. 70		Johannes, Felton, -1434	Sermones dominicales	Latin		paper	Contemporary tawed skin over wooden boards (window fragment and nails on lower board)	Flourish initials	s. XV	1400	1500	England		From the medieval library in University College Oxford (DHC)	20				
+University College MS. 71			Septuplum		codex	vellum	Trimmed chemise binding, tawed leather. "Contemporary binding of white leather on boards." (IMOCL)	"Good initials. Penwork initials, cadels." (IMOCL)	s. XVin.	1400	1450	England		"olim liber Magistri Hawkyns, ex dono Roberti Page, postea coll. Univ. ex dono Willelmi Hawkyns." (Coxe) "Given by William Hawkyns, fellow, 1527, fol. 14v." (IMOCL)	21	Cat. No. 479			
+University College MS. 72			Britton (Operis juridicalis)	French	codex	vellum	19th-century pigskin	Initials with leaves	s. XIIIex. or XIV	1270	1450	England			21				
+University College MS. 74		Rolle, Richard, 1290?-1349	Commentary on the Psalms	Middle English	codex	vellum	Contemporary leather over wooden boards		s. XV	1400	1500	England		Given by Thomas Walker (DHC)	22		p. 108		
+University College MS. 75		Guilelmus Peraldus, approximately 1190-1271	Sermones Dominicales (Epistles)	Latin		paper	Contemporary white tawed skin over wooden boards	small flourish initials.	s. XV	1400	1500	England		“fol 44r John Dowetyng.  Ex dono Magr Willi As[plyon] (label on back cover)” (DHC) See University College MS. 57 (companion volume)	22				
+University College MS. 76			Repertorium de re theologica philosophicaque	Latin		paper	Contemporary white leather over wooden boards		s. XV	1400	1500	England		"olim Johannis Castell." (Coxe). Commonplace book of John Castell, Master of Univ., 1410-20.	22				
+University College MS. 77				Latin	codex	vellum	White leather over square ended wooden boards		s. XIII	1200	1300	England		 "de communitate fratrum minorum Salopie [Shrewsbury, Franciscans]." (f. 2r) "olim liber de communitate fratrum minorum Salopiæ, postea ex librario monasterii de Hangmod [Haughmond] sumptus et Ricardo Fowler præsentatus a Johanne Shelrock, rectore de Smethcott, 4 Aug. 1606." (Coxe)  Label of gift to college, 1606, behind horn window on spine.	22				
+			Gospel of Matthew, glossed																
+			Treatise on the Mass																
+			Gospel of Luke, glossed																
+University College MS. 78A			Missal, use of Hereford	Latin ; Middle English	codex	vellum	Leather spine, exposed wooden boards (rebacked).	"Fine borders, fine and other initials." (IMOCL)	s. XVin.	1400	1450	England		 "olim Gul. Rogers, ex hospit. Lincoln. 1668." (Coxe) "Dedication of Hereford Cathedral in the calendar. Dedication of St Dubricius, Whitchurch, Monmouthshire, probably a contemporary addition. Given in 1668 by William Rogers of Painswyck, commoner, fols. 1,7, 227v." (IMOCL) Parish of Whitchurch, Herefordshire (Ker, p. 389).	23	Cat. No. 422	pp. 108-9		
+University College MS. 78B			Missal, use of York	Latin		vellum	Contemporary trimmed chemise binding	Illuminated, flourish initials. "Sketch of a figure, fol. 184v." (IMOCL)	s. XVmed.	1430	1470	England.		 "olim ecclesiæ de Cocknay ex dono Willelmi Sheppard." (Coxe) "Calendar (feast of relics 19 Oct.) suggests York Minster. Obit of Margaret Haverham, 1532. Given to Cuckney church by William Sheppard. Fols. 1, 184v. Given to the College by Thomas Walker, master (d. 1665)." (IMOCL)	23	Cat. No. 509			
+University College MS. 79		Rainerius, de Pisis, -approximately 1348	Summæ Theologiæ (pars prima, A-E)	Latin		paper	Contemporary white leather over wooden boards. Nail and chain marks.		s. XV	1400	1500	England.		 "ex dono Will. Asplyon, unius e xij. Sacerdotibus monast. S. Salvatoris in Sion; 1473." (Coxe)	23				
+University College MS. 80		Rainerius, de Pisis, -approximately 1348	Summæ Theologiæ (pars altera, E-I)	Latin		paper	Contemporary white leather over wooden boards		s. XV	1400	1500	England.			23				
+University College MS. 81A		Rainerius, de Pisis, -approximately 1348	Summæ Theologiæ (volumen quarta, P-R)	Latin		paper	Contemporary white leather over wooden boards		s. XV	1400	1500	England.			23				
+University College MS. 81B			Alphabetum narrationum, In vitis patrum	Latin		paper	Contemporary white leather over wooden boards		s. XV	1400	1500	England.			23				
+University College MS. 82			Cartulary of St John's Beverley (Beverley Minster)	Latin	codex	vellum	"Metal cross, a roundel with a distich under horn cover on more recent binding of brown leather on pasteboard." (IMOCL)	"Fine historiated initials (drawings). Calligraphic interlace initials." (IMOCL) Late fourtheenth century drawing of Athelstan and St John of Beverley (f. 7r).	s. XV	1400	1500	England.		 "St. John's, Beverley, Yorks." (IMOCL)	24	Cat. No. 548			
+University College MS. 84		Justinian	Codex, glossed by Franciscus Accurius	Latin	codex	vellum	English 15th-century white leather over wooden boards (lacking clasps)		s. XIII	1200	1300			"ex dono Thomæ Walker, S.T.P. magistri." (Coxe)	25				
+University College MS. 85					codex	vellum	19th-century brown leather	Two half-page miniatures , borders (including two full bar borders) and text decoration	s. XVmed.-ex.	1430	1500	England	London	"Crest, two arms embossed vested azure, holding between the hands proper a garb or and the motto 'Oublier ne doit', pp. 1, 70. Verses in French by Michel Otheu [Otthen], physician of Emperor Maxmilian II addressed to Anne, duchess of Somerset, added pp. 2, 18, 180, 1585." (IMOCL) Possibly given by Obadiah Walker, s. VXII.	25	Cat. No. 549	p. 108-9		
+		Alain Chartier	Quadrilogue invectif	Middle English															
+		Pseudo-Aristotle (trans. John Lydgate)	Secreet of Secreets	Middle English															
+			Three consideracions right necessarye to the good gouernaunce of a prince	Middle English															
+University College MS. 86		Gratian, active 12th century	Decretum	Latin	codex	vellum	14th-century tawed leather over wooden boards to page edge. Originally had seven clasps. 	"Good miniature. Fine initials. Fine penwork initials. Marginal sketch, fol. 267. Fols. 189-243 an insertion of saec. xiii in. with fine penwork initials." (IMOCL)	s. XIIIex.	1260	1300	England	Durham (?)	"olim armarioli communis Dunelmensis, postea Johannis de Kelton." (Coxe) Give by Charles Hales. (DHC) "Ex libris of Durham cathedral and pressmark 'Q', saec. xv. fol. 1. (IMOCL)	26	Cat. No. 265			
+University College MS. 87		Augustine, Saint, Bishop of Hippo	Contra Faustum manichaeum	Latin		vellum	19th-century reversed leather	Interlace initial with faces, initials in red, blue, and green.	s. XIIin.	1100	1150	England.			26	Cat. No. 12			
+University College MS. 88		Forrest, William, 1530-1581	The history of Joseph	Latin		vellum	Contemporary gilt-stamped calf with arabesque corner pieces, lion mask brass bosses at corners (one lacking, binding restored).		s. XVI	1500	1600	England. 		Autograph manuscript and presentation copy. Gift of C. Theyer (DHC).	26			This is volume I. Volume II is British Library, MS Royal 18.C.XIII	
+University College MS. 89					codex	vellum	16th-century blind-tooled calf ruled and tooled with diamonds containing sprays decorated with petals (upper joint split, lacking clasps and catches)	Illuminated and flourish initials	s. XIV	1300	1400				26				
+		Galen	Microtechnon	Latin															
+		Hippocrates, v460-v370	Aphorisms	Latin															
+		Hippocrates, v460-v370	Prognostica	Latin															
+		Hippocrates, v460-v370	Regimen acutorum	Latin															
+University College MS. 90			Lands of the earl of Ormonde	English	codex	paper	17th-century gilt stamped with Carew arms 		s. XV	1400	1500	England or Ireland. 		Copied from the Red Book by William White, 1480, from the collection of Sir George Carew, earl of Totnes (1555-1629).	27		p. 109		
+University College MS. 91		Guilelmus Peraldus, approximately 1190-1271	De vitiis septem	Latin		vellum	Contemporary doeskin over wooden boards (lacking clasps)	Flourish initials	s. XIII	1200	1300	France. 		"olim decani de Crediton, ex legatione W. Palmer, postea Gulielmi Muggi ex dono Georgii Mason." Bequeathed to Crediton church by William Palmer who had bought it from the London stationer Thomas Veysey in 1433	27				
+University College MS. 92		Robert Cowton, active 1302-1340	Commentarius in Sententiarum (librum primum)	Latin	codex	vellum	Contemporary, perhaps original, white leather over wooden boards, straps with brass clasps and catches	Flourish initials	s. XIV	1300	1400	England.			27				
+University College MS. 93		Anon	Lecturæ de controversiis inter reformatos et ecclesiam romanam, 1586-1588	Latin		paper	Contemporary blind-stamped brown leather (very worn), 12th-century parchment folios as lifted endleaves		s. XVI	1500	1600	England.			27				
+University College MS. 94		Diogenes Laertius 	De vitis philosophorum, trans. by Ambrogio Traversari	Italian		vellum	Contemporary blind-stamped knotwork binding (slightly rubbed, lacking clasps and catches)	Fine humanist script, white vine border and initials, coat of arms. "manu Italica optime exaratus et quoad literas initiales ornatus." (Coxe)	s. XV	1400	1500	Italy	Ferrara	Ferrara. "olim Thomæ Kech ex dono M. Thomæ Gandy." (Coxe) Given by John Hales (DHC)	27	Cat. No. 988			
+University College MS. 95					codex	vellum	17th-century limp vellum (leaf from upper cover now University College MS. 192)	Flourish initials	s. XV	1400	1500	England.		 Once belonged to Edington Priory. "olim Johannis Naylor, coll. Univ. socii." (Coxe)	28				
+			Liber dictus Rosarium	Latin															
+			List of Gospels and Epistles for the year	Latin															
+		Hugh, of Saint-Victor, 1096?-1141	De archa Noe (fragment)	Latin															
+University College MS. 96			Wycliffite Summary of the Old Testament with Interpretations of Scripture (including the General Prologue to the Wycliffite Bible); Gospel lections in Middle English for Easter and Palm Sunday	Middle English	codex	vellum	Unbound	Red initials. Spaces left for initials. Script is Anglican showing Secretary influence.	s. XVin./med.	1400	1470	England.	Printed in London, 1550 (Coxe) 	 "This book seemeth to have been made by  John  Wickliffe." "I take this note to be of Mr Obad. Walker’s handwriting. Teste Guil. Smith, Aug. 26, 1700." (Notes on the flyleaf) "List of contents in the hand of O. Walker." (anonymous note in Duke Humphrey copy of Coxe)	28		p. 109		
+University College MS. 97					codex		Contemporary			1350	1500			"olim ecclesiæ [S. Petri] de [Westmonasertio?] in qua Blanchia ducissa Lancastriæ an. 1368 sepulta; postea coll. Univ e dono Th. Walker, magistri." (Coxe)	28		p. 109-12		
+	1		Prophecies of St Thomas of Canterbury	Middle English		vellum and paper			s. XIVex.					England.					
+			Gesta romanorum moralista	Latin															
+			Papal Bull (to Thomas Bourchier, archbishop of Canterbury, dated 1456)																
+	2		Devotional treatises	Middle English		vellum			s. XV										
+			Wycliffite version of Visitatio infirmorum																
+			Short chronicles																
+		Sir Johne Clanvowe	Treatise																
+			Documents and chronicles relating to St Paul's Cathedral, London																
+University College MS. 98		Gregory, I, Pope, approximately 540-604	Pastoralis curæ	Latin	codex	vellum	19th-century half morocco	One large patterned initial, initials & ampersands in green and red	s. XII	1100	1200	England.			29				
+University College MS. 99			Collection of nine treastises, incl. Gregory the Great (Pastoralis curæ), Augustine of Hippo (De conflictu vitiorum, De disciplina christiana), Pseudo-Aritstotle (De pomo)	Latin	codex	paper	Contemporary tawed skin over bevelled wooden boards with two catches (lacking straps and clasps). Papal bull of 1380 in favour of Patrick Asseburne as endleaves.		s. XVin.	1400	1450	England.		 “manu M.T. de Ashburne scriptus; olim Roberti Halytreholme” (Coxe)	30				
+University College MS. 100					codex	vellum	Medieval trimmed chemise of white doeskin over wooden boards to page edges, strap.	Flourish initials. "Good miniatures (mainly coloured drawings). Good penwork initials." (IMOCL)	s. XIIIex.	1250	1300			"ex dono Gul. Rogers de Painswyck." (Coxe) "Given in 1669 by William Rogers of Painswyck, commoner, fols. 1, 98." (IMOCL)	30	Cat. No. 259			
+			Apocalypse of John	French															
+			Carmen de vita et morte B. Mariæ Virginis	French															
+University College MS. 101			Breviary (Cluny) with additional texts	Latin		vellum	17th- or 18th-century limp vellum		s. XIIex.	1150	1200	England	Monk Bretton and Pontefract		30				
+University College MS. 102		Mirk, John, active 1403?	Festial (temporal section with two additional sermons)	Middle English	codex	paper	Contemporary pink-stained leather (lacking clasp and catch)	Initials touched red.	s. XV	1400	1500	England			31		p. 112-9		
+University College MS. 104		Julian of Toledo, 0642?-0690	Prognosticon futuri sæculi	Latin	codex	vellum	Original wooden boards and tabs at spine, early rebacking in tawed skin	Green and red initials	s. XI	1000	1100	England	Battle Abbey		31				
+University College MS. 106			Pocket Bible (with the Prologues of St Jerome)		codex	vellum	Calf with gilt lettering (recording donation by William Percyval of Shenley in 1616)	Decorated, flourish initials throughout.	s. XIV	1300	1400			"ex dono Gulielmi Percyval, de Shenlye, co. Buckingham. 1616." (Coxe)	32				
+University College MS. 107			Statuta Angliæ	Latin and French		vellum	17th-century		s. XIV	1300	1400	England.		 Thomas Parlysh (s. XVI) fol. 168 (DHC)	32				
+University College MS. 108		Ogilvy of Boyne	Cartulary	Latin	codex	paper	Original limp vellum with monogram "OB" on upper cover.		s. XVI	1500	1600	Scotland			32				
+University College MS. 109					codex	vellum	Contemporary white leather over wooden boards	Flourish initials in red and blue.	s. XV	1400	1500	England		"olim Thomæ Raynes, postea Ricardi Gosmore, deinde Thomæ Browne et denique coll. Univ. ex dono Thomæ Walker, magistri." (Coxe)	33				
+		Jacobus, de Voragine, approximately 1229-1298	Sermons	Latin															
+		John Chrysostom, Saint, -407	De compunctione cordis	Latin															
+		John Chrysostom, Saint, -407	De reparatione lapsi	Latin															
+		John Chrysostom, Saint, -407	Quod nemo læditur nisi Seipso	Latin															
+		Grossteste, Robert, 1175?-1253	Liber de confessione	Latin															
+		Augustine, Saint, Bishop of Hippo	De vera et falsa pœnitentia	Latin															
+		Augustine, Saint, Bishop of Hippo	De septem peccatis mortalibus & De quinque sensibus	Latin															
+University College MS. 110		Duns Scotus, Johannes, 1265-1308	Quæstiones quodlibetales	Latin	codex	vellum	15th-century panelled calf, tooled, includes rabbit, agnus dei, dog and bird (restored)	Flourish initials. Written M.J. Goold (Coxe, f. 134).	s. XV	1400	1500	England		"olim Galfridi Burdon." (Coxe)	33				
+University College MS. 112		Petrus, Comestor, active 12th century	Historia Scholastica	Latin	codex	vellum	14th-century doeskin over wooden boards to text block, parallel raised bands.	Illuminated."Fine historiated and other initials. Good penwork initials." (IMOCL)	s. XIIIin.	1200	1250	France. 		"The will of Stephanus atte Roche, vicar of Fen Ditton, Cambs., 1381, formerly lining the upper cover of the binding, is now University College MS. 192, fol. 29." (IMOCL)		Cat. No. 655			
+University College MS. 113						vellum	Loose in cardboard.		s. XIII	1200	1300	England	Dominican convent, Beverley	England. Beverley Dominicans (Ker). "olim ecclesiæ S. Mariæ Rievallensis, ex dono, ut videtur, Johannis de Elyngton, postea C. Hyldyard." (Coxe)	34			List of contents in hand of Obadiah Walker.	
+		Peter Lombard, Bishop of Paris, approximately 1100-1160	Sentences	Latin															
+		Hugolinus de Urbe Veteri (c. 1380-c. 1457)	Distinctiones	Latin															
+University College MS. 114		Priscian	Institutiones grammaticæ	Latin		vellum	White leather over bevelled wooden boards.	Opening initial in magenta with red flowerheads and green cusped leaves.	s. XV	1400	1500	England			34				
+University College MS. 115			Old Testament (containing Pentateuch, Joshua, Judges, Ruth, Kings, Isaiah, fragments of Jeremiah, Prologues of St Jerome)	Latin	codex	vellum	Uncovered boards. "The first two quaternions of Deuteronomy may have been transposed in binding." (DHC)	"Fine and other initials (unfinished)." (IMOCL)	s. XII	1100	1200				34	Cat. No. 85			
+University College MS. 116						vellum	Uncovered board, rebacked. Foredge painting.	Puzzle initials, penwork borders, manicules and faces in the margins. "Fine penwork borders, initials. Marginal scribbes [sic.]." (IMOCL)	s. XIIIex.	1250	1300			"olim Willelmi Wharton, postea Johannis Thorgott." (Coxe) "List of sermon subjects for the use of an order of Preachers, p. 306. John Thorgott, saec. xvi, pp. 1, 396." (IMOCL)	34	Cat. No. 237			
+			Old Testament 	Latin															
+			New Testatment (with Prologues of St Jerome)	Latin															
+University College MS. 117		Augustine, Saint, Bishop of Hippo	Various works	Latin	codex	vellum	19th-century half morocco		s. XIIex. or XIIIin.	1150	1250	England. 		"olim liber eccl. S. Augustini Cantuar." (Coxe)	35				
+University College MS. 118					codex	vellum	16th-century panelled calf ruled and roll tooled in blind (rebacked and restored)			1100	1300	England. 		"olim Willelmi Parkhous, postea coll. Univ. ex dono Tho. Walker, magistri." (Coxe)	35				
+	1	Isidore, of Seville, Saint -636	Etymologiæ	Latin				Initials in blue and red or green and red, some foliate	s. XII										
+	2	Avicenna, 980-1037	Practica	Latin				Flourish initials in red and blue	s. XIII										
+University College MS. 119		Thomas, de Chobham, active 1200-1233	Summa pœnitentia	Latin		vellum	17th-century limp vellum		s. XIIIex.	1250	1300	England. 		"olim Thomæ de Billingham." (Coxe)	35				
+University College MS. 120					codex	vellum	Contemporary limp vellum.	Colour-washed drawings. "Good miniatures (mainly coloured drawings)." (IMOCL)		1200	1450	England.		 William Rogers' name and year 1669 written on f. 1r.	36	Cat. No. 267			
+	1		Bestiary	Latin					s. XIII										
+	2	Burley, Walter, 1275-1345	De universalibus	Latin					s. XVex.										
+University College MS. 122		William, of Pagula, approximately 1290-1332	Oculus sacerdotis (Part 1)	Latin		paper	Reused 13th-century leaf (stained)		s. XV	1400	1500	England.			36				
+University College MS. 123					codex	vellum	16th-century blind stamped calf, roll tooled vertically with standing woman dragon, hunter and deer		s. XV	1400	1500	England. 		"ex dono Gulielmi Rogers. (Coxe)	36		p. 120		
+		Bonaventure, Saint, Cardinal, approximately 1217-1274, pseudo	Speculum vitæ Christi, trans. Love, Nicholas, active 1410	Middle English (Buckinghamshire dialect)															
+			A shorte tretis of the heiest and moste worthi sacrament of Cristis body and the miraclis theroff	Middle English (Buckinghamshire dialect)															
+			Two devotional texts	Middle English (Buckinghamshire dialect)															
+University College MS. 124		Aquinas, Thomas, Saint, 1225-1274	Quodlibeta	Latin	codex	vellum	Medieval white leather over wooden boards (restored)	Flourish initials in blue and red with extravagant marginal extensions	s. XIIIin.	1200	1250	England	Fountains Abbey	 "anno 1580 peculium Ricardi Tomsoni; deinde 1596 Willelmi Wraye, et denique coll. Univ. ex dono Tho. Walker, magistri." (Coxe)	37				
+University College MS. 125		Melanchthon, Philipp, 1497-1560	Compendium interdecreti	Latin		paper	Vellum wrapper from 13th-century theological manuscript		s. XVI	1500	1600				37			Index in Italian added in 1549.	
+University College MS. 129		Balbi, Giovanni, -1298	Catholicon	Latin		vellum	Contemporary white leather over bevelled wooden boards (lacking clasps and pins).	"Fine border, initials, added to an Italian MS. with penwork initials, saec. xiii2. Mutilated." (IMOCL)	s. XIV	1300	1400	England	Winchester	"olim capellæ S. Elizabthæ juxta Winton. ex sono Joh. Pountoyse 'quondam ep. Winton.' postea Ricardi Neuport, et anno 1667 Gulielmi Shippen." (Coxe) "Given by John de Pontisarra (Pontoise), bp. of Winchester (d. 1304), to the Chapel of the Hospital of St. Elizabeth of Hungary, Winchester, fols. I, 378v. William Shippen, fellow, rector of Stockport, Cheshire (d. 1693), fol. i." (IMOCL)	37	Cat. No. 714			
+University College MS. 130			Old Testament (The Octateuch, Job, Kings, Ezekiel, Prologues of St Jerome)	Latin	codex	vellum	Contemporary tawed leather over boards with strap, pin and clasp.	"Fine historiated and other initials. Fine arabesque initials. Marginal sketches, fols. 1v, 124v." (IMOCL)	s. XII	1100	1200	England		 "Ex libris of St. Neot's priory, Hunts., fol 171v, saec. xic." (IMOCL)	38	Cat. No. 140			
+University College MS. 138		Cicero, Marcus Tullius	De amicitia	Latin		vellum	19th-century half morocco		s. XII or XIII	1100	1300	England	St Augustine's Abbey, Canterbury	Canterbury (St Augustine's), England "olim Gul. Rogers, ex hospit. Lincoln. 1669." (Coxe)	38				
+University College MS. 140				Greek	codex	paper	19th-century purple cloth	Diagrams.	s. XVI	1500	1600			Possibly given to Univ. by Mary Langbaine.	39				
+		Manuel Byrennius	On harmonies 																
+		Porphyry, approximately 234-approximately 305	Commentary on Ptolemy's Harmonies																
+		Ptolemy, active 2nd century	Harmonies (Book III) 																
+University College MS. 142				Middle English (South west Sussex dialect)	codex	vellum	Medieval wooden boards, stripped and rebacked with maroon morocco		s. XV	1400	1500	England		"olim Johannis Ramsey." (Coxe) Previously owned by Ricardus Rauf P L, John and William Weston de Ocham. Belonged to Gerald Langbaine. Possibly given to Univ. by Mary Langbaine.	39		p. 120-1		
+		Rolle, Richard, 1290?-1349 (Richard Hampole)	Pricke of conscience					Red initials. Written by Thomas Plenus-amoris.											
+			Printed treatise											Printed in London, 1530 (Coxe)					
+			"Of seuen maystyrs of art"																
+University College MS. 143		Peter Riga, approximately 1140-1209	Aurora	Latin	codex	vellum	19th-century calf (rubbed)		s. XIIIin.	1200	1250			Sudbury, England. Possibly given to Univ. by Mary Langbaine.	39				
+University College MS. 145			Statutes of the Hospital at Ewelme	English		vellum	19th-century purple cloth		s. XVI	1500	1600	England.		 "Made by William de la Poole. Possibly given to Univ. by Mary Langbaine.	39				
+University College MS. 148				Latin		vellum	Modern vellum		ss. XII to XIV	1100	1400	England.	Chichester.	 "olim Gerardi Langbaine, [coll. Reg. præposto filii] postea coll. Univ. ex dono Mariæ Langbaine viduæ, in gratiam mariti sui Gerardi muper defuncti, olim per multos annos hujus colegii superioris ordinis commensalis; anno Domini 1692." (Coxe)	40				
+			Charters, rules, and liturgical texts relating to Chichester																
+			Cartulary and rule St Mary's Hospital, Chichester 											Signed by John Cutchere, dean of Chichester, and dated 1447.					
+University College MS. 154			Chronicle of England (Brut Chronicle)	Middle English		vellum	Late 15th-century panelled brown leather (worn)	Border and initial on opening folio, flourish initials throughout.	s. XV	1400	1500	England. 		"olim, ut videtur, Willelmi Manyngham, Christophori Purpilli, W. Bendloues, et Willelmi Bere." (Coxe) "Christopher Purpillus, 1604, pp. i, 241. Possibly given to Univ. by Mary Langbaine, widow of Gerard Langbaine (d. 1692)." (IMOCL)	42	Cat. No. 551	p. 121		
+University College MS. 156		Netter, Thomas, approximately 1375-1430	De sacramentalibus	Latin		paper	19th-century calf. Almost certainly a Beckford binding. Printed waste endleaves from Bacon's Nova Atlantis.		s. XVex.	1475	1500	England.	Lincoln.	Copied out by John Rusell, bishop of Lincoln, in 1491-2. Probably given to Univ. by Mary Langbaine.	43				
+University College MS. 158			Relationes casuum legalium	French and Latin	codex	vellum and paper	Speckled calf by Beckford		s. XVIex.	1550	1600	England. 		Probably given to Univ. by Mary Langbaine.	43				
+University College MS. 165				Latin	codex	vellum	Durham, c. 1120.	One miniature in full colour, colour washed drawings, historiated and decorated initials.	s. XII	1100	1200	England	Durham.	 "olim M. Lelonde, Joh. Theyer de Cowpers Hill juxta Glouc., Fulconis Wallwyn, ex dono Danielis Bacheler, Willelmi et Thomæ Leigh, et denique coll. Univ. ex dono Gul. Rogers." (Coxe) Southwick (Ker)	45	Cat. No. 17.			
+		Bede, the Venerable, Saint, 673-735	Vita et miracula S. Cuthberti																
+			Prayer to St Cuthbert																
+University College MS. 166			Rental of Salisbury Cathedral	Latin	codex	vellum			s. XIV	1300	1400	England			45				
+University College MS. 167			Fountains Abbey, Cartulary, with Cistercian privileges to 1490	Latin	codex	vellum	White leather over boards, chemise lacking pins and most of straps with clasps.		s. XVex.	1450	1500	England	Fountains Abbey		45				
+University College MS. 168				Latin	codex	vellum	Contemporary binding of white leather over bevelled wooden boards flush to page edge, strap trimmed from upper board. 	"Good historiated initial. Fine borders in an unusual style, fine and other initials. Fine penwork initials. Marginal drawings (catchwords), later pencil sketches, saec. xvi." (IMOCL)	s. XV	1400	1500	England.			46	Cat. No. 419			
+			Collection of commentaries on Song of Songs; 																
+		Bede, the Venerable, Saint, 673-735	Commentaries (Song of Songs, the Gospels of Mark and Luke)																
+University College MS. 169			Barking Abbey, Ordinale	Latin & Middle English 	codex	vellum	"New Bound. 1731." (note on inside upper board) 1731 panelled reversed calf, lacking clasps	Illuminated initials, penwork initials with faces. "Fine borders, initials. Fine penwork initials." (IMOCL)	s. XVin.	1400	1450	England	Barking Abbey	Note of f. 6v: "Memorandum quod anno domini millesimo quadragintesimo quarto domina Sibilla . . . Abbatissa de Berkyng hunc librum ad usum Abbatissarum in dicta domo . . . concessit." "Commissioned and given to Barking abbey in 1404 by Sibilla de Felton, abbess 1394-1419, p. 2. Obits of Barking abbesses, fols. i-v, saec. xv. Obadiah Walker, master 1676-89. Sold at the sale of John Humphrey of Rothwell, 4 Dec., 1682, lot 20." (IMOCL) 	47	Cat. No. 387	p. 121		
+University College MS. 170			Fountains Abbey, Cartulary	Latin		vellum	19th-century reversed calf		s. XII or XIII	1100	1300	England. 		"ex dono Hugonis Todd socii, 1696." (DHC)	47				
+University College MS. 172		Gregory, X, Pope, -1276	Constitutions of the Second Council of Lyon 1274	Latin		vellum	19th-century cloth		s. XIV	1300	1400	England. 		"olim Gul. Rogers, 1669." (Coxe)	47				
+University College MS. 177 A-B		Higden, Ranulf, -1364	Polychronicon (with prologue)		codex	vellum	Contemporary white leather chemise over straight-edge wooden boards. Bookmarker in Vol. I	Puzzle initials with grotesques in the margins. "Fine penwork borders, initials." (IMOCL)	s. XIVex.	1350	1400	England. 		"olim Thomæ Sparchi ex dono Matthæi Piggotti." (Coxe) "Evidence for Barnwell priory, Cambridgeshire, from obits in the margin." (IMOCL)	48	Cat. No. 342			
+University College MS. 178			Missal (fragments)	Latin		vellum	19th-century hogskin.	Initials and borders.	s. XIVex.	1350	1400	England. 		"University College chapel. Obits in the calendar: magister Walker Skirlaw, bp. of Durham, 1406; Henry Percy, 1455. Note on the dedication of the Chapel to St. Cuthbert, 1476." (IMOCL)	48	Cat. No. 349			
+University College MS. 179			Devotional book, including: Prayers, Hours of the Blessed Virgin Mary, Placebo, Seven Penitential Psalms, Litany	Latin & Middle English	codex	vellum	18th-century limp vellum.		s. XV	1400	1500	England.		 Given by Francis Rockley (DHC).	49		pp. 121-4; 132-5		
+University College MS. 180						vellum	19th-century cloth		ss. XII or s. XIII	1100	1300	England. 		"olim Thomæ Ailesbury, clerici." (Coxe)					
+			Gospels	Latin															
+			Glossing on Song of Songs	Latin															
+			Sermon on Lucerna pedibus meis (Psalm 119.105)	Latin															
+			Book of Job, glossed (fragment)	Latin															
+			Catalogue, of works by Anselm and Augustine	Latin															
+University College MS. 181					codex	vellum	Original leather over bevelled boards sewn into white leather chemise, lined with blue and white striped cloth, metal bosses on upper and lower covers (lacking clasps and pins). 	"Fine borders, fine and other initials. Miniatures pasted in and removed." (IMOCL)	s. XVin.	1400	1450	England. 		"olim, anno scilicet 1491, Henrici Percei de N. postea, anno 1577, Roberti Hedrington." (Coxe) "Given in 1490 to dominus Henry Percy, prior of Newnham, Bedfordshire, by his predecessor, Johannis Renhall, fol. 40v. Robert Hendrington, 1577, fol. 1." (IMOCL)		Cat. No. 560	p. 124		
+		Guillaume, de Déguileville, 1295-1360	The pilgrimage of the soul	Middle English															
+		Hoccleve, Thomas, 1370?-1450?	Compleynte paramont	Middle English															
+University College MS. 188			Romance of Parthenopex (lacking at beginning and end)	Middle English	codex	vellum	19th-century morocco	Some bastard secretary script.	s. XIVex.	1375	1450	England.			51				
+University College MS. 190		Petrus, Comestor, active 12th century	Historia scholastica	Latin	codex	vellum	19th-century half morocco	Diagram of the Temple.	s. XIIex./s. XIII	1175	1250	England.		 “Belonged to the Dominicans of Beverley in s. xv, if not in s. xiii: ‘Fratrium predicatorum’ at the head of f. 1 and ‘fratris Roberti de Eston’ at the foot, both probably in the same hand, s. xiii; ‘Conuentus Beuerlaci’ f. 137, s. xv, ‘C. Hyldyard’ MS 113, f. 169, s. xvi, may have been written before or after the last four leaves of art. 2 were transferred to MS. 113: the same name is on MS. 113, f. 1.  Both manuscripts were the gift of Obadiah Walker, master 1676-9.” (Ker)					
+University College MS. 191		Gregory, I, Pope, approximately 540-604	Homilies	Latin	codex	vellum	Half-morocco over medieval boards (lacking clasps and catches)	Large green and red initials with foliate patterns, one blue initial with red pattern.	s. XII	1100	1200	England. 		Cistercian. "[Liber] sancta M[arie] d[e….] anathema sit." (f. 4v)					
+University College MS. 192			Fragments, removed from bindings of other manuscripts. 		guardbook	vellum	19th-century cloth	Colour initials.	ss. XII - XV	1100	1500	England. 		Possibly copied for choirbook of King Henry VI.		Cat. No. 655			
+			Antiphonary	Latin															
+			Gradual	Latin															
+			Will of Simon de Bredon	Latin															
+			Will of Stephanus atte Roche	Latin															
+			Musical fragments from a royal choirbook including Credo by Thomas Damett	Latin															
+University College MS. 208			Fragments, removed from the bindings of University College MS. 41						s. XIII - XIV	1200	1400								


### PR DESCRIPTION
This branch contains the result of converting the spreadsheet that Philip Burnett produced last year into TEI records.

Matching authors and places-of-origin to authority entries has been somewhat successful. Matching titles to works authorities is trickier, so to be on the safe side I've added "Possible work keys" in comments after the title elements.

There is a "Notes" column which I've mapped to `accMat` elements in the TEI, because that seems most appropriate in most cases, but maybe not all.

I've assumed IMOCL stands for _Illuminated manuscripts in Oxford college libraries_, but I don't know what IMEP is, so I've just added those as "IMEP" then the page number.

There's one University College manuscript in Digital Bodleian, so that is the only one with surrogates.

If you spot anything that needs changing across all records, or if you want to suggest a value for `availability/@status`,  I can regenerate the records, as long as no manual changes have been made to the files.