### PR TITLE
Distinguish Middle Dutch (dum) from Dutch (nl)

### DIFF
--- a/collections/Ashmole/MS_Ashmole_1291.xml
+++ b/collections/Ashmole/MS_Ashmole_1291.xml
@@ -116,13 +116,14 @@
                         <incipit>
                            <sic>Elegiit</sic> dominus virum de plebe </incipit>
                         <incipit type="collect">Omnipotens sempiterne deus cui precibus et meritis beati Sebastiane gloriosissymy martiris tui</incipit>
-                        <note> In the lower margin of fol. 97v is added in Netherlandish(?) ‘God ghorai(?) Gidion contra(?) …(?)’</note>
+                        <note> In the lower margin of fol. 97v is added in Middle Dutch(?) ‘God ghorai(?) Gidion contra(?) …(?)’</note>
                         <!-- TODO ? -->
                      </msItem>
                      <msItem>
                         <locus>(fols. 98v–99r)</locus>
-                        <note> Added text in Netherlandish</note>
+                        <note>Added text in Middle Dutch</note>
                         <incipit>Hii siit heren … oghen op slaet … </incipit>
+                        <textlang mainLang="dum">Middle Dutch</textlang>
                         <!-- TODO -->
                      </msItem>
                      <msItem>

--- a/collections/Ashmole/MS_Ashmole_189.xml
+++ b/collections/Ashmole/MS_Ashmole_189.xml
@@ -341,8 +341,8 @@
                   <msContents>
                      <msItem xml:id="MS-Ashmole-189-part3-item1-1">
                         <locus>(fol. 116)</locus>
-                        <title type="desc" key="work_16519">Astrological-medical compilation</title>  <textLang mainLang="nl" otherLangs="la">Flemish and Latin</textLang>
-                        <note>For a full inventory see L. S. Chardonnens  and J. G. M. Kienhorst, ‘<ref target="https://repository.ubn.ru.nl/handle/2066/198513">Newly Discovered Notebooks of a Sixteenth-Century Flemish Astrologer Physician</ref>’, <title>Queeste: Journal of Medieval Literature in the Low Countries</title>, 25.1 (2018), 1–31. Includes:</note>
+                        <title type="desc" key="work_16519">Astrological-medical compilation</title>  <textLang mainLang="dum" otherLangs="la">Middle Dutch (Flemish dialect) and Latin</textLang>
+                        <note>For a full inventory see L. S. Chardonnens  and J. G. M. Kienhorst, ‘<ref target="https://hdl.handle.net/2066/198513">Newly Discovered Notebooks of a Sixteenth-Century Flemish Astrologer Physician</ref>’, <title>Queeste: Journal of Medieval Literature in the Low Countries</title>, 25.1 (2018), 1–31. Includes:</note>
                       
                      </msItem>
                      <msItem xml:id="MS-Ashmole-189-part3-item1-2">
@@ -356,7 +356,7 @@
                            intitulatur Thesaurus Pauperum magistri Petri Hispani
                            quondam Pape</finalRubric>
                         <note>Chardonnens  and Kienhorst, no. 24.</note>
-                        <textLang mainLang="nl">Latin with some glosses in Flemish</textLang>
+                        <textLang mainLang="dum">Latin with some glosses in Middle Dutch (Flemish dialect)</textLang>
                      </msItem>
 
                   </msContents>

--- a/collections/Bodl/MS_Bodl_340.xml
+++ b/collections/Bodl/MS_Bodl_340.xml
@@ -177,13 +177,13 @@
                         <rubric> Passio alexandri papae.</rubric>
                         <note> At the end of the homily the scribe wrote 'Explicit hic liber'. The
                            verso of f. 169 of MS. 340 is blank, except for scribbles in Latin of
-                           verses, &amp;c., and a line of Netherlandish (s. xi2), see following. One
+                           verses, &amp;c., and a line of Middle Dutch (s. xi2), see following. One
                            of the hands on this page does not look English.</note>
                      </msItem>
                      <msItem>
                         <locus>(fol. 169v)</locus>
                         <note>Pen trials, c. 1100, including verse in Dutch, 'Hebban olla vogala', pr. Sisam 1933; Erik Kwakkel, ‘Hebban Olla Vogala in Historisch Perspectief’, <title>Tijdschrift Voor Nederlandse Taal- &amp; Letterkunde</title>, 121 (2005)</note>
-                        <textLang mainLang="la" otherLangs="nl">Latin and Dutch</textLang>
+                        <textLang mainLang="la" otherLangs="dum">Latin and Middle Dutch</textLang>
                      </msItem>
                      <textLang mainLang="ang">Old English</textLang>
                   </msItem>

--- a/collections/Bodl/MS_Bodl_340.xml
+++ b/collections/Bodl/MS_Bodl_340.xml
@@ -177,13 +177,13 @@
                         <rubric> Passio alexandri papae.</rubric>
                         <note> At the end of the homily the scribe wrote 'Explicit hic liber'. The
                            verso of f. 169 of MS. 340 is blank, except for scribbles in Latin of
-                           verses, &amp;c., and a line of Middle Dutch (s. xi2), see following. One
+                           verses, &amp;c., and a line of Old Dutch (s. xi<hi rend="superscript">2</hi>), see following. One
                            of the hands on this page does not look English.</note>
                      </msItem>
                      <msItem>
                         <locus>(fol. 169v)</locus>
-                        <note>Pen trials, c. 1100, including verse in Dutch, 'Hebban olla vogala', pr. Sisam 1933; Erik Kwakkel, ‘Hebban Olla Vogala in Historisch Perspectief’, <title>Tijdschrift Voor Nederlandse Taal- &amp; Letterkunde</title>, 121 (2005)</note>
-                        <textLang mainLang="la" otherLangs="dum">Latin and Middle Dutch</textLang>
+                        <note>Pen trials, written shortly before 1100, including verses in Old Dutch, 'Hebban olla vogala', pr. <ref target="https://doi.org/10.1093/res/os-ix.33.1">Sisam 1933</ref>; Erik Kwakkel, <q><ref target="https://www.dbnl.org/tekst/_tij003200501_01/_tij003200501_01_0001.php"><title>Hebban olla vogala</title> in historisch perspectief</ref></q>, <title>Tijdschrift voor Nederlandse Taal- en Letterkunde</title>, 121 (2005)</note>
+                        <textLang mainLang="la" otherLangs="odt">Latin and Old Dutch</textLang>
                      </msItem>
                      <textLang mainLang="ang">Old English</textLang>
                   </msItem>

--- a/collections/Bodl/MS_Bodl_790.xml
+++ b/collections/Bodl/MS_Bodl_790.xml
@@ -165,7 +165,7 @@
                              n="1"
                              xml:id="MS_Bodl_790-part4-item1">
                         <title key="work_10326" type="desc">Astrological notes</title>
-                        <textLang mainLang="la" otherLangs="nl">Latin and Dutch</textLang>
+                        <textLang mainLang="la" otherLangs="dum">Latin and Middle Dutch</textLang>
                      </msItem>
                   </msContents>
                   <physDesc>

--- a/collections/Broxb/MS_Broxb_853.xml
+++ b/collections/Broxb/MS_Broxb_853.xml
@@ -39,7 +39,7 @@
                <msContents>
                   <msItem class="#oratio" n="1" xml:id="MS_Broxb_853-item1">
                      <title key="work_13943" type="desc">Prayers.</title>
-                     <textLang mainLang="nl">Dutch</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Broxb/MS_Broxb_855.xml
+++ b/collections/Broxb/MS_Broxb_855.xml
@@ -39,7 +39,7 @@
                <msContents>
                   <msItem class="#devotiones" n="1" xml:id="MS_Broxb_855-item1">
                      <title key="work_11531" type="desc">Devotions.</title>
