### PR TITLE
MS. Laud Misc. 133: new description

### DIFF
--- a/collections/Laud_Misc/MS_Laud_Misc_133.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_133.xml
@@ -49,9 +49,6 @@
                         <collation>1–3<hi rend="superscript">8</hi> (fols. 1–24), 4<hi rend="superscript">10</hi> (fols. 25–34), 5–10<hi rend="superscript">8</hi> (fols. 35–82), 11<hi rend="superscript">8–1</hi> (8th cancelled; fols. 83–89) | 12–17<hi rend="superscript">8</hi> (fols. 90–137), 18<hi rend="superscript">6</hi> (fols. 138–143) | 19<hi rend="superscript">4+1</hi> (1st added; fols. 144–148), 20<hi rend="superscript">10–1</hi> (1st cancelled). <signatures>Quires 1–3 signed ‘Q ·i·’–‘·iii·’; 5–9 signed v–viiij; 16–17 signed v–vi.</signatures></collation>
                      </supportDesc>
                   </objectDesc>
-                  <handDesc>
-                     <handNote script="minusculeCaroline">Carolingian minuscule, described in detail by Bischoff, <title>Lorsch im Spiegel seiner Handschriften</title> (Munich, 1974), pp. 110–113.</handNote>
-                  </handDesc>
                   <bindingDesc>
                      <binding when="1638">
                         <p>Standard Laudian binding; brown tanned calf over laminated pulpboard. Cloth ties excised.</p>
@@ -59,15 +56,15 @@
                   </bindingDesc>
                </physDesc>
                <history>
-                  <origin><orgName key="org_143763943">Lorsch Abbey</orgName>; written there according to Bischoff (<q>Jüngerer Lorscher Stil</q>). Certainly there during the Cistercian interlude, 1232/34-ca. 1245: Becker, <title>Catalogi bibliothecarum antiqui</title> (Bonn, 1885), no. 37, pp. 182, 122–131.</origin>
-                  <provenance><orgName key="org_133214228">Cistercian Abbey of the Virgin Mary, Eberbach</orgName>. The 1470s <title>Rheinischen Gesamtkatalog</title> lists the book under the signature <q>Erb’ Ma. O 2</q> (Palmer, <title>Zisterzienser und ihre Bücher</title>, p. 228). Inscription, <q>Liber sancte Marie virginis in Ebirbach</q>, 15th century (cf. MS. Laud. misc. 107, fol. 1v). Listed in the Eberbach catalog of 1502 under the signature G 15: <q>G 15 Quedam epistoli beati augustini Item epistoli eiusdem super psalmos Initium <q>Domino sancto iuremerito ac venerabili</q></q> (Palmer, p. 239).</provenance>
+                  <origin><orgName key="org_143763943">Lorsch Abbey</orgName>; written there, according to Bischoff (<q>Jüngerer Lorscher Stil</q>). Certainly there during the Cistercian interlude, 1232/34-ca. 1245 (see Palmer, <title>Zisterzienser und ihre Bücher</title>).</origin>
+                  <provenance><orgName key="org_133214228">Cistercian Abbey of the Virgin Mary, Eberbach</orgName>. Although all three parts of the manuscript were written at Lorsch, the evidence of catalogues suggests that they were bound together at Eberbach. The 1470s <title>Rheinischen Gesamtkatalog</title> lists the book under the signature <q>Erb’ Ma. O 2</q> (Palmer, <title>Zisterzienser und ihre Bücher</title>, p. 228). Inscription, <q>Liber sancte Marie virginis in Ebirbach</q>, 15th century (cf. <ref target="https://medieval.bodleian.ox.ac.uk/catalog/manuscript_6916">MS. Laud. Misc. 107</ref>, fol. 1v). Listed in the Eberbach catalog of 1502 under the signature G 15: <q>G 15 Quedam epistoli beati augustini Item epistoli eiusdem super psalmos Initium <q>Domino sancto iuremerito ac venerabili</q></q> (Palmer, p. 239).</provenance>
                   <provenance notBefore="1631"><persName key="person_54940373">Willam Laud (1573–1645)</persName> acquired many German manuscripts plundered during the Thirty Years’ War. Inscribed, <q>Liber Guil.mi Laude archiepi. Cant. et Cancellarii vniuersit. Oxon. 1636</q> (fol. 1r).</provenance>
