### PR TITLE
Add dclp refs

### DIFF
--- a/collections/Gr_bib/MS_Gr_bib_c_2_P.xml
+++ b/collections/Gr_bib/MS_Gr_bib_c_2_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_4945" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_4945">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -55,7 +55,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/62331"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/62331">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/62331">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -123,7 +132,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_bib/MS_Gr_bib_d_3_P.xml
+++ b/collections/Gr_bib/MS_Gr_bib_d_3_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_4948" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_4948">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -60,7 +60,7 @@
                      <recordHist>
                         <source>Summary description abbreviated from R. P. Salomons, <title>Papyri Bodleianae</title> (1996). Previously described in the Summary Catalogue. <listBibl>
                               <bibl facs="abj0051.gif" type="SC">Summary Catalogue, vol. 6, p. 13</bibl>
-                           <bibl facs="abj0013.gif" type="SC">Summary Catalogue, Vol. 6, p. xi [corrigenda]</bibl>
+                              <bibl facs="abj0013.gif" type="SC">Summary Catalogue, Vol. 6, p. xi [corrigenda]</bibl>
                            </listBibl>
                         </source>
                      </recordHist>
@@ -69,11 +69,25 @@
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
                         <bibl>
+                           <ref target="https://papyri.info/dclp/62267">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
                            <ref target="http://pinakes.irht.cnrs.fr/notices/cote/74580/">
                               <title>Pinakes | Πίνακες: Textes et manuscrits grecs</title>
-                           </ref></bibl>
-                        <bibl><ref target="http://www.trismegistos.org/text/62267"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
-                        <bibl><ref target="http://www.trismegistos.org/text/92036"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/62267">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/92036">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -143,7 +157,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_bib/MS_Gr_bib_d_5_P.xml
+++ b/collections/Gr_bib/MS_Gr_bib_d_5_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_4950" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_4950">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -82,7 +82,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/61937"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/61937">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/61937">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -91,7 +100,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_bib/MS_Gr_bib_d_6_P.xml
+++ b/collections/Gr_bib/MS_Gr_bib_d_6_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_4951" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_4951">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -82,12 +82,27 @@
                         </source>
                      </recordHist>
                   </adminInfo>
-                  <surrogates><bibl subtype="partial" type="digital-facsimile"><ref target="https://digital.bodleian.ox.ac.uk/objects/97b61b7a-bead-444b-91ec-383910956634/"><title>Digital Bodleian</title></ref>
-                        <note>(1 image from 35mm slides)</note></bibl></surrogates>
+                  <surrogates>
+                     <bibl subtype="partial" type="digital-facsimile">
+                        <ref target="https://digital.bodleian.ox.ac.uk/objects/97b61b7a-bead-444b-91ec-383910956634/">
+                           <title>Digital Bodleian</title>
+                        </ref>
+                        <note>(1 image from 35mm slides)</note>
+                     </bibl>
+                  </surrogates>
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/61798"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/61798">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/61798">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -96,7 +111,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_bib/MS_Gr_bib_e_4_P.xml
+++ b/collections/Gr_bib/MS_Gr_bib_e_4_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_4954" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_4954">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -82,11 +82,20 @@
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
                         <bibl>
+                           <ref target="https://papyri.info/dclp/62090">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
                            <ref target="http://pinakes.irht.cnrs.fr/notices/cote/74581/">
                               <title>Pinakes | Πίνακες: Textes et manuscrits grecs</title>
                            </ref>
                         </bibl>
-                        <bibl><ref target="http://www.trismegistos.org/text/62090"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/62090">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -95,7 +104,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_bib/MS_Gr_bib_e_5_P.xml
+++ b/collections/Gr_bib/MS_Gr_bib_e_5_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_4955" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_4955">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -79,11 +79,20 @@
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
                         <bibl>
+                           <ref target="https://papyri.info/dclp/61764">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
                            <ref target="http://pinakes.irht.cnrs.fr/notices/cote/47962/">
                               <title>Pinakes | Πίνακες: Textes et manuscrits grecs</title>
                            </ref>
                         </bibl>
-                        <bibl><ref target="http://www.trismegistos.org/text/61764"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/61764">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -92,7 +101,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_bib/MS_Gr_bib_e_6_P.xml
+++ b/collections/Gr_bib/MS_Gr_bib_e_6_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_4956" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_4956">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -74,7 +74,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/62177"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/62177">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/62177">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -83,7 +92,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_bib/MS_Gr_bib_f_4_P.xml
+++ b/collections/Gr_bib/MS_Gr_bib_f_4_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_4957" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_4957">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -82,11 +82,20 @@
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
                         <bibl>
+                           <ref target="https://papyri.info/dclp/62148">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
                            <ref target="http://pinakes.irht.cnrs.fr/notices/cote/74582/">
                               <title>Pinakes | Πίνακες: Textes et manuscrits grecs</title>
                            </ref>
                         </bibl>
-                        <bibl><ref target="http://www.trismegistos.org/text/62148"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/62148">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -95,7 +104,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_bib/MS_Gr_bib_g_1_P.xml
+++ b/collections/Gr_bib/MS_Gr_bib_g_1_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_4958" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_4958">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -81,7 +81,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/62260"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/62260">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/62260">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -90,7 +99,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_bib/MS_Gr_bib_g_2_P.xml
+++ b/collections/Gr_bib/MS_Gr_bib_g_2_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_4959" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_4959">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -72,7 +72,9 @@
                         <!--ORIGINAL: Egyptian, Deir el-Bala'izah-->
                      </origPlace>
                   </origin>
-                  <provenance><orgName key="org_124557775">Deir-el-Bala'izah</orgName></provenance>
+                  <provenance>
+                     <orgName key="org_124557775">Deir-el-Bala'izah</orgName>
+                  </provenance>
                </history>
                <additional>
                   <adminInfo>