-                     <textLang mainLang="nl">Dutch</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Broxb/MS_Broxb_8910.xml
+++ b/collections/Broxb/MS_Broxb_8910.xml
@@ -42,7 +42,7 @@
                      <bibl type="bible">
                         <title>Bible, Psalms</title>
                      </bibl>
-                     <textLang mainLang="nl">Dutch</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Broxb/MS_Broxb_8911.xml
+++ b/collections/Broxb/MS_Broxb_8911.xml
@@ -39,7 +39,7 @@
                <msContents>
                   <msItem class="#oratio" n="1" xml:id="MS_Broxb_8911-item1">
                      <title key="work_13935" type="desc">Prayer book.</title>
-                     <textLang mainLang="nl">Flemish</textLang>
+                     <textLang mainLang="dum">Middle Dutch (Flemish dialect)</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Broxb/MS_Broxb_8913.xml
+++ b/collections/Broxb/MS_Broxb_8913.xml
@@ -39,7 +39,7 @@
                <msContents>
                   <msItem class="#liturgica" n="1" xml:id="MS_Broxb_8913-item1">
                      <title key="work_10509" type="desc">Book of Hours.</title>
-                     <textLang mainLang="nl">Dutch</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Broxb/MS_Broxb_898.xml
+++ b/collections/Broxb/MS_Broxb_898.xml
@@ -39,7 +39,7 @@
                <msContents>
                   <msItem class="#liturgica" n="1" xml:id="MS_Broxb_898-item1">
                      <title key="work_10509" type="desc">Book of Hours.</title>
-                     <textLang mainLang="nl">Dutch</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Buchanan/MS_Buchanan_e_18.xml
+++ b/collections/Buchanan/MS_Buchanan_e_18.xml
@@ -39,7 +39,7 @@
                <msContents>
                   <msItem class="#liturgica" xml:id="MS_Buchanan_e_18-item1">
                      <title key="work_10563" type="desc">Book of Hours, Use of Rome</title>
-                     <textLang mainLang="la" otherLangs="nl">Latin and Netherlandish</textLang>
+                     <textLang mainLang="la" otherLangs="dum">Latin and Middle Dutch</textLang>
                      <msItem xml:id="MS_Buchanan_e_18-item1-item1">
                         <note>[Item 1 occupies quires I-II] </note>
                      </msItem>
@@ -144,10 +144,10 @@
                      <msItem xml:id="MS_Buchanan_e_18-item1-item16">
                         <locus>(fols. 136v-137v)</locus>
                         <note>Hymns</note>
-                        <note> The first with a rubric in Netherlandish</note>
+                        <note> The first with a rubric in Middle Dutch</note>
                         <msItem xml:id="MS_Buchanan_e_18-item1-item16-item1">
                            <locus>(fols. 136v-137v)</locus>
-                           <rubric xml:lang="nl">Vanden heilighen sacrament</rubric>
+                           <rubric xml:lang="dum">Vanden heilighen sacrament</rubric>
                            <incipit xml:lang="la">Pange lingua gloriosi corporis misterium </incipit>
                            <explicit>procedenti ab utroque comparsit laudatio</explicit>
                            <note>(<ref target="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=14467">Chevalier 14467</ref>), with a versicle and the prayer</note>
@@ -156,7 +156,7 @@
                               <note>(the latter pr. Bruylants, <title>Oraisons</title>, II, no. 393)</note>
                               <textLang mainLang="la">Latin</textLang>
                            </msItem>
-                           <textLang mainLang="la" otherLangs="nl">Latin and Netherlandish</textLang>
+                           <textLang mainLang="la" otherLangs="dum">Latin and Middle Dutch</textLang>
                         </msItem>
                         <msItem xml:id="MS_Buchanan_e_18-item1-item16-item2">
                            <locus>(fol. 137v)</locus>
@@ -169,12 +169,12 @@
                      <msItem xml:id="MS_Buchanan_e_18-item1-item17">
                         <locus>(fols. 137v-142v)</locus>
                         <note>Suffrages</note>
-                        <note>Predominantly to Dominican saints, in Latin and Netherlandish, with rubrics in Netherlandish (most consisting of an antiphon, versicle and response, followed by a rubric '<hi rend="italic">Te benedictus</hi>' and a second antiphon, versicle and response, before the collect) to: (i) Dominic, (ii) Peter Martyr ('<hi rend="italic">Van sinte pieter van melaene.</hi>'), (iii) Thomas Aquinas, (iv) Vincent Ferrer (canonised in 1455), (v) Catherine of Siena ('<hi rend="italic">Van sinte kath' vand' predicaers</hi>') (canonised in 1461), (vi) Donatian ('<hi rend="italic">Van sinte donaes. Archebijscop</hi>'), (vii) Elisabeth of Thuringia, the latter <locus>(fol. 142r-v)</locus> entirely in Netherlandish:</note>
+                        <note>Predominantly to Dominican saints, in Latin and Middle Dutch, with rubrics in Middle Dutch (most consisting of an antiphon, versicle and response, followed by a rubric '<hi rend="italic">Te benedictus</hi>' and a second antiphon, versicle and response, before the collect) to: (i) Dominic, (ii) Peter Martyr ('<hi rend="italic">Van sinte pieter van melaene.</hi>'), (iii) Thomas Aquinas, (iv) Vincent Ferrer (canonised in 1455), (v) Catherine of Siena ('<hi rend="italic">Van sinte kath' vand' predicaers</hi>') (canonised in 1461), (vi) Donatian ('<hi rend="italic">Van sinte donaes. Archebijscop</hi>'), (vii) Elisabeth of Thuringia, the latter <locus>(fol. 142r-v)</locus> entirely in Middle Dutch:</note>
                         <msItem xml:id="MS_Buchanan_e_18-item1-item17-item1">
                            <rubric>Van Sinte lysebette van dueringhen</rubric>
                            <incipit>O werde vrauwe sinte lisabette Ionc pogedi ondeuweghe vreden</incipit>
                            <explicit>Doet my beseffen. van huwen loone. Amen</explicit>
-                           <textLang mainLang="nl">Netherlandish</textLang>
+                           <textLang mainLang="dum">Middle Dutch</textLang>
                         </msItem>
                         <note>(prayers pr. in <title>Corpus orationum</title> are nos. (i) 1559, and (iii) 1562).</note>
                      </msItem>

--- a/collections/Buchanan/MS_Buchanan_f_3.xml
+++ b/collections/Buchanan/MS_Buchanan_f_3.xml
@@ -37,7 +37,7 @@
                   </altIdentifier>
                </msIdentifier>
                <head>
-                  <title>Book of Hours, in Dutch, Netherlandish, 15th century, second quarter</title>
+                  <title>Book of Hours, in Middle Dutch, Netherlandish, 15th century, second quarter</title>
                </head>
                <msContents>
                   <msItem class="#liturgica" xml:id="MS_Buchanan_f_3-part1-item1">

--- a/collections/Canon_Liturg/MS_Canon_Liturg_147.xml
+++ b/collections/Canon_Liturg/MS_Canon_Liturg_147.xml
@@ -40,7 +40,7 @@
                <msContents>
                   <msItem class="#liturgica" n="1" xml:id="MS_Canon_Liturg_147-item1">
                      <title key="work_10560" type="desc">Book of Hours, Use of Rome</title>
-                     <textLang mainLang="la" otherLangs="nl">Latin and Dutch</textLang>
+                     <textLang mainLang="la" otherLangs="dum">Latin and Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Canon_Liturg/MS_Canon_Liturg_148.xml
+++ b/collections/Canon_Liturg/MS_Canon_Liturg_148.xml
@@ -46,7 +46,7 @@
                           n="1"
                           xml:id="MS_Canon_Liturg_148-item1">
                      <title key="work_13969" type="desc">Prayers, meditations, etc.</title>