-                  <acquisition>Donated to the Bodleian Library as part of Laud’s third donation, 28 June 1639. Previous shelfmarks, <q>L.25</q> (on fol. ii verso) and <q>C.97 Laud.</q> (on the back).</acquisition>
+                  <acquisition>Donated to the Bodleian Library as part of Laud’s third donation, 28 June 1639. Previous shelfmarks, <q>L.25</q> (on fol. ii verso) and <q>C.97 Laud.</q> (upper flyleaf).</acquisition>
                </history>
                <additional>
                   <adminInfo>
                      <recordHist>
-                        <source><ref target="https://medieval.bodleian.ox.ac.uk/about">Summary description</ref> abbreviated from the Quarto Catalogue (H. O. Coxe, <title>Laudian Manuscripts</title>, Quarto Catalogues II, repr. with corrections, 1969, from the original ed. of 1858–1885). Decoration, localization and date [part 1] follow Pächt and Alexander (1973). <listBibl>
+                        <source>Description adapted and revised by Andrew Dunning (May 2022) from Michael Kautz, Bibliotheca Laureshamensis (2014). Previously described in the Quarto Catalogue (H. O. Coxe, <title>Laudian Manuscripts</title>, Quarto Catalogues II, repr. with corrections, 1969, from the original ed. of 1858–1885). Decoration, localization and date [part 1] follow Pächt and Alexander (1973). <listBibl>
                               <bibl facs="aby0114.gif" type="QUARTO">Quarto Catalogue, col. 132</bibl>
                               <bibl facs="aby0115.gif" type="QUARTO">Quarto Catalogue, cols. 133–4</bibl>
                               <bibl facs="aap0087.gif" type="SC">Summary Catalogue, vol. 2, part 1, p. 66</bibl>
@@ -173,15 +170,18 @@
                            </layout>
                         </layoutDesc>
                      </objectDesc>
+                     <handDesc>
+                        <handNote script="minusculeCaroline">Carolingian minuscule, described by Bischoff, <title>Lorsch im Spiegel seiner Handschriften</title> (Munich, 1974).</handNote>
+                     </handDesc>
                      <decoDesc>
-                        <decoNote>Border (marginal sketch, fol. 143v), added in the 12th century, first half. (<ref target="https://catalog.hathitrust.org/Record/000468709">Pächt and Alexander</ref> iii. 1301)</decoNote>
+                        <decoNote type="initial">Plain initials.</decoNote>
                      </decoDesc>
                   </physDesc>
                   <history>
                      <origin>
                         <origDate calendar="Gregorian" notAfter="1150" notBefore="0800">9th century, first half</origDate>; <origDate calendar="Gregorian" notAfter="1150" notBefore="1100" type="additions">added decoration, 12th century, first half</origDate>
                         <origPlace>
-                           <country key="place_7000084">German</country>
+                           <orgName key="org_143763943">Lorsch Abbey</orgName>
                         </origPlace>
                      </origin>
                   </history>
@@ -246,18 +246,25 @@
                         </supportDesc>
                         <layoutDesc>
                            <layout columns="1" writtenLines="29 31">Ruled in drypoint, 29–31 long lines, ruled space <dimensions type="ruled" unit="mm">
-                              <height>230</height>
-                              <width>175</width>
-                           </dimensions>
+                                 <height>230</height>
+                                 <width>175</width>
+                              </dimensions>
                            </layout>
                         </layoutDesc>
                      </objectDesc>
+                     <handDesc>
+                        <handNote script="minusculeCaroline">Carolingian minuscule, described by Bischoff, <title>Lorsch im Spiegel seiner Handschriften</title> (Munich, 1974).</handNote>
+                     </handDesc>
+                     <decoDesc>
+                        <decoNote type="border">Border (marginal sketch, fol. 143v), added in the 12th century, first half. (<ref target="https://catalog.hathitrust.org/Record/000468709">Pächt and Alexander</ref> iii. 1301)</decoNote>
+                        <decoNote type="initial">Plain initials.</decoNote>
+                     </decoDesc>
                   </physDesc>
                   <history>
                      <origin>
                         <origDate calendar="Gregorian" notAfter="0850" notBefore="0800">9th century, first half</origDate>
                         <origPlace>
-                           <country key="place_7000084">German</country>
+                           <orgName key="org_143763943">Lorsch Abbey</orgName>
                         </origPlace>
                      </origin>
                   </history>
