### PR TITLE
add lost arks back in

### DIFF
--- a/collections/Bodl/MS_Bodl_867.xml
+++ b/collections/Bodl/MS_Bodl_867.xml
@@ -40,6 +40,8 @@
                   <institution>University of Oxford</institution>
                   <repository>Bodleian Library</repository>
                   <idno type="shelfmark">MS. Bodl. 867</idno>
+                  <idno type="ieArk">ark:29072/x03x816n46bb</idno>
+                  <idno type="crArk">ark:29072/x0jm214p2615</idno>
                   <altIdentifier type="internal">
                      <idno type="SCN">2746</idno>
                   </altIdentifier>

--- a/collections/Douce/MS_Douce_30.xml
+++ b/collections/Douce/MS_Douce_30.xml
@@ -45,6 +45,8 @@
                   <institution>University of Oxford</institution>
                   <repository>Bodleian Library</repository>
                   <idno type="shelfmark">MS. Douce 30</idno>
+                  <idno type="ieArk">ark:29072/x00k225c07g0</idno>
+                  <idno type="crArk">ark:29072/x08w32r6285h</idno>
                   <altIdentifier type="internal">
                      <idno type="SCN">21604</idno>
                   </altIdentifier>

--- a/collections/Douce/MS_Douce_44.xml
+++ b/collections/Douce/MS_Douce_44.xml
@@ -39,6 +39,8 @@
                   <institution>University of Oxford</institution>
                   <repository>Bodleian Library</repository>
                   <idno type="shelfmark">MS. Douce 44</idno>
+                  <idno type="ieArk">ark:29072/x044558f06qb</idno>
+                  <idno type="crArk">ark:29072/x0k0698759mx</idno>
                   <altIdentifier type="internal">
                      <idno type="SCN">21618</idno>
                   </altIdentifier>

--- a/collections/Douce/MS_Douce_49.xml
+++ b/collections/Douce/MS_Douce_49.xml
@@ -39,6 +39,8 @@
                   <institution>University of Oxford</institution>
                   <repository>Bodleian Library</repository>
                   <idno type="shelfmark">MS. Douce 49</idno>
+                  <idno type="ieArk">ark:29072/x02r36tz40d7</idno>
+                  <idno type="crArk">ark:29072/x0k930bx09jg</idno>
                   <altIdentifier type="internal">
                      <idno type="SCN">21623</idno>
                   </altIdentifier>


### PR DESCRIPTION
https://github.com/bodleian/medieval-mss/pull/750/commits/a3df0b0fec7d1a33bbe131b42ab2bee5bd321257 removed assigned ARKs, so this branch adds them back in.