-                     <textLang mainLang="nl">Dutch</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Canon_Liturg/MS_Canon_Liturg_217.xml
+++ b/collections/Canon_Liturg/MS_Canon_Liturg_217.xml
@@ -40,13 +40,13 @@
                <msContents>
                   <msItem class="#liturgica #biblia #oratio" n="1" xml:id="MS_Canon_Liturg_217-item1">
                      <title key="work_13972" type="desc">Prayers, Psalms, and liturgical Offices</title>
-                     <textLang mainLang="nl">Dutch</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                   <msItem n="2" xml:id="MS_Canon_Liturg_217-item2">
                      <author key="person_66806872">Augustine</author>
                      <title key="work_791">Enchiridion</title>
                      <note>(Dutch translation)</note>
-                     <textLang mainLang="nl">Dutch</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Canon_Misc/MS_Canon_Misc_278.xml
+++ b/collections/Canon_Misc/MS_Canon_Misc_278.xml
@@ -42,11 +42,11 @@
                      <author key="person_56624842">Jacob van Maerlant</author>
                      <title key="work_2298">Martin</title>
                      <note>(with <title key="work_5925" type="desc">Latin translation</title> by <persName key="person_286134771" role="trl">Jan Bukelare</persName>)</note>
-                     <textLang mainLang="la" otherLangs="nl">Latin and Dutch</textLang>
+                     <textLang mainLang="la" otherLangs="dum">Latin and Middle Dutch</textLang>
                   </msItem>
                   <msItem class="#versus" n="2" xml:id="MS_Canon_Misc_278-item2">
                      <title key="work_15434" type="desc">Verses</title>
-                     <textLang mainLang="la" otherLangs="de frm nl">Latin, German (Dutch?) and Middle French</textLang>
+                     <textLang mainLang="la" otherLangs="frm dum">Latin, Middle Dutch, and Middle French</textLang>
                   </msItem>
                   <msItem class="#grammatica" n="3" xml:id="MS_Canon_Misc_278-item3">
                      <title key="work_11561">Disticha Catonis</title>
@@ -55,11 +55,11 @@
                   </msItem>
                   <msItem class="#proverbia" n="4" xml:id="MS_Canon_Misc_278-item4">
                      <title key="work_14062" type="desc">Proverbs</title>
-                     <textLang mainLang="de" otherLangs="nl">German (Dutch?)</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                   <msItem class="#versus #miscellanea" n="5" xml:id="MS_Canon_Misc_278-item5">
                      <title key="work_13842" type="desc">Poem of advice to a youth</title>
-                     <textLang mainLang="de" otherLangs="frm nl">German (Dutch?) and Middle French</textLang>
+                     <textLang mainLang="dum" otherLangs="frm">Middle Dutch and Middle French</textLang>
                   </msItem>
                </msContents>
                <physDesc>
@@ -71,7 +71,7 @@
                </physDesc>
                <history>
                   <origin>
-                     <origDate calendar="Gregorian" notAfter="1500" notBefore="1400">15th century</origDate>
+                     <origDate calendar="Gregorian" notAfter="1479" notBefore="1467">1467 × 1470s</origDate>
                   </origin>
                   <provenance notAfter="1805" notBefore="1727" resp="#MMM"><persName key="person_2384880" role="fmo">Matteo Luigi Canonici, 1727–1805</persName></provenance>
                   <provenance notAfter="1807" resp="#MMM"><persName key="person_446" role="fmo">Giuseppe Canonici , -1807</persName></provenance>
@@ -90,6 +90,7 @@
                   <listBibl type="WRAPPER">
                      <listBibl type="INTERNET">
                         <head>Online resources:</head>
+                        <bibl><ref target="http://hdl.handle.net/11240/82434293-a841-4824-9fe6-7acff5f40cb9"><title>BNM-I: Bibliotheca Neerlandica Manuscripta &amp; Impressa</title></ref></bibl>
                         <bibl><ref target="http://www.handschriftencensus.de/6989"><title>Handschriftencensus: Eine Bestandsaufnahme der handschriftlichen Überlieferung deutschsprachiger Texte des Mittelalters</title></ref></bibl>
                         <bibl><ref target="http://jonas.irht.cnrs.fr/manuscrit/76397"><title>JONAS: Répertoire des textes et des manuscrits médiévaux d'oc et d'oïl</title></ref></bibl>
                      </listBibl>

--- a/collections/DOrville/MS_DOrville_213.xml
+++ b/collections/DOrville/MS_DOrville_213.xml
@@ -40,7 +40,7 @@
                <msContents>
                   <msItem class="#liturgica" n="1" xml:id="MS_DOrville_213-item1">
                      <title key="work_10590" type="desc">Book of Hours, Use of Utrecht</title>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/DOrville/MS_DOrville_214.xml
+++ b/collections/DOrville/MS_DOrville_214.xml
@@ -40,7 +40,7 @@
                <msContents>
                   <msItem class="#liturgica" n="1" xml:id="MS_DOrville_214-item1">
                      <title key="work_10590" type="desc">Book of Hours, Use of Utrecht</title>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Douce/MS_Douce_243.xml
+++ b/collections/Douce/MS_Douce_243.xml
@@ -40,7 +40,7 @@
                <msContents>
                   <msItem class="#liturgica" n="1" xml:id="MS_Douce_243-item1">
                      <title key="work_10509" type="desc">Book of Hours</title>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Douce/MS_Douce_248.xml
+++ b/collections/Douce/MS_Douce_248.xml
@@ -40,7 +40,7 @@
                <msContents>
                   <msItem class="#liturgica" n="1" xml:id="MS_Douce_248-item1">
                      <title key="work_10509" type="desc">Book of Hours</title>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Douce/MS_Douce_266.xml
+++ b/collections/Douce/MS_Douce_266.xml
@@ -40,7 +40,7 @@
                <msContents>
                   <msItem class="#liturgica" n="1" xml:id="MS_Douce_266-item1">
                      <title key="work_10584" type="desc">Book of Hours, Use of Tournai</title>
-                     <textLang mainLang="nl" otherLangs="la">Netherlandish and Latin</textLang>
+                     <textLang mainLang="dum" otherLangs="la">Middle Dutch and Latin</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Douce/MS_Douce_373.xml
+++ b/collections/Douce/MS_Douce_373.xml
@@ -41,7 +41,7 @@
                      <author key="person_311822937">Gielis vander Hecken, 1491-1538</author>
                      <title key="work_13899">Labyrinthi</title>
                      <note>Thirty-three schematic diagrams, usually on the recto of a leaf; the facing verso containing explanatory Latin verses (6-line hexameters) usually with a Dutch paraphrase (three quatrains). The last drawing (fol. xxxii) is a diagrammatic map of <placeName key="place_7007868">Brussels</placeName>. Prefatory poems in Latin (fols. 2v-3r) and Dutch (fols. 3v-4r) state that the manuscript was assembled after Gielis's death (in 1538) by his cousin Joos vanden Hecke (Shepers, 261) and it has been argued that the explanatory poems, as well as the prefatory poems, were also added after 1538 (Schepers, 262; Evans, 39). This seems to be the text described in a contemporary account of Zevenborren: 'Item opus figurarum insigne, titulo Labyrinthi, quas a sacris paginis meditatus est, calamo scitissime delineavit depinxitque' (Schepers, 253), and which according to a later historian of Zevenborren was left to the house (J. B. Wiaert, <title>Historia Septifontana</title> (1688), p. 62).  </note>
-                     <textLang mainLang="la" otherLangs="nl">Latin and Dutch</textLang>
+                     <textLang mainLang="la" otherLangs="dum">Latin and Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Douce/MS_Douce_381.xml
+++ b/collections/Douce/MS_Douce_381.xml
@@ -218,7 +218,7 @@
                         <author key="person_40224714">Martijn van Thorout</author>
                         <title key="work_3106">Lives of Saints</title>
                         <note>(fragment)</note>