@@ -87,11 +89,20 @@
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
                         <bibl>
+                           <ref target="https://papyri.info/dclp/62051">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
                            <ref target="http://pinakes.irht.cnrs.fr/notices/cote/74583/">
                               <title>Pinakes | Πίνακες: Textes et manuscrits grecs</title>
                            </ref>
                         </bibl>
-                        <bibl><ref target="http://www.trismegistos.org/text/62051"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/62051">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -100,7 +111,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_bib/MS_Gr_bib_g_3_P.xml
+++ b/collections/Gr_bib/MS_Gr_bib_g_3_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_4960" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_4960">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -82,7 +82,8 @@
                   <surrogates>
                      <bibl subtype="full" type="digital-facsimile">
                         <ref target="https://digital.bodleian.ox.ac.uk/objects/ee402a0d-1778-47f5-9851-50d08c983e9b/">
-                           <title>Digital Bodleian</title></ref>
+                           <title>Digital Bodleian</title>
+                        </ref>
                         <note>(full digital facsimile)</note>
                      </bibl>
                   </surrogates>
@@ -90,11 +91,20 @@
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
                         <bibl>
+                           <ref target="https://papyri.info/dclp/62022">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
                            <ref target="http://pinakes.irht.cnrs.fr/notices/cote/74584/">
                               <title>Pinakes | Πίνακες: Textes et manuscrits grecs</title>
                            </ref>
                         </bibl>
-                        <bibl><ref target="http://www.trismegistos.org/text/62022"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/62022">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -103,7 +113,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_bib/MS_Gr_bib_g_4_P.xml
+++ b/collections/Gr_bib/MS_Gr_bib_g_4_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_4961" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_4961">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -74,12 +74,27 @@
                         <source>Summary description abbreviated from the Trismegistos record and from unpublished notes of E. Lobel. Previously described in the Summary Catalogue.</source>
                      </recordHist>
                   </adminInfo>
-                  <surrogates><bibl subtype="partial" type="digital-facsimile"><ref target="https://digital.bodleian.ox.ac.uk/objects/d300edf6-f3e6-40c0-bd3d-52078ee5c0a8/"><title>Digital Bodleian</title></ref>
-                        <note>(1 image from 35mm slides)</note></bibl></surrogates>
+                  <surrogates>
+                     <bibl subtype="partial" type="digital-facsimile">
+                        <ref target="https://digital.bodleian.ox.ac.uk/objects/d300edf6-f3e6-40c0-bd3d-52078ee5c0a8/">
+                           <title>Digital Bodleian</title>
+                        </ref>
+                        <note>(1 image from 35mm slides)</note>
+                     </bibl>
+                  </surrogates>
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/61701"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/61701">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/61701">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -88,7 +103,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_bib/MS_Gr_bib_g_5_P.xml
+++ b/collections/Gr_bib/MS_Gr_bib_g_5_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_4962" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_4962">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -74,7 +74,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/61926"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/61926">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/61926">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -83,7 +92,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_a_10_P.xml
+++ b/collections/Gr_class/MS_Gr_class_a_10_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_4972" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_4972">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -78,7 +78,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/58931"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/58931">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/58931">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -87,7 +96,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_a_7_P.xml
+++ b/collections/Gr_class/MS_Gr_class_a_7_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_4983" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_4983">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -79,7 +79,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/62998"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/62998">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/62998">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -88,7 +97,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_b_10_P.xml
+++ b/collections/Gr_class/MS_Gr_class_b_10_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_4986" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_4986">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -81,7 +81,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/60572"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/60572">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/60572">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -90,7 +99,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_b_18_P.xml
+++ b/collections/Gr_class/MS_Gr_class_b_18_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_4994" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_4994">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -42,6 +42,9 @@
                   <altIdentifier type="external">
                      <idno type="TM">59074</idno>
                   </altIdentifier>
+                  <altIdentifier type="external">
+                     <idno type="TM">60200</idno>
+                  </altIdentifier>
                </msIdentifier>
                <msContents>
                   <msItem n="1" xml:id="MS_Gr_class_b_18_P-item1">
@@ -75,7 +78,25 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/59074"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/59074">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/59074">Papyrological Navigator (papyri.info)</ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/60200">Papyrological Navigator (papyri.info)</ref> (fr. 29)</bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/59074">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/60200">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref> (fr. 29)</bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -84,7 +105,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_b_18_P.xml
+++ b/collections/Gr_class/MS_Gr_class_b_18_P.xml
@@ -84,10 +84,10 @@
                            </ref>
                         </bibl>
                         <bibl>
-                           <ref target="https://papyri.info/dclp/59074">Papyrological Navigator (papyri.info)</ref>
+                           <ref target="https://papyri.info/dclp/59074"><title>Papyrological Navigator (papyri.info)</title></ref>
                         </bibl>
                         <bibl>
-                           <ref target="https://papyri.info/dclp/60200">Papyrological Navigator (papyri.info)</ref> (fr. 29)</bibl>
+                           <ref target="https://papyri.info/dclp/60200"><title>Papyrological Navigator (papyri.info)</title></ref> (fr. 29)</bibl>
                         <bibl>
                            <ref target="http://www.trismegistos.org/text/59074">
                               <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>

--- a/collections/Gr_class/MS_Gr_class_b_19_P1-3.xml
+++ b/collections/Gr_class/MS_Gr_class_b_19_P1-3.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_4995" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_4995">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -85,7 +85,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/61450"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/61450">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -94,7 +103,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_b_19_P1-3.xml
+++ b/collections/Gr_class/MS_Gr_class_b_19_P1-3.xml
@@ -86,7 +86,7 @@
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
                         <bibl>