@@ -305,18 +312,21 @@
                         </supportDesc>
                         <layoutDesc>
                            <layout columns="2" writtenLines="34">Ruled in drypoint, 2 columns of 34 lines, ruled space <dimensions type="ruled" unit="mm">
-                              <height>220</height>
-                              <width>170</width>
-                           </dimensions>
+                                 <height>220</height>
+                                 <width>170</width>
+                              </dimensions>
                            </layout>
                         </layoutDesc>
                      </objectDesc>
+                     <handDesc>
+                        <handNote script="minusculeCaroline">Carolingian minuscule, described by Bischoff, <title>Lorsch im Spiegel seiner Handschriften</title> (Munich, 1974).</handNote>
+                     </handDesc>
                   </physDesc>
                   <history>
                      <origin>
                         <origDate calendar="Gregorian" notAfter="0893" notBefore="0891">891–893</origDate>
                         <origPlace>
-                           <country key="place_7000084">German</country>
+                           <orgName key="org_143763943">Lorsch Abbey</orgName>
                         </origPlace>
                      </origin>
                   </history>

--- a/collections/Laud_Misc/MS_Laud_Misc_133.xml
+++ b/collections/Laud_Misc/MS_Laud_Misc_133.xml
@@ -8,9 +8,8 @@
             <title>MS. Laud Misc. 133</title>
             <title type="collection">MSS. Laud Misc. (Laud miscellaneous)</title>
             <respStmt>
-               <resp>Summary description</resp>
-               <persName>Elizabeth Solopova</persName>
-               <persName>Matthew Holford</persName>
+               <resp>Description</resp>
+               <persName>Andrew Dunning</persName>
             </respStmt>
          </titleStmt>
          <publicationStmt>
@@ -38,8 +37,33 @@
                   </altIdentifier>
                </msIdentifier>
                <physDesc>
-                  <p n="composite">Composite: A || B || C</p>
+                  <objectDesc form="codex">
+                     <supportDesc material="perg">
+                        <support>parchment</support>
+                        <extent>i (early modern parchment) + 157 + i (early modern parchment) + i (early modern paper) leaves <dimensions type="leaf" unit="mm">
+                              <height>315</height>
+                              <width>245</width>
+                           </dimensions>
+                        </extent>
+                        <foliation>Modern foliation.</foliation>
+                        <collation>1–3<hi rend="superscript">8</hi> (fols. 1–24), 4<hi rend="superscript">10</hi> (fols. 25–34), 5–10<hi rend="superscript">8</hi> (fols. 35–82), 11<hi rend="superscript">8–1</hi> (8th cancelled; fols. 83–89) | 12–17<hi rend="superscript">8</hi> (fols. 90–137), 18<hi rend="superscript">6</hi> (fols. 138–143) | 19<hi rend="superscript">4+1</hi> (1st added; fols. 144–148), 20<hi rend="superscript">10–1</hi> (1st cancelled). <signatures>Quires 1–3 signed ‘Q ·i·’–‘·iii·’; 5–9 signed v–viiij; 16–17 signed v–vi.</signatures></collation>
+                     </supportDesc>
+                  </objectDesc>
+                  <handDesc>
+                     <handNote script="minusculeCaroline">Carolingian minuscule, described in detail by Bischoff, <title>Lorsch im Spiegel seiner Handschriften</title> (Munich, 1974), pp. 110–113.</handNote>
+                  </handDesc>
+                  <bindingDesc>
+                     <binding when="1638">
+                        <p>Standard Laudian binding; brown tanned calf over laminated pulpboard. Cloth ties excised.</p>
+                     </binding>
+                  </bindingDesc>
                </physDesc>