-                        <textLang mainLang="nl">Netherlandish</textLang>
+                        <textLang mainLang="dum">Middle Dutch</textLang>
                      </msItem>
                   </msContents>
                   <physDesc>
@@ -447,7 +447,7 @@
                         <locus>fols. 78–88</locus>
                         <title key="work_10505" type="desc">Book of Hours</title>
                         <note>(fragment, see also MS. Douce d. 19 fol. 71v)</note>
-                        <textLang mainLang="la" otherLangs="nl">Latin and Netherlandish</textLang>
+                        <textLang mainLang="la" otherLangs="dum">Latin and Middle Dutch</textLang>
                      </msItem>
                   </msContents>
                   <physDesc>
@@ -485,7 +485,7 @@
                         <locus>(fols. 89–103)</locus>
                         <title key="work_10509" type="desc">Book of Hours</title>
                         <note>(cuttings)</note>
-                        <textLang mainLang="nl">Netherlandish</textLang>
+                        <textLang mainLang="dum">Middle Dutch</textLang>
                      </msItem>
                   </msContents>
                   <physDesc>

--- a/collections/Douce/MS_Douce_44.xml
+++ b/collections/Douce/MS_Douce_44.xml
@@ -42,7 +42,7 @@
                      <author key="person_78750420">Mechtild von Hackeborn</author>
                      <title key="work_3165">Liber specialis gratiae</title>
                      <note>books 2, 3, 4</note>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Dutch/MS_Dutch_b_2.xml
+++ b/collections/Dutch/MS_Dutch_b_2.xml
@@ -45,7 +45,7 @@
                      <author key="person_100198644">Jacobus de Voragine</author>
                      <title key="work_2327">Legenda Aurea</title>
                      <note>(one leaf)</note>
-                     <textLang mainLang="nl">Dutch</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Dutch/MS_Dutch_e_1.xml
+++ b/collections/Dutch/MS_Dutch_e_1.xml
@@ -39,7 +39,7 @@
                <msContents>
                   <msItem class="#liturgica" n="1" xml:id="MS_Dutch_e_1-item1">
                      <title key="work_10590" type="desc">Book of Hours, Use of Utrecht</title>
-                     <textLang mainLang="nl">Dutch</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                      <msItem xml:id="MS_Dutch_e_1-item1-item1">
                         <locus>(fol. 3r)</locus>
                         <note>Calendar, with Sts. Pontianus, Pancratius, Servatius, Boniface, Odulfus, Lebuinus, Geroen, and Wilibrord, all in red; and St. Engelmont (21 June)</note>

--- a/collections/Dutch/MS_Dutch_e_2.xml
+++ b/collections/Dutch/MS_Dutch_e_2.xml
@@ -37,13 +37,13 @@
                   </altIdentifier>
                </msIdentifier>
                <msContents>
+                  <textLang mainLang="dum">Middle Dutch</textLang>
                   <msItem class="#vitae_sanctorum" n="1" xml:id="MS_Dutch_e_2-item1">
                      <locus>(fols. 1r-159r)</locus>
                      <title key="work_13054" type="desc">Lives of Saints</title>
                      <note>Starting imperfect. Fol. 159v blank.</note>
                      <incipit defective="true">bloede. ende dauid vas sijn geboerte treckende wt der stat van bethleem</incipit>
                      <explicit>Des gonne ons die heer die vader daer te lauen alle gader Amen</explicit>
-                     <textLang mainLang="nl">Dutch</textLang>
                   </msItem>
                   <msItem xml:id="MS_Dutch_e_2-item2">
                      <locus>(fols. 160r-214r)</locus>
@@ -53,7 +53,6 @@
                      <rubric>Van enen wonderliken ende merckeliken gesicht van eenre zielen die geordelt <del>was</del> solde werden Ende van der wroeginge des duuels ...</rubric>
                      <incipit>Een persoen waekende in hoeren gebede ende niet slapende sach in een geestelick gesichte</incipit>
                      <explicit>Dese reuelacie is gespraken van iij vrouwen van den derde die noch leuende was ghinck in een cloester volbregende dat ouerloep oers leuens in groet heilicheit</explicit>
-                     <textLang mainLang="nl">Dutch</textLang>
                   </msItem>
                   <msItem xml:id="MS_Dutch_e_2-item3">
                      <locus>(fol. 214v)</locus>

--- a/collections/Dutch/MS_Dutch_f_1.xml
+++ b/collections/Dutch/MS_Dutch_f_1.xml
@@ -39,9 +39,9 @@
                </msIdentifier>
                <head>Private devotions; Netherlands, late 15th cent.</head>
                <msContents>
+                  <textLang mainLang="dum">Middle Dutch</textLang>
                   <msItem class="#oratio #devotiones" n="1" xml:id="MS_Dutch_f_1-item1">
                      <title key="work_13958" type="desc">Prayers and meditations for private use</title>
-                     <textLang mainLang="nl">Dutch</textLang>
                      <msItem class="#liturgica" xml:id="MS_Dutch_f_1-item1-item1">
                         <locus>[Items 1–3 occupy Quire I]</locus>
                         <locus>(fols. 1–11v)</locus>
@@ -49,7 +49,6 @@
                         <rubric>Hier beginnient die getijde van den lijden ons lieven heren Ihesus Christus</rubric>
                         <incipit>Gedenck des bermentlicken affscheidens dat ons lieve Here <note>(vespers)</note></incipit>
                         <incipit>O lieve gemijnder sueter Here <note>(prayer for vespers)</note></incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem class="#oratio" n="2" xml:id="MS_Dutch_f_1-item1-item2">
                         <locus>(fols. 11v-15r)</locus>
@@ -57,7 +56,6 @@
                         <note>A series of seven prayers, here attributed to <persName cert="low" key="person_79150891" role="aut">Pope Innocent V</persName>, carrying an indulgence</note>
                         <rubric>Die paus Innocentius quintus dichte dese oracien op die seven getijden der heiliger kercken</rubric>
                         <incipit>Du schoen god und licht alle onser duijsternisse Suete here Ihesus christus weest ons een geleide in deser ellendiger werlt</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem class="#liturgica" n="3" xml:id="MS_Dutch_f_1-item1-item3">
                         <locus>(fols. 15r-17r)</locus>
@@ -65,7 +63,6 @@
                         <rubric>Dijt sijnt die getijden op onser liever vrouwen druk die sante Clemens die paus gemacket hevet…</rubric>
                         <incipit>Toe metten tijt wart Maria gebaetschopt</incipit>
                         <note>Another MS. is Brussels, Bibl. Royale 21953, fol.365, see M. Meertens, <title>De Godsvrucht in de Nederlanden</title> VI, 1934, p. 139. Fol. 17v–18v are blank.</note>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem class="#oratio" n="4" xml:id="MS_Dutch_f_1-item1-item4">
                         <locus>[Items 4–5 occupy quires II-IV]</locus>
@@ -81,7 +78,6 @@
                            <note>The last (fol. 39) begins:</note>
                            <incipit>O barmhertige Godes soen o suete here Ihesus</incipit>
                         </msItem>
-                        <textLang mainLang="nl">Dutch</textLang>
                         <finalRubric>Hier ennden die gebeder von der kijntheit Ihesus enn van synre wandelinge mytten mynschen in der erden</finalRubric>
                      </msItem>
                      <msItem class="#oratio" n="5" xml:id="MS_Dutch_f_1-item1-item5">
@@ -91,7 +87,6 @@
                         <rubric>Hiernae volgen die gebeder van der passien Christus</rubric>
                         <note>The first begins:</note>
                         <incipit>Ick gebenedie enn danck du here I.C. barmhertige verloesser der geloinger</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem class="#contemplationes #oratio" n="6" xml:id="MS_Dutch_f_1-item1-item6">
                         <locus>[Items 6–8 occupy quires V-VI]</locus>