-                           <ref target="https://papyri.info/dclp/">
+                           <ref target="https://papyri.info/dclp/61450">
                               <title>Papyrological Navigator (papyri.info)</title>
                            </ref>
                         </bibl>

--- a/collections/Gr_class/MS_Gr_class_b_1_P1-12.xml
+++ b/collections/Gr_class/MS_Gr_class_b_1_P1-12.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_4996" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_4996">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -95,7 +95,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/69067"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/69067">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -104,7 +113,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_b_1_P1-12.xml
+++ b/collections/Gr_class/MS_Gr_class_b_1_P1-12.xml
@@ -96,7 +96,7 @@
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
                         <bibl>
-                           <ref target="https://papyri.info/dclp/">
+                           <ref target="https://papyri.info/dclp/69067">
                               <title>Papyrological Navigator (papyri.info)</title>
                            </ref>
                         </bibl>

--- a/collections/Gr_class/MS_Gr_class_b_23_P.xml
+++ b/collections/Gr_class/MS_Gr_class_b_23_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5000" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5000">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -67,8 +67,21 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/61505"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
-                        <bibl><ref target="http://www.trismegistos.org/text/29167"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/61505">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/61505">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/29167">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -138,7 +151,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_b_24_P1-2.xml
+++ b/collections/Gr_class/MS_Gr_class_b_24_P1-2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5001" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5001">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -77,8 +77,21 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/29168"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
-                        <bibl><ref target="http://www.trismegistos.org/text/29169"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/29168">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/29169">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -87,7 +100,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_b_24_P1-2.xml
+++ b/collections/Gr_class/MS_Gr_class_b_24_P1-2.xml
@@ -78,7 +78,7 @@
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
                         <bibl>
-                           <ref target="https://papyri.info/dclp/">
+                           <ref target="https://papyri.info/dclp/29169">
                               <title>Papyrological Navigator (papyri.info)</title>
                            </ref>
                         </bibl>

--- a/collections/Gr_class/MS_Gr_class_b_4_P.xml
+++ b/collections/Gr_class/MS_Gr_class_b_4_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5004" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5004">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -58,7 +58,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/63690"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/63690">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/63690">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -128,7 +137,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_c_130_P_a.xml
+++ b/collections/Gr_class/MS_Gr_class_c_130_P_a.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5058" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5058">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -69,12 +69,24 @@
                   <adminInfo>
                      <recordHist>
                         <source>Summary description by Elizabeth Solopova and Matthew Holford. </source>
-                     </recordHist>                      <availability>                         <p>This item is unglazed and may only be consulted by prior arrangement and subject to curatorial approval. To make an application, please click the request button above. When your request is received, you will be asked to contact the relevant curator.</p>                      </availability>
+                     </recordHist>                      
+                     <availability>                         
+                        <p>This item is unglazed and may only be consulted by prior arrangement and subject to curatorial approval. To make an application, please click the request button above. When your request is received, you will be asked to contact the relevant curator.</p>                      
+                     </availability>
                   </adminInfo>
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/64904"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/64904">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/64904">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -83,7 +95,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_c_167_P_a.xml
+++ b/collections/Gr_class/MS_Gr_class_c_167_P_a.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5152" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5152">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -55,7 +55,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/64209"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/64209">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/64209">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -121,7 +130,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_c_214_P_a.xml
+++ b/collections/Gr_class/MS_Gr_class_c_214_P_a.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5257" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5257">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -68,13 +68,30 @@
                         <source>Summary description by Elizabeth Solopova and Matthew Holford. </source>
                      </recordHist>
                   </adminInfo>
+                  <listBibl type="WRAPPER">
+                     <listBibl type="PRINT">
+                        <head>Online resources:</head>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/64499">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/64499">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
+                     </listBibl>
+                  </listBibl>
                </additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_c_41_P.xml
+++ b/collections/Gr_class/MS_Gr_class_c_41_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5377" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5377">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -73,7 +73,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/111290"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/111290">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/111290">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -82,7 +91,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_c_54_P.xml
+++ b/collections/Gr_class/MS_Gr_class_c_54_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5390" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5390">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -61,8 +61,21 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/69879"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
-                        <bibl><ref target="http://www.trismegistos.org/text/62613"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/62613">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/69879">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/62613">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -131,7 +144,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_c_74_P1-4.xml
+++ b/collections/Gr_class/MS_Gr_class_c_74_P1-4.xml
@@ -95,7 +95,7 @@
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
                         <bibl>
-                           <ref target="https://papyri.info/dclp/">
+                           <ref target="https://papyri.info/dclp/62375">
                               <title>Papyrological Navigator (papyri.info)</title>
                            </ref>
                         </bibl>

--- a/collections/Gr_class/MS_Gr_class_c_74_P1-4.xml
+++ b/collections/Gr_class/MS_Gr_class_c_74_P1-4.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5407" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5407">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -94,7 +94,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/62375"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/62375">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -103,7 +112,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_c_75_P.xml
+++ b/collections/Gr_class/MS_Gr_class_c_75_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5408" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5408">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -76,7 +76,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/62712"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/62712">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/62712">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -85,7 +94,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_c_76_P1-2.xml
+++ b/collections/Gr_class/MS_Gr_class_c_76_P1-2.xml
@@ -9,7 +9,6 @@
             <title type="collection">MSS. Gr. class. (Greek classical)</title>
             <respStmt>
                <resp>Summary description</resp>
-               <persName>Elizabeth Solopova</persName>
                <persName>Matthew Holford</persName>
             </respStmt>
          </titleStmt>