+               <history>
+                  <origin><orgName key="org_143763943">Lorsch Abbey</orgName>; written there according to Bischoff (<q>Jüngerer Lorscher Stil</q>). Certainly there during the Cistercian interlude, 1232/34-ca. 1245: Becker, <title>Catalogi bibliothecarum antiqui</title> (Bonn, 1885), no. 37, pp. 182, 122–131.</origin>
+                  <provenance><orgName key="org_133214228">Cistercian Abbey of the Virgin Mary, Eberbach</orgName>. The 1470s <title>Rheinischen Gesamtkatalog</title> lists the book under the signature <q>Erb’ Ma. O 2</q> (Palmer, <title>Zisterzienser und ihre Bücher</title>, p. 228). Inscription, <q>Liber sancte Marie virginis in Ebirbach</q>, 15th century (cf. MS. Laud. misc. 107, fol. 1v). Listed in the Eberbach catalog of 1502 under the signature G 15: <q>G 15 Quedam epistoli beati augustini Item epistoli eiusdem super psalmos Initium <q>Domino sancto iuremerito ac venerabili</q></q> (Palmer, p. 239).</provenance>
+                  <provenance notBefore="1631"><persName key="person_54940373">Willam Laud (1573–1645)</persName> acquired many German manuscripts plundered during the Thirty Years’ War. Inscribed, <q>Liber Guil.mi Laude archiepi. Cant. et Cancellarii vniuersit. Oxon. 1636</q> (fol. 1r).</provenance>
+                  <acquisition>Donated to the Bodleian Library as part of Laud’s third donation, 28 June 1639. Previous shelfmarks, <q>L.25</q> (on fol. ii verso) and <q>C.97 Laud.</q> (on the back).</acquisition>
+               </history>
                <additional>
                   <adminInfo>
                      <recordHist>
@@ -57,47 +81,83 @@
                <msPart xml:id="MS_Laud_Misc_133-part1">
                   <msIdentifier>
                      <altIdentifier type="partial">
-                        <idno type="part">MS. Laud Misc. 133 – Part 1</idno>
+                        <idno type="part">MS. Laud Misc. 133, fols. 1–89</idno>
                      </altIdentifier>
                   </msIdentifier>
                   <msContents>
-                     <msItem n="1" xml:id="MS_Laud_Misc_133-part1-item1">
+                     <textLang mainLang="la">Latin</textLang>
+                     <msItem>
                         <author key="person_66806872">Augustine</author>
                         <title key="work_801">Letters</title>
-                        <note>(epp. 156, 157, 186, 170, 194, 214)</note>
-                        <textLang mainLang="la">Latin</textLang>
+                        <msItem>
+                           <locus>(fol. 1r)</locus>
+                           <bibl>ep. 156</bibl>
+                        </msItem>
+                        <msItem>
+                           <locus>(fols. 1r–12r)</locus>
+                           <bibl>ep. 157</bibl>
+                        </msItem>
+                        <msItem>
+                           <locus>(fols. 12r–22r)</locus>
+                           <bibl>ep. 186</bibl>
+                        </msItem>
                      </msItem>
-                     <msItem n="2" xml:id="MS_Laud_Misc_133-part1-item2">
+                     <msItem>
+                        <locus>(fols. 22r–33r)</locus>
                         <author key="person_66806872">Augustine</author>
                         <title key="work_740">Contra duas epistulas Pelagianorum</title>
-                        <note>(bk. i)</note>
-                        <textLang mainLang="la">Latin</textLang>
+                        <bibl>book 1</bibl>
                      </msItem>
-                     <msItem n="3" xml:id="MS_Laud_Misc_133-part1-item3">
+                     <msItem>
                         <author key="person_66806872">Augustine</author>
-                        <title key="work_766">De gratio et libero arbitrio</title>
-                        <textLang mainLang="la">Latin</textLang>
+                        <title key="work_801">Letters</title>
+                        <msItem>
+                           <locus>(fols. 33r–34v)</locus>
+                           <bibl>ep. 170</bibl>
+                        </msItem>
+                        <msItem>
+                           <locus>(fol. 35r–v)</locus>
+                           <bibl>ep. 191</bibl>
+                        </msItem>
+                        <msItem>
+                           <locus>(fols. 35v–47r)</locus>
+                           <bibl>ep. 194</bibl>
+                        </msItem>
+                        <msItem>
+                           <locus>(fols. 47r–48v)</locus>
+                           <bibl>ep. 214</bibl>
+                        </msItem>
                      </msItem>
-                     <msItem n="4" xml:id="MS_Laud_Misc_133-part1-item4">
+                     <msItem>
+                        <locus>(fols. 48vb–67ra)</locus>
+                        <author key="person_66806872">Augustine</author>
+                        <title key="work_766">De gratia et libero arbitrio</title>
+                     </msItem>
+                     <msItem>
+                        <locus>(fols. 67r–83v)</locus>
                         <author key="person_66806872">Augustine</author>
                         <title key="work_757">De correptione et gratia</title>