@@ -115,19 +110,16 @@
                            <incipit>O guede Ihesus gij wart in den cruce verhaven</incipit>
                         </msItem>
                         <note>Most of the remaining prayers begin with formulae similar to the third and fourth</note>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem class="#oratio" n="7" xml:id="MS_Dutch_f_1-item1-item7">
                         <locus>(fols. 77v-78r)</locus>
                         <title type="desc">Prayer</title>
                         <incipit>Ick doepe my alle dage seven werff</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem n="8" xml:id="MS_Dutch_f_1-item1-item8">
                         <locus>(fol.78v)</locus>
                         <rubric>Dit naegeschreven gebedeken wart sante Augustijnus geapenbaert…</rubric>
                         <incipit>O alre lieffste here I.C. om die alre suetste wonde</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem n="9" xml:id="MS_Dutch_f_1-item1-item9">
                         <locus>[Items 9–11 occupy quire VII]</locus>
@@ -135,14 +127,12 @@
                         <rubric>Dyt gebet plach die heilige vader sante Bernardus</rubric>
                         <incipit>O guede Ihesus, O mijlde Ihesus</incipit>
                         <note>The Latin text is pr. Leroquais, <hi rend="italic">Livres d'heures</hi> II.345</note>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem n="10" xml:id="MS_Dutch_f_1-item1-item10">
                         <locus>(fols.81r-84v)</locus>
                         <title>Prayer</title>
                         <rubric>Hier begijnt cen suverlick gebet van den sueten gebenediden naem Ihesus</rubric>
                         <incipit>O du barmhertige Ihesus</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem class="#oratio" n="11" xml:id="MS_Dutch_f_1-item1-item11">
                         <locus>(fol.85r)</locus>
@@ -177,7 +167,6 @@
                            <rubric>vanden geboerten Ihesus gebet</rubric>
                            <incipit>O alre sueste guedertierenste enn (?) mynlicste kynt Ihesus woe groet is die volheit dynre mylder sueter barmherticheit in dijnre dancbariger toe comst</incipit>
                         </msItem>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem n="12" xml:id="MS_Dutch_f_1-item1-item12">
                         <locus>[Items 12–13 occupy quire VIII]</locus>
@@ -185,13 +174,11 @@
                         <rubric>Hier begijnt eyn schoen gebet van den liden ons lieven heren</rubric>
                         <incipit type="preface">Nu begeet ic aen te sien Christus liden enn myn leven</incipit>
                         <incipit type="text">O alre lieffste mylde barmhertige genedige suete gemynde here I.C.</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem n="13" xml:id="MS_Dutch_f_1-item1-item13">
                         <locus>(fol.98v)</locus>
                         <rubric>Eyn gebet van onsen lieven heren</rubric>
                         <incipit>O myn gemynde rotvercoeren rotdusenden ic offer dujr die onspreckelicke sueticheit die van ewicheit rot dynen gotlicken herten gebloeten heest in den vader</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem class="#oratio" n="14" xml:id="MS_Dutch_f_1-item1-item14">
                         <locus>[Items 14–21 occupy quires IX-X]</locus>
@@ -200,7 +187,6 @@
                         <rubric>Hier begijnt eijn schoen oeffinge enn dancberheit Doer die wecke toe der heiliger drieuoldicheit enn is seer guet gelesen die mannendach</rubric>
                         <note>One for each day of the week, the first (for Monday) beg.:</note>
                         <incipit>O almechtich ewige got, O heilige drievoldicheit</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem class="#devotiones" n="15" xml:id="MS_Dutch_f_1-item1-item15">
                         <locus>(fols. 103v-107r)</locus>
@@ -208,27 +194,23 @@
                         <incipit type="preface">Onse lieve here sprack</incipit>
                         <incipit type="text">Vader ons… Ick offer dij lieve here hemelsche vader.</incipit>
                         <note>Also in Brussels Bibl. Royale MS.11231–6, fol.184v, see Neertens op.cit. VI.65</note>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem class="#oratio" n="16a" xml:id="MS_Dutch_f_1-item1-item16">
                         <locus>(fol.107r-108r)</locus>
                         <title type="desc">Prayer</title>
                         <rubric>Soe wije dit gebet leest mit ennen pater noster voer onser lieuer vrouwen beelt ter noet die verdient xxx dusent iaer aflaets pater noster</rubric>
                         <incipit>Ic offer dij fonteijne der genaden (?) Dit pater noster enn aue maria</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem class="#oratio" n="16b" xml:id="MS_Dutch_f_1-item1-item17">
                         <locus>(fol.108r-v)</locus>
                         <title type="desc">Prayer</title>
                         <rubric>Soe wie dit gebet leest mit eijnen pater noster voer dat gecroende hoest ons lieuen heren die verdient drie dusent iaer aflaits</rubric>
                         <incipit>O lieve here ic gruet dijn heilige hoeft gecroent mit dornen</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem n="17" xml:id="MS_Dutch_f_1-item1-item18">
                         <locus>(fol.108v)</locus>
                         <rubric>Als gij in die kerc komt so seget aldus’</rubric>
                         <incipit>O lieve here ic valle u te voeten</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem n="18" xml:id="MS_Dutch_f_1-item1-item19">
                         <locus>(fols. 109r-116v)</locus>
@@ -242,13 +224,11 @@
                            <note>Followed by three further prayers, the first:</note>
                            <incipit>O wee eyn geboeren soen troester</incipit>
                         </msItem>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem n="19" xml:id="MS_Dutch_f_1-item1-item20">
                         <locus>(fol.117)</locus>
                         <rubric>Hier begijnt eyn ynnich gebet totter moder Godes voer die ontfenckenisse des heiligen sacrements</rubric>
                         <incipit>Ick biddij gebenedide vrouwe Maria hemelsche keiserijnne</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem n="20" xml:id="MS_Dutch_f_1-item1-item21">
                         <locus>(fol.117v)</locus>