@@ -69,7 +68,7 @@
                   <origin>
                      <origDate calendar="Gregorian" notAfter="0200" notBefore="0100">2nd century</origDate>
                      <origPlace>
-                        <country key="place_7014986">Egyptian</country>, <settlement key="place_7001267">Oxyrhynchus</settlement> (?)
+                        <country key="place_7014986">Egyptian</country>, <settlement key="place_7001267">Oxyrhynchus (?)</settlement>
                         <!--ORIGINAL: Egyptian, Oxyrhynchus-->
                      </origPlace>
                   </origin>
@@ -96,7 +95,7 @@
                         <head>Online resources:</head>
                         <head>Printed:</head>
                         <bibl>
-                           <ref target="https://papyri.info/dclp/">
+                           <ref target="https://papyri.info/dclp/62705">
                               <title>Papyrological Navigator (papyri.info)</title>
                            </ref>
                         </bibl>
@@ -105,9 +104,11 @@
                               <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
                            </ref>
                         </bibl>
-                        <bibl>Prauscello, L. , 'The Alexandrian Edition of Sappho', in P. Finglass &amp; A. Kelly (Eds.), <title>The Cambridge Companion to Sappho</title> (Cambridge, 2021), pp. 219-231. doi:10.1017/9781316986974.017</bibl>
-                        <bibl>
-                           <title>Sappho et Alcaeus. Fragmenta</title>, ed. E.-M. Voigt (Amsterdam, 1971)</bibl>
+                       <listBibl type="PRINT">
+                          <head>Selected editions and studies:</head>
+                          <bibl>Prauscello, L. , 'The Alexandrian Edition of Sappho', in P. Finglass &amp; A. Kelly (Eds.), <title>The Cambridge Companion to Sappho</title> (Cambridge, 2021), pp. 219-231. doi:10.1017/9781316986974.017</bibl>
+                          <bibl>
+                           <title>Sappho et Alcaeus. Fragmenta</title>, ed. E.-M. Voigt (Amsterdam, 1971)</bibl></listBibl>
                      </listBibl>
                   </listBibl>
                </additional>

--- a/collections/Gr_class/MS_Gr_class_c_76_P1-2.xml
+++ b/collections/Gr_class/MS_Gr_class_c_76_P1-2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5409" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5409">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -59,7 +59,8 @@
                            <dimensions unit="mm" type="fragment">
                               <height>177</height>
                               <width>132</width>
-                           </dimensions><note>(first fragment)</note>
+                           </dimensions>
+                           <note>(first fragment)</note>
                         </extent>
                      </supportDesc>
                   </objectDesc>
@@ -78,20 +79,35 @@
                <additional>
                   <adminInfo>
                      <recordHist>
-                        <source>Description adapted (May 2022) from <ref target="https://archive.org/details/oxyrhynchuspapyr10gren/page/20/mode/2up"><title>The Oxyrhynchus Papyri</title> X (1914), no. 1231</ref>, with reference to other published literature as cited.</source>
+                        <source>Description adapted (May 2022) from <ref target="https://archive.org/details/oxyrhynchuspapyr10gren/page/20/mode/2up">
+                              <title>The Oxyrhynchus Papyri</title> X (1914), no. 1231</ref>, with reference to other published literature as cited.</source>
                      </recordHist>
                   </adminInfo>
-                  <surrogates><bibl subtype="partial" type="digital-facsimile"><ref target="https://digital.bodleian.ox.ac.uk/objects/3a80751f-3d05-48b4-b7da-70b3e1dee856/"><title>Digital Bodleian</title></ref>
-                        <note>(1 image from 35mm slides)</note></bibl></surrogates>
+                  <surrogates>
+                     <bibl subtype="partial" type="digital-facsimile">
+                        <ref target="https://digital.bodleian.ox.ac.uk/objects/3a80751f-3d05-48b4-b7da-70b3e1dee856/">
+                           <title>Digital Bodleian</title>
+                        </ref>
+                        <note>(1 image from 35mm slides)</note>
+                     </bibl>
+                  </surrogates>
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/62705"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
-                     </listBibl>
-                     <listBibl>
                         <head>Printed:</head>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/62705">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                         <bibl>Prauscello, L. , 'The Alexandrian Edition of Sappho', in P. Finglass &amp; A. Kelly (Eds.), <title>The Cambridge Companion to Sappho</title> (Cambridge, 2021), pp. 219-231. doi:10.1017/9781316986974.017</bibl>
-                        <bibl><title>Sappho et Alcaeus. Fragmenta</title>, ed. E.-M. Voigt (Amsterdam, 1971)</bibl>
+                        <bibl>
+                           <title>Sappho et Alcaeus. Fragmenta</title>, ed. E.-M. Voigt (Amsterdam, 1971)</bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -101,7 +117,9 @@
       <revisionDesc>
          <change when="2022-05-10">Description revised for publication on Digital Bodleian.</change>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_c_77_P.xml