-                        <textLang mainLang="la">Latin</textLang>
                      </msItem>
-                     <msItem n="5" xml:id="MS_Laud_Misc_133-part1-item5">
-                        <author key="person_199159880"><!-- check: and/or 231793925 -->Evodius Uzalitanus</author>
-                        <title key="work_1520">Letter</title>
-                        <textLang mainLang="la">Latin</textLang>
+                     <msItem>
+                        <locus>(fols. 83v–85r)</locus>
+                        <author key="person_199159880">Evodius Uzalitanus</author>
+                        <title key="work_1520">Epistula ad Valentinum abb. Hadrumetinum</title>
                      </msItem>
-                     <msItem n="6" xml:id="MS_Laud_Misc_133-part1-item6">
+                     <msItem>
+                        <locus>(fols. 85r–v)</locus>
                         <author key="person_170225">Celestine I</author>
-                        <title key="work_1220">Letter</title>
-                        <note>(ep. 21)</note>
-                        <textLang mainLang="la">Latin</textLang>
+                        <title key="work_1220">Epistula ad episcopos Galliarum</title>
+                        <bibl>ep. 21</bibl>
                      </msItem>
-                     <msItem n="7" xml:id="MS_Laud_Misc_133-part1-item7">
+                     <msItem>
+                        <locus>(fols. 85v–88r)</locus>
+                        <author key="person_52485706">Prosper of Aquitaine</author>
+                        <title key="work_17509">Praeteritorum sedis apostolicae episcoporum auctoritates de gratia Dei</title>
+                     </msItem>
+                     <msItem>
+                        <locus>(fols. 88r–89r)</locus>
                         <author key="person_7386286">Ps.-Augustine</author>
-                        <title key="work_3873">Commonitorium quomodo sit agendum cum manichaeis</title>
-                        <textLang mainLang="la">Latin</textLang>
+                        <title key="work_3873">Commonitorium quomodo sit agendum cum Manichaeis qui confitentur</title>
                      </msItem>
                   </msContents>
                   <physDesc>
@@ -105,6 +165,13 @@
                         <supportDesc material="perg">
                            <support>parchment</support>
                         </supportDesc>
+                        <layoutDesc>
+                           <layout columns="2" writtenLines="29">Ruled in drypoint, two columns of 29 lines, ruled space <dimensions type="ruled" unit="mm">
+                                 <height>220</height>
+                                 <width>170</width>
+                              </dimensions>
+                           </layout>
+                        </layoutDesc>
                      </objectDesc>
                      <decoDesc>
                         <decoNote>Border (marginal sketch, fol. 143v), added in the 12th century, first half. (<ref target="https://catalog.hathitrust.org/Record/000468709">Pächt and Alexander</ref> iii. 1301)</decoNote>
@@ -122,15 +189,54 @@
                <msPart xml:id="MS_Laud_Misc_133-part2">
                   <msIdentifier>
                      <altIdentifier type="partial">
-                        <idno type="part">MS. Laud Misc. 133 – Part 2</idno>
+                        <idno type="part">MS. Laud Misc. 133, fols. 90–143</idno>
                      </altIdentifier>
                   </msIdentifier>
                   <msContents>
-                     <msItem n="1" xml:id="MS_Laud_Misc_133-part2-item1">
+                     <textLang mainLang="la">Latin</textLang>
+                     <msItem>
                         <author key="person_66806872">Augustine</author>
                         <title key="work_790">Enarrationes in Psalmos</title>
-                        <note>(Ps. xci-c)</note>
-                        <textLang mainLang="la">Latin</textLang>
+                        <msItem>
+                           <locus>(fols. 90r–94v)</locus>
+                           <bibl>in Ps 91</bibl>
+                        </msItem>
+                        <msItem>
+                           <locus>(fols. 94v–98v)</locus>
+                           <bibl>in Ps 92</bibl>
+                        </msItem>
+                        <msItem>
+                           <locus>(fols. 98v–111r)</locus>
+                           <bibl>in Ps 93</bibl>
+                        </msItem>
+                        <msItem>
+                           <locus>(fols. 111r–115v)</locus>
+                           <bibl>in Ps 94</bibl>
+                        </msItem>
+                        <msItem>
+                           <locus>(fols. 115v–120r)</locus>
+                           <bibl>in Ps 95</bibl>
+                        </msItem>
+                        <msItem>
+                           <locus>(fols. 120r–126v)</locus>
+                           <bibl>in Ps 96</bibl>
+                        </msItem>
+                        <msItem>
+                           <locus>(fols. 126v–128v)</locus>
+                           <bibl>in Ps 97</bibl>
+                        </msItem>
+                        <msItem>
+                           <locus>(fols. 128v–134r)</locus>
+                           <bibl>in Ps 98</bibl>
+                        </msItem>
+                        <msItem>
+                           <locus>(fols. 134r–138v)</locus>
+                           <bibl>in Ps 99</bibl>
+                        </msItem>
+                        <msItem>
+                           <locus>(fols. 138v–143v)</locus>
+                           <bibl>in Ps 100</bibl>
+                        </msItem>
                      </msItem>
                   </msContents>
                   <physDesc>
