### PR TITLE
add scope to multiple layouts

### DIFF
--- a/collections/Canon_Misc/MS_Canon_Misc_262.xml
+++ b/collections/Canon_Misc/MS_Canon_Misc_262.xml
@@ -1,4 +1,4 @@
-<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_3282">
+<?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc-mmol.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc-mmol.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_3282">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -90,15 +90,15 @@
                            </dimensions></extent>
                      </supportDesc>
                      <layoutDesc resp="#MLH">
-                        <layout columns="2" writtenLines="28 43">Fols. 1-197: 2 cols., c. 28-43 lines, ruled space <dimensions unit="mm" type="ruled">
+                        <layout columns="2" writtenLines="28 43" scope="major">Fols. 1-197: 2 cols., c. 28-43 lines, ruled space <dimensions unit="mm" type="ruled">
                            <height max="95" min="90">90–5</height>
                            <width>80</width>
                         </dimensions></layout>
-                        <layout columns="2" writtenLines="33 41">Fols. 203-217: 2 cols., c. 33-41 lines, ruled space <dimensions unit="mm" type="ruled">
+                        <layout columns="2" writtenLines="33 41" scope="minor">Fols. 203-217: 2 cols., c. 33-41 lines, ruled space <dimensions unit="mm" type="ruled">
                            <height>100</height>
                            <width>80</width>
                         </dimensions></layout>
-                        <layout columns="2" writtenLines="32 36">Fols. 223-232: 2 cols., c. 32-6 lines, ruled space <dimensions unit="mm" type="ruled">
+                        <layout columns="2" writtenLines="32 36" scope="minor">Fols. 223-232: 2 cols., c. 32-6 lines, ruled space <dimensions unit="mm" type="ruled">
                            <height>100</height>
                            <width>80</width>
                         </dimensions> </layout>

--- a/collections/Canon_Misc/MS_Canon_Misc_361.xml
+++ b/collections/Canon_Misc/MS_Canon_Misc_361.xml
@@ -57,7 +57,7 @@
                         </extent>
                      </supportDesc>
                      <layoutDesc resp="#DD">
-                        <layout writtenLines="30" columns="1">1 col., 30 lines, <dimensions unit="mm" type="written">
+                        <layout writtenLines="30" columns="1">1 col., 30 lines, <dimensions unit="mm" type="written" scope="major">
                               <height>165</height>
                               <width>85</width>
                            </dimensions>


### PR DESCRIPTION
test commit of two files - using MMOL odd customization to add a `scope` attribute in cases where a `layoutDesc` contains more than one `layout` - to enable automated identification of a manuscripts "typical" or "main" layout, for data analysis purposes.