+++ b/collections/Gr_class/MS_Gr_class_c_77_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5410" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5410">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -76,7 +76,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/59367"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/59367">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/59367">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -85,7 +94,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_c_90_P_a.xml
+++ b/collections/Gr_class/MS_Gr_class_c_90_P_a.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5423" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5423">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -58,8 +58,21 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/10262"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
-                        <bibl><ref target="http://www.trismegistos.org/text/92224"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/92224">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/10262">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/92224">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -127,7 +140,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_c_96_P.xml
+++ b/collections/Gr_class/MS_Gr_class_c_96_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5438" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5438">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -81,7 +81,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/64957"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/64957">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/64957">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -90,7 +99,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_d_101_P.xml
+++ b/collections/Gr_class/MS_Gr_class_d_101_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5443" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5443">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -58,7 +58,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/58949"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/58949">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/58949">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -128,7 +137,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_d_113_P.xml
+++ b/collections/Gr_class/MS_Gr_class_d_113_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5456" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5456">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -74,7 +74,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/62353"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/62353">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/62353">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -83,7 +92,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_d_114_P.xml
+++ b/collections/Gr_class/MS_Gr_class_d_114_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5457" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5457">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -75,7 +75,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/60025"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/60025">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/60025">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -84,7 +93,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_d_13_P.xml
+++ b/collections/Gr_class/MS_Gr_class_d_13_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5475" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5475">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -55,7 +55,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/66763"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/66763">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/66763">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -151,7 +160,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_d_150_P.xml
+++ b/collections/Gr_class/MS_Gr_class_d_150_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5486" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5486">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -70,7 +70,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/66761"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/66761">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/66761">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -79,7 +88,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_d_163_P.xml
+++ b/collections/Gr_class/MS_Gr_class_d_163_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5497" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5497">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -72,7 +72,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/61349"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/61349">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/61349">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -81,7 +90,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_d_19_P.xml
+++ b/collections/Gr_class/MS_Gr_class_d_19_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5500" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5500">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -55,7 +55,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/66101"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/66101">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/66101">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -123,7 +132,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_d_20_P.xml
+++ b/collections/Gr_class/MS_Gr_class_d_20_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5501" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5501">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -79,7 +79,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/60326"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/60326">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/60326">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -88,7 +97,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_d_2_P.xml
+++ b/collections/Gr_class/MS_Gr_class_d_2_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5511" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5511">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -67,13 +67,30 @@
                         </source>
                      </recordHist>
                   </adminInfo>
+                  <listBibl type="WRAPPER">
+                     <listBibl type="PRINT">
+                        <head>Online resources:</head>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/64902">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/64902">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
+                     </listBibl>
+                  </listBibl>
                </additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_d_36_P.xml
+++ b/collections/Gr_class/MS_Gr_class_d_36_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5518" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5518">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -74,7 +74,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/383637"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/383637">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/383637">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -83,7 +92,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_d_41_P.xml
+++ b/collections/Gr_class/MS_Gr_class_d_41_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5524" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5524">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -75,7 +75,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/60281"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/60281">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/60281">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -84,7 +93,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_d_45_P.xml
+++ b/collections/Gr_class/MS_Gr_class_d_45_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5525" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5525">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -75,7 +75,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/60573"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/60573">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/60573">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -84,7 +93,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_d_57_P.xml
+++ b/collections/Gr_class/MS_Gr_class_d_57_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5538" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5538">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -74,7 +74,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/66758"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/66758">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/66758">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -83,7 +92,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_d_64_P.xml
+++ b/collections/Gr_class/MS_Gr_class_d_64_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5546" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5546">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -79,7 +79,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/62612"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/62612">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/62612">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -88,7 +97,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_d_71_P.xml
+++ b/collections/Gr_class/MS_Gr_class_d_71_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5554" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5554">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -61,8 +61,21 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/31430"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
-                        <bibl><ref target="http://www.trismegistos.org/text/64212"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/64212">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/31430">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/64212">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -131,7 +144,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_d_76_P.xml
+++ b/collections/Gr_class/MS_Gr_class_d_76_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5559" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5559">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -79,7 +79,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/59299"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/59299">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/59299">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -88,7 +97,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_d_77_P.xml
+++ b/collections/Gr_class/MS_Gr_class_d_77_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5560" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5560">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -74,7 +74,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/63049"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/63049">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/63049">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -83,7 +92,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_d_79_P.xml
+++ b/collections/Gr_class/MS_Gr_class_d_79_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5562" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5562">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -58,7 +58,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/62732"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/62732">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/62732">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -125,7 +134,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_d_80_P.xml
+++ b/collections/Gr_class/MS_Gr_class_d_80_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5564" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5564">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -78,7 +78,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/59110"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/59110">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/59110">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -87,7 +96,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_d_81_P.xml
+++ b/collections/Gr_class/MS_Gr_class_d_81_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5565" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5565">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -77,7 +77,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/65668"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/65668">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/65668">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -86,7 +95,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_d_97_P.xml
+++ b/collections/Gr_class/MS_Gr_class_d_97_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5578" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5578">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -79,7 +79,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/58915"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/58915">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/58915">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -88,7 +97,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_e_126_P.xml
+++ b/collections/Gr_class/MS_Gr_class_e_126_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5602" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5602">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -72,7 +72,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/60997"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/60997">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/60997">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -81,7 +90,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_e_21_P.xml
+++ b/collections/Gr_class/MS_Gr_class_e_21_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5628" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5628">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -78,7 +78,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/60996"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/60996">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/60996">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -87,7 +96,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_e_33_P.xml
+++ b/collections/Gr_class/MS_Gr_class_e_33_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5637" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5637">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -76,7 +76,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/61297"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/61297">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/61297">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -85,7 +94,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_e_44_P.xml
+++ b/collections/Gr_class/MS_Gr_class_e_44_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5647" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5647">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -75,7 +75,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/59205"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/59205">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/59205">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -84,7 +93,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_e_58_P.xml
+++ b/collections/Gr_class/MS_Gr_class_e_58_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5650" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5650">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -75,7 +75,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/60357"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/60357">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/60357">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -84,7 +93,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_e_72_P.xml
+++ b/collections/Gr_class/MS_Gr_class_e_72_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5666" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5666">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -84,7 +84,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/59044"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/59044">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/59044">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -93,7 +102,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_e_87_P.xml
+++ b/collections/Gr_class/MS_Gr_class_e_87_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5682" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5682">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -76,7 +76,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/59266"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/59266">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/59266">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -85,7 +94,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_e_89_P.xml
+++ b/collections/Gr_class/MS_Gr_class_e_89_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5684" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5684">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -79,7 +79,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/62768"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/62768">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/62768">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -88,7 +97,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_e_99_P.xml
+++ b/collections/Gr_class/MS_Gr_class_e_99_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5690" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5690">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -79,7 +79,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/61550"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/61550">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/61550">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -88,7 +97,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_f_109_P.xml
+++ b/collections/Gr_class/MS_Gr_class_f_109_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5700" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5700">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -72,7 +72,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/59423"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/59423">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/59423">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -81,7 +90,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_f_113_P.xml
+++ b/collections/Gr_class/MS_Gr_class_f_113_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5705" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5705">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -70,7 +70,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/62737"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/62737">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/62737">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -79,7 +88,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_f_1_P.xml
+++ b/collections/Gr_class/MS_Gr_class_f_1_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5728" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5728">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -55,7 +55,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/59439"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/59439">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/59439">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -124,7 +133,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_f_24_P.xml
+++ b/collections/Gr_class/MS_Gr_class_f_24_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5733" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5733">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -76,7 +76,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/60764"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/60764">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/60764">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -85,7 +94,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_f_2_P.xml
+++ b/collections/Gr_class/MS_Gr_class_f_2_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5739" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5739">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -74,7 +74,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/65433"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/65433">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/65433">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -83,7 +92,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_f_31_P.xml
+++ b/collections/Gr_class/MS_Gr_class_f_31_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5741" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5741">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -76,7 +76,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/64213"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/64213">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/64213">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -85,7 +94,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_f_38_P.xml
+++ b/collections/Gr_class/MS_Gr_class_f_38_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5748" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5748">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -74,7 +74,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/62722"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/62722">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/62722">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -83,7 +92,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_f_39_P.xml
+++ b/collections/Gr_class/MS_Gr_class_f_39_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5749" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5749">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -71,13 +71,30 @@
                         </source>
                      </recordHist>
                   </adminInfo>