@@ -138,6 +244,13 @@
                         <supportDesc material="perg">
                            <support>parchment</support>
                         </supportDesc>
+                        <layoutDesc>
+                           <layout columns="1" writtenLines="29 31">Ruled in drypoint, 29–31 long lines, ruled space <dimensions type="ruled" unit="mm">
+                              <height>230</height>
+                              <width>175</width>
+                           </dimensions>
+                           </layout>
+                        </layoutDesc>
                      </objectDesc>
                   </physDesc>
                   <history>
@@ -152,20 +265,37 @@
                <msPart xml:id="MS_Laud_Misc_133-part3">
                   <msIdentifier>
                      <altIdentifier type="partial">
-                        <idno type="part">MS. Laud Misc. 133 – Part 3</idno>
+                        <idno type="part">MS. Laud Misc. 133, fols. 144–157</idno>
                      </altIdentifier>
                   </msIdentifier>
                   <msContents>
-                     <msItem n="1" xml:id="MS_Laud_Misc_133-part3-item1">
+                     <textLang mainLang="la">Latin</textLang>
+                     <msItem>
+                        <locus>(fols. 145r–156r)</locus>
                         <author key="person_66806872">Augustine</author>
                         <title key="work_812">Sermo de pastoribus</title>
-                        <textLang mainLang="la">Latin</textLang>
+                        <bibl>serm. 46</bibl>
                      </msItem>
-                     <msItem n="2" xml:id="MS_Laud_Misc_133-part3-item2">
+                     <msItem>
+                        <locus>(fols. 156r–157v)</locus>
                         <author key="person_66806872">Augustine</author>
                         <title key="work_801">Letters</title>
-                        <note>(epp. 18, 20, 19, 1)</note>
-                        <textLang mainLang="la">Latin</textLang>
+                        <msItem>
+                           <locus>(fol. 156r–v)</locus>
+                           <bibl>ep. 18</bibl>
+                        </msItem>
+                        <msItem>
+                           <locus>(fols. 156v–157r)</locus>
+                           <bibl>ep. 20</bibl>
+                        </msItem>
+                        <msItem>
+                           <locus>(fol. 157r–v)</locus>
+                           <bibl>ep. 19</bibl>
+                        </msItem>
+                        <msItem>
+                           <locus>(fol. 157v)</locus>
+                           <bibl>ep. 1.1–3</bibl>
+                        </msItem>
                      </msItem>
                   </msContents>
                   <physDesc>
@@ -173,6 +303,13 @@
                         <supportDesc material="perg">
                            <support>parchment</support>
                         </supportDesc>
+                        <layoutDesc>
+                           <layout columns="2" writtenLines="34">Ruled in drypoint, 2 columns of 34 lines, ruled space <dimensions type="ruled" unit="mm">
+                              <height>220</height>
+                              <width>170</width>
+                           </dimensions>
+                           </layout>
+                        </layoutDesc>
                      </objectDesc>
                   </physDesc>
                   <history>
@@ -188,6 +325,7 @@
          </sourceDesc>
       </fileDesc>
       <revisionDesc>
+         <change when="2022-05-24"><persName>Andrew Dunning</persName> Revised with consultation of original.</change>
          <change when="2017-07-01">First online publication.</change>
          <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
       </revisionDesc>


### PR DESCRIPTION
Additional details are still available from <https://bibliotheca-laureshamensis-digital.de/view/bodleian_mslaudmisc133> and Bischoff, but I have kept to a summary; let me know if you think it needs more detail.