@@ -259,13 +239,11 @@
                            <author key="person_78750420">Mechtild of Hackeborn</author>
                            <title>Liber specialis gratiae</title>
                         </bibl>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem class="#oratio" n="21" xml:id="MS_Dutch_f_1-item1-item22">
                         <locus>(fol.118v)</locus>
                         <title type="desc">Prayer to Our Lady</title>
                         <incipit>O Marie eijn rosen bloym der kuysheit</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem class="#devotiones" n="22" xml:id="MS_Dutch_f_1-item1-item23">
                         <locus>[Items 22–23 occupy quires XI-XIII</locus>
@@ -273,35 +251,30 @@
                         <title type="desc">Devotional work prescribing prayers and meditations for use by religious throughout the day</title>
                         <incipit>Des morgens toe vier uren soe richt u wackerlic</incipit>
                         <explicit>soe gedijncket der geboerte des alren soetste soen gotz</explicit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem class="#devotiones" n="23" xml:id="MS_Dutch_f_1-item1-item24">
                         <locus>(fol.151)</locus>
                         <title type="desc">Devotion of seven Pater Nosters and Ave Marias</title>
                         <note>According to the rubric given by an angel to a pilgrim on the road to Rome during the ‘annus aureus’</note>
                         <incipit>Dat erste Pater Noster enn Ave Maria soldij sprecken in der eeren</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem class="#oratio" n="24" xml:id="MS_Dutch_f_1-item1-item25">
                         <locus>[Items 24–26 occupy quires XIV-XV]</locus>
                         <locus>(fol.153)</locus>
                         <title type="desc">Prayers on the Passion</title>
                         <incipit>O mijn alre liefste here I.C. alset sich nakende was dijnre bitterre passien</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                         <!-- more detailed list in PJK files, but draft only -->
                      </msItem>
                      <msItem class="#devotiones" n="25" xml:id="MS_Dutch_f_1-item1-item26">
                         <locus>(fol.174v)</locus>
                         <title type="desc">Dialogue between Christ and a good man</title>
                         <incipit>Eijn guet mensche eerden ons Heren geboert enn sijn leven</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem class="#sacramenta" n="26" xml:id="MS_Dutch_f_1-item1-item27">
                         <locus>(fol.177)</locus>
                         <!-- from PJK -->
                         <title type="desc">Instructions on preparation for confession</title>
                         <incipit>Item als die mensche sijn bicht doet soe heeft hij mijt gode gerekent enn sijn scholt bekeen</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem class="#sacramenta" n="27" xml:id="MS_Dutch_f_1-item1-item28">
                         <locus>[Items 27–30 occupy quires XVI-XVII]</locus>
@@ -327,20 +300,17 @@
                         <rubric>Een suverlicke leeringe van den religiosen hoe hy leven sal</rubric>
                         <incipit>Sante Pauwels seyt recht als die doede heeft verloeren</incipit>
                         <explicit>nyet daer tegen werdigen en mach</explicit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem class="#devotiones" n="28" xml:id="MS_Dutch_f_1-item1-item32">
                         <locus>[Items 28–32 occupy quire XVIII]</locus>
                         <locus>(fol.201)</locus>
                         <title type="desc">Devotion</title>
                         <incipit>Bystu een getrouwe bruit soe en laet die wapen</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem n="29" xml:id="MS_Dutch_f_1-item1-item33">
                         <locus>(fol.203)</locus>
                         <rubric>Hier begijnnen drie punten die sant Bernardus synen broederen liet aen synen lesten eynde toe eenen testament</rubric>
                         <incipit>Dat eerste is dat ich nyemant schandelisieren</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem n="30" xml:id="MS_Dutch_f_1-item1-item34">
                         <locus>(fols. 203v-204r)</locus>
@@ -361,7 +331,6 @@
                         <locus>(fol.213)</locus>
                         <title type="desc">Prayers on the sacrament</title>
                         <incipit>Here I.C. connick der engelen</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                         <msItem xml:id="MS_Dutch_f_1-item1-item37-item1">
                            <locus>(fol.216)</locus>
                            <incipit>O here I.C. connick der glorien</incipit>
@@ -458,13 +427,11 @@
                         <title type="desc">Meditation on the sacrament</title>
                         <incipit>In tween manieren ontfangen wy onsen lieven heren</incipit>
                         <explicit>van vorten gelaeten</explicit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem n="35" xml:id="MS_Dutch_f_1-item1-item39">
                         <locus>(fol.241)</locus>
                         <rubric>Van den heiligen sacrament</rubric>
                         <incipit>Eyn mensche die gerne toe ons heren licham geit</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem class="#exempla" n="36" xml:id="MS_Dutch_f_1-item1-item40">
                         <locus>(fol.242v)</locus>
@@ -472,39 +439,33 @@
                         <note>in which Christ appears to a good man in the form of a child, and promises him life everlasting</note>
                         <rubric>Eyn leringe</rubric>
                         <incipit>Eyn guet mensche die plach te eren</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem class="#oratio" n="37a" xml:id="MS_Dutch_f_1-item1-item41">
                         <locus>[Items 37–34 occupy quire XXIII]</locus>
                         <locus>(fol.245)</locus>
                         <title type="desc">Prayer</title>
                         <incipit>O utfruchtende enn verschrecklick Got</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem class="#oratio" n="37b" xml:id="MS_Dutch_f_1-item1-item42">
                         <locus>(fol.245v)</locus>
                         <title type="desc"> Prayer for all souls</title>
                         <incipit>Weest gegruet alle gelouyge selen</incipit>
                         <note>The Latin is pr.Leroquis <hi rend="italic">Livres d'heures</hi> II.341. For other MSS. of this version see Meertens VI.43</note>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem class="#liturgica" n="38" xml:id="MS_Dutch_f_1-item1-item43">
                         <locus>(fol.245v)</locus>
                         <title type="desc">Litany of the dead</title>
                         <incipit>O here vader genadige Got wanttu eyn troester</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem class="#oratio" n="39" xml:id="MS_Dutch_f_1-item1-item44">
                         <locus>(fol.247v)</locus>
                         <title type="desc">Prayer to St. Anthony the abbot</title>
                         <incipit>O heilige vader sante Anthonyus du biste eyn marscalck des heiligen levens</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem n="40" xml:id="MS_Dutch_f_1-item1-item45">
                         <locus>(fol.249)</locus>
                         <rubric>Dijt sal eyn mensche sprecken of hoeren voer synen dode</rubric>
                         <incipit>O mijn Got enn o myn here vader alre barmherticheit</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem n="41" xml:id="MS_Dutch_f_1-item1-item46">
                         <locus>(fols. 250r-251r)</locus>
@@ -516,13 +477,11 @@
                         <title type="desc">Prayer after communicating</title>
                         <rubric>Eyn guet gebet nae der ontfenckenys</rubric>
                         <rubric>O here hemelsche vader du heb ick ontfangen</rubric>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                      <msItem class="#sacramenta #oratio" n="43" xml:id="MS_Dutch_f_1-item1-item48">
                         <locus>(fol.252)</locus>
                         <title type="desc">Prayer after communicating</title>
                         <rubric>O here nu heb ick ontfangen dynen heiligen licham</rubric>
-                        <textLang mainLang="nl">Dutch</textLang>
                      </msItem>
                   </msItem>
                </msContents>

--- a/collections/E_D_Clarke/MS_E_D_Clarke_30.xml
+++ b/collections/E_D_Clarke/MS_E_D_Clarke_30.xml
@@ -40,7 +40,7 @@
                <msContents>
                   <msItem class="#liturgica" n="1" xml:id="MS_E_D_Clarke_30-item1">
                      <title key="work_10589" type="desc">Book of Hours, Use of Utrecht</title>
-                     <textLang mainLang="nl" otherLangs="la">Dutch and Latin</textLang>
+                     <textLang mainLang="dum" otherLangs="la">Middle Dutch and Latin</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Fragments_printed_books/Auct_2Q_5_7.xml
+++ b/collections/Fragments_printed_books/Auct_2Q_5_7.xml
@@ -47,7 +47,7 @@
                      <title key="work_6229">Epistola de gubernatione rei familiaris</title>
                      <incipit>Ick Bernaert ghecomen terhoutheden ontbiede saluut dem gracieusen ende zalighen riddere</incipit>
                      <note>Manuscript insertion in printed book (Bod-Inc C-170(1)).</note>
-                     <textLang mainLang="nl">Dutch</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Lat_liturg/MS_Lat_liturg_f_3.xml
+++ b/collections/Lat_liturg/MS_Lat_liturg_f_3.xml
@@ -54,7 +54,7 @@
                <msContents>
                   <msItem class="#liturgica" n="1" xml:id="MS_Lat_liturg_f_3-item1">
                      <title key="work_10556" type="desc">Book of Hours, Use of Rome.</title>
-                     <textLang mainLang="nl" otherLangs="la">Dutch and Latin</textLang>
+                     <textLang mainLang="dum" otherLangs="la">Middle Dutch and Latin</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Lat_liturg/MS_Lat_liturg_g_3.xml
+++ b/collections/Lat_liturg/MS_Lat_liturg_g_3.xml
@@ -39,14 +39,14 @@
                </msIdentifier>
                <msContents>
                   <msItem n="1" xml:id="MS_Lat_liturg_g_3-item1">
-                     <title key="work_13954">Prayers and devotions to St.Bartholomew</title>
+                     <title key="work_13954">Prayers and devotions to St Bartholomew</title>
                      <note>to be said privately before, during and after Mass, Office and meals throughout the patronal festival.</note>
                      <textLang mainLang="la">Latin</textLang>
                      <msItem xml:id="MS_Lat_liturg_g_3-item1-item1">
                         <locus>(fols. 25v)</locus>
                         <title>Prayer with neums</title>
                         <incipit>Siint Bartholomeus du hemmel</incipit>
-                        <textLang mainLang="nl">Dutch</textLang>
+                        <textLang mainLang="dum">Middle Dutch</textLang>
                      </msItem>
                   </msItem>
                </msContents>

--- a/collections/Lat_misc/MS_Lat_misc_b_26.xml
+++ b/collections/Lat_misc/MS_Lat_misc_b_26.xml
@@ -505,7 +505,7 @@
                         <locus>(fols. 100–114)</locus>
                         <title key="work_11618">Documents</title>
                         <note>(fols. 100–111) French, three complete documents and six (?) incomplete items, late 14th – 17th cent. (fol. 112) Dutch, part of a document in Dutch, 16th cent.; and (fol. 113) Italian, a Latin document from the chancery of the Archbishop of <placeName key="place_7011179">Siena</placeName> , 1544.</note>
-                        <textLang mainLang="la" otherLangs="nl">Latin and Dutch</textLang>
+                        <textLang mainLang="la" otherLangs="dum">Latin and Middle Dutch</textLang>
                      </msItem>
                   </msContents>
                   <physDesc>

--- a/collections/Lat_misc/MS_Lat_misc_e_122.xml
+++ b/collections/Lat_misc/MS_Lat_misc_e_122.xml
@@ -107,8 +107,8 @@
                   <msContents>
                      <msItem xml:id="MS_Lat_misc_e_122-part2-item1">
                         <locus>(fols.2–16) </locus>
-                        <note>Once the front pastedown and presumably the cartonnage of the pad or pads removed in 1948 ‘from the cover of 8o Rawl. 178’ (Pindar, gr., Basel, A. Cratander 1526, in a contemporary Louvain binding with blind-panels of acorn design, see J.B. Oldham, <hi rend="italic">Blind Panels of English binders</hi>, Cambridge 1958, p. 14, pl. II, no. AC. 7). No original dimensions recoverable. Nos. 1–3, Latin; nos. 4–8, Netherlandish.</note>
-                        <textLang mainLang="nl" otherLangs="la">Netherlandish and Latin</textLang>
+                        <note>Once the front pastedown and presumably the cartonnage of the pad or pads removed in 1948 ‘from the cover of 8o Rawl. 178’ (Pindar, gr., Basel, A. Cratander 1526, in a contemporary Louvain binding with blind-panels of acorn design, see J.B. Oldham, <hi rend="italic">Blind Panels of English binders</hi>, Cambridge 1958, p. 14, pl. II, no. AC. 7). No original dimensions recoverable. Nos. 1–3, Latin; nos. 4–8, Middle Dutch.</note>
+                        <textLang mainLang="dum" otherLangs="la">Middle Dutch and Latin</textLang>
                      </msItem>
                   </msContents>
                   <history>
@@ -209,7 +209,7 @@
                            <locus>(fols. 9, 10)</locus>
                            <title key="work_10064">Accounts (?)</title>
                            <note>(fragments)</note>
-                           <textLang mainLang="nl">Netherlandish</textLang>
+                           <textLang mainLang="dum">Middle Dutch</textLang>
                         </msItem>
                      </msContents>
                      <physDesc>
@@ -236,7 +236,7 @@
                            <locus>(fol.11)</locus>
                            <title key="work_12639">Letter</title>
                            <note>(fragment)</note>
-                           <textLang mainLang="nl">Netherlandish</textLang>
+                           <textLang mainLang="dum">Middle Dutch</textLang>
                         </msItem>
                      </msContents>
                      <physDesc>
@@ -262,8 +262,8 @@
                         <msItem xml:id="MS_Lat_misc_e_122-part2-part6-item1">
                            <locus>(fol.11)</locus>
                            <title key="work_12723">Letter-book (?)</title>
-                           <note>Two fragments mentioning personal and place-names (e.g. Antwerp, England), in Netherlandish but with occasional Latin glosses, possibly from a letter-book</note>
-                           <textLang mainLang="nl" otherLangs="la">Netherlandish and Latin</textLang>
+                           <note>Two fragments mentioning personal and place-names (e.g. Antwerp, England), in Dutch but with occasional Latin glosses, possibly from a letter-book</note>
+                           <textLang mainLang="dum" otherLangs="la">Middle Dutch and Latin</textLang>
                         </msItem>
                      </msContents>
                      <physDesc>
@@ -290,7 +290,7 @@
                            <locus>(fol.11)</locus>
                            <title key="work_15440">Verses on biblical subjects</title>
                            <note>Fragment; including a set on the miracle at Cana, beg. ‘Als Cristus out was xxx jaer/doe(n) maecte hij vande(n) wat[e]r wij[n]…’, with (verso) crude drawings of buildings. Fol. 15 blank.</note>
-                           <textLang mainLang="nl" otherLangs="la">Netherlandish and Latin</textLang>
+                           <textLang mainLang="dum" otherLangs="la">Middle Dutch and Latin</textLang>
                         </msItem>
                      </msContents>
                      <physDesc>

--- a/collections/Liturg/MS_Liturg_29.xml
+++ b/collections/Liturg/MS_Liturg_29.xml
@@ -44,7 +44,7 @@
                   <msItem class="#liturgica" n="1" xml:id="MS_Liturg_29-item1">
                      <title key="work_10560" type="desc">Book of Hours, Use of Rome</title>
                      <note>Additions in Dutch.</note>
-                     <textLang mainLang="la" otherLangs="nl">Latin and Dutch</textLang>
+                     <textLang mainLang="la" otherLangs="dum">Latin and Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Marshall/MS_Marshall_109.xml
+++ b/collections/Marshall/MS_Marshall_109.xml
@@ -42,7 +42,7 @@
                           n="1"
                           xml:id="MS_Marshall_109-item1">
                      <title key="work_13039" type="desc">Liturgical texts and devotional treatises, including Psalter of the Virgin Mary, prayers to the Virgin, and Office of the Passion</title>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Marshall/MS_Marshall_11.xml
+++ b/collections/Marshall/MS_Marshall_11.xml
@@ -44,7 +44,7 @@
                      <bibl type="bible">
                         <title>Bible, New Testament</title>
                      </bibl>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Marshall/MS_Marshall_110.xml
+++ b/collections/Marshall/MS_Marshall_110.xml
@@ -40,7 +40,7 @@
                <msContents>
                   <msItem class="#devotiones" n="1" xml:id="MS_Marshall_110-item1">
                      <title key="work_13991" type="desc">Private devotions</title>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Marshall/MS_Marshall_119.xml
+++ b/collections/Marshall/MS_Marshall_119.xml
@@ -41,7 +41,7 @@
                   <msItem n="1" xml:id="MS_Marshall_119-item1">
                      <author key="person_19689348">Jan van Ruysbroek (Ruusbroec)</author>
                      <title key="work_2358">Devotional treatises</title>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Marshall/MS_Marshall_123.xml
+++ b/collections/Marshall/MS_Marshall_123.xml
@@ -40,7 +40,7 @@
                <msContents>
                   <msItem class="#liturgica" n="1" xml:id="MS_Marshall_123-item1">
                      <title key="work_10546" type="desc">Book of Hours, Use of Liège</title>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Marshall/MS_Marshall_124.xml
+++ b/collections/Marshall/MS_Marshall_124.xml
@@ -40,13 +40,13 @@
                <msContents>
                   <msItem class="#sermones #devotiones" n="1" xml:id="MS_Marshall_124-item1">
                      <title key="work_11527" type="desc">Devotional treatises and sermons</title>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                   <msItem n="2" xml:id="MS_Marshall_124-item2">
                      <author key="person_59077661">Thomas à Kempis</author>
                      <title key="work_4860">Imitatio Christi</title>
                      <note>(incomplete translation of bks 1 and 2)</note>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Marshall/MS_Marshall_125.xml
+++ b/collections/Marshall/MS_Marshall_125.xml
@@ -40,7 +40,7 @@
                <msContents>
                   <msItem class="#liturgica" n="1" xml:id="MS_Marshall_125-item1">
                      <title key="work_10545" type="desc">Book of Hours, Use of Liège (?).</title>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Marshall/MS_Marshall_127.xml
+++ b/collections/Marshall/MS_Marshall_127.xml
@@ -42,7 +42,7 @@
                      <author key="person_306415749">Ps.-Bernard of Clairvaux</author>
                      <title key="work_3950">Formula honestae vitae</title>
                      <note>(Dutch translation)</note>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Marshall/MS_Marshall_128.xml
+++ b/collections/Marshall/MS_Marshall_128.xml
@@ -40,7 +40,7 @@
                <msContents>
                   <msItem class="#liturgica" n="1" xml:id="MS_Marshall_128-item1">
                      <title key="work_10508" type="desc">Book of Hours</title>
-                     <textLang mainLang="nl" otherLangs="la">Netherlandish and Latin</textLang>
+                     <textLang mainLang="dum" otherLangs="la">Middle Dutch and Latin</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Marshall/MS_Marshall_25.xml
+++ b/collections/Marshall/MS_Marshall_25.xml
@@ -44,7 +44,7 @@
                   <msItem n="1" xml:id="MS_Marshall_25-item1">
                      <author key="person_19689348">Jan van Ruysbroek (Ruusbroec)</author>
                      <title key="work_2359">Expositie van den Tabernacule</title>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Marshall/MS_Marshall_28.xml
+++ b/collections/Marshall/MS_Marshall_28.xml
@@ -40,7 +40,7 @@
                <msContents>
                   <msItem class="#scientifica" n="1" xml:id="MS_Marshall_28-item1">
                      <title key="work_14442">Romance of Sydrac and Boctus</title>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Marshall/MS_Marshall_48.xml
+++ b/collections/Marshall/MS_Marshall_48.xml
@@ -49,28 +49,28 @@
                      <bibl type="bible">
                         <title>Bible, Catholic Epistles</title>
                      </bibl>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                   <msItem class="#biblia" n="2" xml:id="MS_Marshall_48-item2">
                      <title key="work_10100" type="desc">Acts of the Apostles</title>
                      <bibl type="bible">
                         <title>Bible, Acts</title>
                      </bibl>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                   <msItem class="#biblia" n="3" xml:id="MS_Marshall_48-item3">
                      <title key="work_10228" type="desc">Apocalypse</title>
                      <bibl type="bible">
                         <title>Bible, Apocalypse</title>
                      </bibl>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                   <msItem class="#biblia" n="4" xml:id="MS_Marshall_48-item4">
                      <title key="work_14042" type="desc">Prophetical passages from the Old Testament</title>
                      <bibl type="bible">
                         <title>Bible, Old Testament</title>
                      </bibl>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Marshall/MS_Marshall_58.xml
+++ b/collections/Marshall/MS_Marshall_58.xml
@@ -43,7 +43,7 @@
                      <bibl type="bible">
                         <title>Bible, Gospels</title>
                      </bibl>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Marshall/MS_Marshall_90.xml
+++ b/collections/Marshall/MS_Marshall_90.xml
@@ -43,7 +43,7 @@
                      <bibl type="bible">
                         <title>Bible, Old Testament</title>
                      </bibl>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Rawl_C/MS_Rawl_C_12.xml
+++ b/collections/Rawl_C/MS_Rawl_C_12.xml
@@ -40,7 +40,7 @@
                <msContents>
                   <msItem class="#liturgica" n="1" xml:id="MS_Rawl_C_12-item1">
                      <title key="work_10509" type="desc">Book of Hours.</title>
-                     <textLang mainLang="nl">Dutch</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Rawl_D/MS_Rawl_D_484.xml
+++ b/collections/Rawl_D/MS_Rawl_D_484.xml
@@ -40,7 +40,7 @@
                <msContents>
                   <msItem class="#christologia" n="1" xml:id="MS_Rawl_D_484-item1">
                      <title key="work_12830" type="desc">Life of Christ</title>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Rawl_D/MS_Rawl_D_533.xml
+++ b/collections/Rawl_D/MS_Rawl_D_533.xml
@@ -40,7 +40,7 @@
                <msContents>
                   <msItem class="#legalia" n="1" xml:id="MS_Rawl_D_533-item1">
                      <title key="work_12521" type="desc">Laws of the city of <placeName key="place_7007867">Bruges</placeName></title>
-                     <textLang mainLang="nl">Dutch</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Rawl_liturg/MS_Rawl_liturg_e_9-star.xml
+++ b/collections/Rawl_liturg/MS_Rawl_liturg_e_9-star.xml
@@ -40,7 +40,7 @@
                <msContents>
                   <msItem class="#liturgica" n="1" xml:id="MS_Rawl_liturg_e_9-star-item1">
                      <title key="work_10509" type="desc">Book of Hours</title>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Rawl_liturg/MS_Rawl_liturg_f_38.xml
+++ b/collections/Rawl_liturg/MS_Rawl_liturg_f_38.xml
@@ -40,7 +40,7 @@
                <msContents>
                   <msItem class="#liturgica" n="1" xml:id="MS_Rawl_liturg_f_38-item1">
                      <title key="work_10532" type="desc">Book of Hours, Use of Brussels</title>
-                     <textLang mainLang="nl" otherLangs="la">Netherlandish, Latin</textLang>
+                     <textLang mainLang="dum" otherLangs="la">Middle Dutch, Latin</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Rawl_liturg/MS_Rawl_liturg_f_8-star.xml
+++ b/collections/Rawl_liturg/MS_Rawl_liturg_f_8-star.xml
@@ -40,7 +40,7 @@
                <msContents>
                   <msItem class="#liturgica" n="1" xml:id="MS_Rawl_liturg_f_8-star-item1">
                      <title key="work_10509" type="desc">Book of Hours</title>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Rawl_liturg/MS_Rawl_liturg_f_8.xml
+++ b/collections/Rawl_liturg/MS_Rawl_liturg_f_8.xml
@@ -40,7 +40,7 @@
                <msContents>
                   <msItem class="#liturgica" n="1" xml:id="MS_Rawl_liturg_f_8-item1">
                      <title key="work_10509" type="desc">Book of Hours</title>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Rawl_liturg/MS_Rawl_liturg_g_4.xml
+++ b/collections/Rawl_liturg/MS_Rawl_liturg_g_4.xml
@@ -40,7 +40,7 @@
                <msContents>
                   <msItem class="#liturgica" n="1" xml:id="MS_Rawl_liturg_g_4-item1">
                      <title key="work_10509" type="desc">Book of Hours</title>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>

--- a/collections/Rawl_liturg/MS_Rawl_liturg_g_5.xml
+++ b/collections/Rawl_liturg/MS_Rawl_liturg_g_5.xml
@@ -40,7 +40,7 @@
                <msContents>
                   <msItem class="#liturgica" n="1" xml:id="MS_Rawl_liturg_g_5-item1">
                      <title key="work_10509" type="desc">Book of Hours</title>
-                     <textLang mainLang="nl">Netherlandish</textLang>
+                     <textLang mainLang="dum">Middle Dutch</textLang>
                   </msItem>
                </msContents>
                <physDesc>


### PR DESCRIPTION
Use Middle Dutch `dum` language tag for works/manuscripts written c. 1100–1550.