+                  <listBibl type="WRAPPER">
+                     <listBibl type="PRINT">
+                        <head>Online resources:</head>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/901292">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/901292">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
+                     </listBibl>
+                  </listBibl>
                </additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_f_3_P.xml
+++ b/collections/Gr_class/MS_Gr_class_f_3_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5750" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5750">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -74,7 +74,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/65433"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/65433">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/65433">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -83,7 +92,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_f_41_P.xml
+++ b/collections/Gr_class/MS_Gr_class_f_41_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5751" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5751">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -77,7 +77,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/68659"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/68659">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/68659">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -86,7 +95,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_f_42_P.xml
+++ b/collections/Gr_class/MS_Gr_class_f_42_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5752" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5752">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -75,7 +75,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/60358"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/60358">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/60358">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -84,7 +93,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_f_45_P.xml
+++ b/collections/Gr_class/MS_Gr_class_f_45_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5755" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5755">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -78,7 +78,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/65759"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/65759">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/65759">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -87,7 +96,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_f_46_P.xml
+++ b/collections/Gr_class/MS_Gr_class_f_46_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5756" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5756">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -58,7 +58,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/59522"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/59522">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/59522">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -127,7 +136,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_f_47_P.xml
+++ b/collections/Gr_class/MS_Gr_class_f_47_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5757" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5757">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -78,7 +78,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/59572"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/59572">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/59572">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -87,7 +96,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_f_48_P.xml
+++ b/collections/Gr_class/MS_Gr_class_f_48_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5758" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5758">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -78,7 +78,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/62363"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/62363">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/62363">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -87,7 +96,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_f_72_P.xml
+++ b/collections/Gr_class/MS_Gr_class_f_72_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5785" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5785">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -76,7 +76,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/59267"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/59267">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/59267">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -85,7 +94,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_f_73_P.xml
+++ b/collections/Gr_class/MS_Gr_class_f_73_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5786" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5786">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -78,7 +78,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/63300"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/63300">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/63300">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -87,7 +96,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_f_74_P.xml
+++ b/collections/Gr_class/MS_Gr_class_f_74_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5787" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5787">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -61,8 +61,21 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/28374"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
-                        <bibl><ref target="http://www.trismegistos.org/text/60576"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/60576">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/28374">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/60576">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -134,7 +147,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_f_75_P.xml
+++ b/collections/Gr_class/MS_Gr_class_f_75_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5788" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5788">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -73,13 +73,30 @@
                         </source>
                      </recordHist>
                   </adminInfo>
+                  <listBibl type="WRAPPER">
+                     <listBibl type="PRINT">
+                        <head>Online resources:</head>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/60574">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/60574">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
+                     </listBibl>
+                  </listBibl>
                </additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_f_78_P.xml
+++ b/collections/Gr_class/MS_Gr_class_f_78_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5790" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5790">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -58,7 +58,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/59733"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/59733">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/59733">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -127,7 +136,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_f_79_P.xml
+++ b/collections/Gr_class/MS_Gr_class_f_79_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5791" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5791">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -77,7 +77,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/65760"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/65760">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/65760">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -86,7 +95,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_f_7_P.xml
+++ b/collections/Gr_class/MS_Gr_class_f_7_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5792" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5792">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -67,7 +67,7 @@
                      <recordHist>
                         <source>Summary description by Elizabeth Solopova and Matthew Holford, based on the Summary Catalogue and supplementary sources. <listBibl>
                               <bibl facs="abj0051.gif" type="SC">Summary Catalogue, vol. 6, p. 13</bibl>
-                           <bibl facs="abj0013.gif" type="SC">Summary Catalogue, Vol. 6, p. xi [corrigenda]</bibl>
+                              <bibl facs="abj0013.gif" type="SC">Summary Catalogue, Vol. 6, p. xi [corrigenda]</bibl>
                            </listBibl>
                         </source>
                      </recordHist>
@@ -75,7 +75,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/63299"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/63299">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/63299">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -84,7 +93,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_f_80_P.xml
+++ b/collections/Gr_class/MS_Gr_class_f_80_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5793" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5793">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -77,7 +77,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/65761"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/65761">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/65761">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -86,7 +95,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_f_88_P.xml
+++ b/collections/Gr_class/MS_Gr_class_f_88_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5801" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5801">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -58,7 +58,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/63298"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/63298">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/63298">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -126,7 +135,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_f_95_P.xml
+++ b/collections/Gr_class/MS_Gr_class_f_95_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5805" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5805">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -76,7 +76,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/61551"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/61551">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/61551">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -85,7 +94,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_g_40_P.xml
+++ b/collections/Gr_class/MS_Gr_class_g_40_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5844" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5844">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -73,7 +73,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/66762"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/66762">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/66762">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -82,7 +91,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_g_42_P.xml
+++ b/collections/Gr_class/MS_Gr_class_g_42_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5846" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5846">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -74,7 +74,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/69006"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/69006">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/69006">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -83,7 +92,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_g_44_P.xml
+++ b/collections/Gr_class/MS_Gr_class_g_44_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5848" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5848">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -55,7 +55,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/68652"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/68652">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/68652">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -125,7 +134,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_g_47_P.xml
+++ b/collections/Gr_class/MS_Gr_class_g_47_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5851" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5851">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -77,7 +77,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/63184"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/63184">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/63184">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -86,7 +95,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_g_48_P.xml
+++ b/collections/Gr_class/MS_Gr_class_g_48_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5852" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5852">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -77,7 +77,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/63185"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/63185">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/63185">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -86,7 +95,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_g_49_P.xml
+++ b/collections/Gr_class/MS_Gr_class_g_49_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5853" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5853">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -76,7 +76,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/61022"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/61022">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/61022">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -85,7 +94,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_g_50_P.xml
+++ b/collections/Gr_class/MS_Gr_class_g_50_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5855" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5855">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -76,7 +76,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/61552"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/61552">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/61552">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -85,7 +94,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_g_51_P.xml
+++ b/collections/Gr_class/MS_Gr_class_g_51_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5856" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5856">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -79,7 +79,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/58997"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/58997">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/58997">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -88,7 +97,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_g_54_P.xml
+++ b/collections/Gr_class/MS_Gr_class_g_54_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5859" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5859">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -79,7 +79,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/62769"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/62769">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/62769">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -88,7 +97,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_g_55_P.xml
+++ b/collections/Gr_class/MS_Gr_class_g_55_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5860" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5860">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -77,7 +77,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/65762"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/65762">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/65762">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -86,7 +95,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_g_5_P.xml
+++ b/collections/Gr_class/MS_Gr_class_g_5_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5865" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5865">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -74,7 +74,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/65094"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/65094">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/65094">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -83,7 +92,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_g_60_P.xml
+++ b/collections/Gr_class/MS_Gr_class_g_60_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5866" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5866">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -58,7 +58,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/59405"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/59405">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/59405">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -128,7 +137,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_g_69_P.xml
+++ b/collections/Gr_class/MS_Gr_class_g_69_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5875" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5875">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -72,7 +72,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/59960"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/59960">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/59960">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -81,7 +90,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_g_7_P.xml
+++ b/collections/Gr_class/MS_Gr_class_g_7_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5887" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5887">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -79,7 +79,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/60898"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/60898">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/60898">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -88,7 +97,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_class/MS_Gr_class_g_80_P.xml
+++ b/collections/Gr_class/MS_Gr_class_g_80_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5888" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5888">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -70,7 +70,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/64764"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/64764">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/64764">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -79,7 +88,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_liturg/MS_Gr_liturg_c_3_P.xml
+++ b/collections/Gr_liturg/MS_Gr_liturg_c_3_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5896" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5896">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -84,7 +84,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/65239"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/65239">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/65239">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -93,7 +102,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_th/MS_Gr_th_b_1_P.xml
+++ b/collections/Gr_th/MS_Gr_th_b_1_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5916" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5916">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -56,7 +56,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/58909"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/58909">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/58909">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -127,7 +136,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_th/MS_Gr_th_c_1_P.xml
+++ b/collections/Gr_th/MS_Gr_th_c_1_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5918" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5918">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -55,7 +55,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/62671"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/62671">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/62671">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -119,7 +128,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_th/MS_Gr_th_d_4_P.xml
+++ b/collections/Gr_th/MS_Gr_th_d_4_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5921" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5921">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -76,7 +76,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/61463"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/61463">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/61463">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -85,7 +94,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_th/MS_Gr_th_d_7_P.xml
+++ b/collections/Gr_th/MS_Gr_th_d_7_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5923" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5923">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -76,7 +76,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/942900"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/942900">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/942900">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -86,7 +95,9 @@
       <revisionDesc>
          <change when="2021-04-20">Add reference to publication; revise date; add link to TM</change>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_th/MS_Gr_th_e_2_P.xml
+++ b/collections/Gr_th/MS_Gr_th_e_2_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5928" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5928">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -74,7 +74,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/62358"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/62358">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/62358">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -83,7 +92,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_th/MS_Gr_th_e_4_P.xml
+++ b/collections/Gr_th/MS_Gr_th_e_4_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5930" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5930">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -77,7 +77,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/65505"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/65505">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/65505">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -86,7 +95,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_th/MS_Gr_th_e_7_P.xml
+++ b/collections/Gr_th/MS_Gr_th_e_7_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5932" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5932">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -81,12 +81,27 @@
                         <p>To ensure its preservation, access to this item is restricted, and readers are asked to work from reproductions and published descriptions as far as possible. If you wish to apply to see the original, please click the request button above. When your request is received, you will be asked to contact the relevant curator outlining the subject of your research, the importance of this item to that research, and the resources you have already consulted.</p>
                      </availability>
                   </adminInfo>
-                  <surrogates><bibl subtype="partial" type="digital-facsimile"><ref target="https://digital.bodleian.ox.ac.uk/objects/4faa79a7-de92-4b0e-99ce-359203cdf724/"><title>Digital Bodleian</title></ref>
-                        <note>(1 image from 35mm slides)</note></bibl></surrogates>
+                  <surrogates>
+                     <bibl subtype="partial" type="digital-facsimile">
+                        <ref target="https://digital.bodleian.ox.ac.uk/objects/4faa79a7-de92-4b0e-99ce-359203cdf724/">
+                           <title>Digital Bodleian</title>
+                        </ref>
+                        <note>(1 image from 35mm slides)</note>
+                     </bibl>
+                  </surrogates>
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/63016"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/62838">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/63016">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -95,7 +110,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_th/MS_Gr_th_e_8_P.xml
+++ b/collections/Gr_th/MS_Gr_th_e_8_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5933" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5933">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -78,7 +78,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/64501"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/64501">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/64501">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -87,7 +96,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_th/MS_Gr_th_f_10_P.xml
+++ b/collections/Gr_th/MS_Gr_th_f_10_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5936" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5936">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -79,7 +79,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/59989"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/59989">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/59989">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -88,7 +97,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_th/MS_Gr_th_f_12_P.xml
+++ b/collections/Gr_th/MS_Gr_th_f_12_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5937" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5937">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -77,7 +77,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/65455"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/65455">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/65455">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -86,7 +95,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_th/MS_Gr_th_f_13_P.xml
+++ b/collections/Gr_th/MS_Gr_th_f_13_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5938" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5938">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -81,7 +81,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/64498"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/64498">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/64498">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -90,7 +99,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_th/MS_Gr_th_f_4_P.xml
+++ b/collections/Gr_th/MS_Gr_th_f_4_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5944" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5944">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -84,7 +84,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/64361"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/64361">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/64361">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -93,7 +102,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_th/MS_Gr_th_f_6_P.xml
+++ b/collections/Gr_th/MS_Gr_th_f_6_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5946" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5946">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -75,7 +75,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/65344"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/65344">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/65344">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -84,7 +93,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_th/MS_Gr_th_f_9_P.xml
+++ b/collections/Gr_th/MS_Gr_th_f_9_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5948" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5948">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -85,7 +85,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/61461"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/61461">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/61461">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -95,7 +104,9 @@
       <revisionDesc>
          <change when="2022-03-22">Revised with additional reference to published literature as cited.</change>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_th/MS_Gr_th_g_11_P.xml
+++ b/collections/Gr_th/MS_Gr_th_g_11_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5949" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5949">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -81,7 +81,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/64601"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/64601">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/64601">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -90,7 +99,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_th/MS_Gr_th_g_2_P.xml
+++ b/collections/Gr_th/MS_Gr_th_g_2_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5951" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5951">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -83,7 +83,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/65095"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/65095">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/65095">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -92,7 +101,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_th/MS_Gr_th_g_4_P.xml
+++ b/collections/Gr_th/MS_Gr_th_g_4_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5953" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5953">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -81,7 +81,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/65240"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/65240">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/65240">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -90,7 +99,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_th/MS_Gr_th_g_6_P.xml
+++ b/collections/Gr_th/MS_Gr_th_g_6_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5955" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5955">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -76,7 +76,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/62242"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/62242">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/62242">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -85,7 +94,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_th/MS_Gr_th_g_8_P.xml
+++ b/collections/Gr_th/MS_Gr_th_g_8_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5957" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5957">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -74,7 +74,16 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
-                        <bibl><ref target="http://www.trismegistos.org/text/69049"><title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title></ref></bibl>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/69049">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/69049">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
                      </listBibl>
                   </listBibl>
                </additional>
@@ -83,7 +92,9 @@
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/collections/Gr_th/MS_Gr_th_g_9_P.xml
+++ b/collections/Gr_th/MS_Gr_th_g_9_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xml:id="manuscript_5958" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_5958">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -69,13 +69,30 @@
                         </source>
                      </recordHist>
                   </adminInfo>
+                  <listBibl type="WRAPPER">
+                     <listBibl type="PRINT">
+                        <head>Online resources:</head>
+                        <bibl>
+                           <ref target="https://papyri.info/dclp/754967">
+                              <title>Papyrological Navigator (papyri.info)</title>
+                           </ref>
+                        </bibl>
+                        <bibl>
+                           <ref target="http://www.trismegistos.org/text/754967">
+                              <title>Trismegistos: an interdisciplinary portal of papyrological and epigraphical resources</title>
+                           </ref>
+                        </bibl>
+                     </listBibl>
+                  </listBibl>
                </additional>
             </msDesc>
          </sourceDesc>
       </fileDesc>
       <revisionDesc>
          <change when="2017-07-01">First online publication.</change>
-         <change when="2017-05-25"><persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref></change>
+         <change when="2017-05-25">
+            <persName>James Cummings</persName> Up-converted the markup using <ref target="https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl">https://github.com/jamescummings/Bodleian-msDesc-ODD/blob/master/convertTolkien2Bodley.xsl</ref>
+         </change>
       </revisionDesc>
    </teiHeader>
    <text>


### PR DESCRIPTION
Add links to papyri-info/DCLP - still a work in progress, but merging this branch now to avoid potential conflicts resulting from work on papryi records as part of digitization work.