### PR TITLE
add preview all collections xslt

### DIFF
--- a/processing/previewAllCollections.xsl
+++ b/processing/previewAllCollections.xsl
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:tei="http://www.tei-c.org/ns/1.0"
+    xmlns:html="http://www.w3.org/1999/xhtml"
+    xpath-default-namespace="http://www.tei-c.org/ns/1.0"
+    exclude-result-prefixes="tei html xs"
+    version="2.0">
+    
+    <!-- productes html preview for a whole collection (i.e. folder) which should be specified in line [29]
+        the aim is to make proofreading of a collection easier -->
+    
+    <!-- Import standard templates shared by all TEI catalogues -->
+    <xsl:import href="https://raw.githubusercontent.com/bodleian/consolidated-tei-schema/master/msdesc2html.xsl"/>
+    
+    <!-- Override the above with customizations specific to this TEI catalogue -->
+    <xsl:include href="customizations.xsl"/>
+    
+    <!-- Set URL here to allow links (e.g. to persons or places) to work
+         when previewing (only if destinations already exist on the web site.) -->
+    <xsl:variable name="website-url" as="xs:string" select="'https://medieval.bodleian.ox.ac.uk'"/>
+    
+  
+    
+    <!-- Set up the collection of files to be converted -->
+    <!-- files and recurse parameters defaulting to '*.xml' and 'no' respectively -->
+    
+    <xsl:variable name="collections" select="'Add_A', 'Add_B', 'Add_C',
+        'Add_D', 'Add_E', 'Arch_Selden', 'Ash_Rolls', 'Ashmole', 'Aubrey',        'Auct_B', 'Auct_D' , 'Auct_E', 'Auct_F', 'Auct_T',
+        'Auct_V',
+        'Barlow',
+        'Barocci',
+        'Bodl',
+        'Bodl_Rolls',
+        'Bowyer',
+        'Brasenose',
+        'Broxb',
+       'Buchanan',
+        'Bywater',
+        'Bywater_adds',
+        'Canon_Bibl_Lat',
+        'Canon_Class_Lat',
+        'Canon_Gr',
+        'Canon_Ital',
+        'Canon_Liturg',
+        'Canon_Misc',
+        'Canon_Pat_Lat',
+       'Carte',
+        'Cherry',
+        'Christ_Church',
+        'Clarendon_Press',
+        'Cromwell',
+        'Dep',
+        'Digby',
+        'Digby_Rolls',
+        'Dodsworth',
+        'Don',
+        'DOrville',
+        'Douce',
+        'Dugdale',
+        'Duke_Humfrey',
+        'Dutch',
+        'E_D_Clarke',
+        'e_Mus',
+        'Egypt',
+        'Eng_bibl',
+        'Eng_hist',
+        'Eng_misc',
+        'Eng_poet',
+        'Eng_th',
+        'Exeter_College',
+        'Fairfax',
+        'Fell',
+        'Finch',
+        'Fragments_printed_books',
+        'French',
+        'Germ',
+        'Gough',
+        'Gr_bib',
+       'Gr_class',
+        'Gr_liturg',
+        'Gr_misc',
+        'Gr_th',
+        'Grabe',
+        'Greaves',
+        'Hamilton',
+        'Hatton',
+        'Hertford_College',
+        'Holkham_Gr',
+        'Holkham_misc',
+        'Holmes',
+        'Icel',
+        'Ir',
+        'Ital',
+        'James',
+        'Jesus_College',
+        'Jones',
+        'Junius',
+        'Kennicott',
+        'Lady_Margaret_Hall',
+        'Lat_bib',
+        'Lat_class',
+        'Lat_hist',
+        'Lat_liturg',
+        'Lat_misc',
+        'Lat_th',
+        'Laud_Gr',
+        'Laud_Lat',
+        'Laud_Misc',
+        'Lawn',
+        'Lincoln_College',
+        'Liturg',
+        'Lyell',
+        'Marshall',
+        'Merton',
+        'Merton_fragments',
+        'Mex',
+        'Michael',
+        'Montagu',
+        'Morrell',
+        'Mus',
+        'Oriel_College',
+        'Radcliffe_Trust',
+        'Rawl_A',
+        'Rawl_B',
+        'Rawl_C',
+        'Rawl_D',
+        'Rawl_Essex',
+        'Rawl_G',
+        'Rawl_liturg',
+        'Rawl_poet',
+        'Rawl_Q',
+        'Rawl_statutes',
+        'Roe',
+        'Savile',
+        'Selden_Superius',
+        'Selden_Supra',
+        'Spanish',
+        'Sparrow',
+        'St_Amand',
+        'St_Johns_College',
+        'Tanner',
+        'Top',
+        'Trinity_College',
+        'Trinity_College_fragments',
+        'University_College',
+        'Wood'"/>
+    
+    <xsl:template match="/">
+        
+         <xsl:param name="files" select="'*.xml'"/>
+    
+    <xsl:param name="recurse" select="'yes'"/>
+  
+    
+    <!-- the main collection of all the documents we are dealing with -->
+    
+        <xsl:for-each select="$collections">
+       <xsl:variable name="collection" select="."></xsl:variable>
+         <xsl:variable name="path">
+        <xsl:value-of
+            select="concat('../collections/', $collection, '?select=', $files,';on-error=warning;recurse=',$recurse)"
+        />
+    </xsl:variable>
+            <xsl:variable name="doc" select="sort(collection($path))"/>
+            
+            
+            <xsl:call-template name="previewCollection">
+            <xsl:with-param name="doc" select="$doc"/>
+            <xsl:with-param name="collection" select="$collection"></xsl:with-param>
+        </xsl:call-template>
+        </xsl:for-each>
+    </xsl:template>
+    
+   
+    
+    
+    <!-- Wrap the output resulting from the above in html and body tags, for previewing
+         while editing the TEI in Oxygen. Do not add anything else to this stylesheet. -->
+    
+    <xsl:template name="previewCollection">
+        <xsl:param name="doc"></xsl:param>
+        <xsl:param name="collection"></xsl:param>
+        <xsl:result-document href="{concat('previews/', $collection, '.html')}">
+        <html>
+            <head>
+                <style type="text/css">
+                    <xsl:value-of select="string-join(tokenize(unparsed-text('preview.css', 'utf-8'), '&#xD;'), ' ')"/>
+                </style>
+            </head>
+            <body style="padding:2em ! important;">
+                <xsl:for-each select="$doc">
+                    <xsl:sort collation="http://www.w3.org/2013/collation/UCA?numeric=yes;reorder=Latn,digit"/>
+                <h1 itemprop="name">
+                    <xsl:value-of select="./tei:TEI/tei:teiHeader/tei:fileDesc/tei:sourceDesc/tei:msDesc/tei:msIdentifier/tei:idno[@type='shelfmark']/text()"/>
+                </h1>
+                <div class="content tei-body" id="{.//TEI/@xml:id}">
+                    <xsl:call-template name="Header"/>
+                    <xsl:apply-templates select=".//msDesc"/>
+                    <xsl:call-template name="AbbreviationsKey"/>
+                    <xsl:call-template name="Footer"/>
+                </div>
+                </xsl:for-each>
+            </body>
+        </html></xsl:result-document>
+    </xsl:template>
+    
+</xsl:stylesheet>

--- a/processing/previews/Add_A.html
+++ b/processing/previews/Add_A.html
@@ -1,0 +1,15013 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <style type="text/css">body, html 
+{ 
+    font-size: 17px; 
+    font-family: "PT Sans", sans-serif;   
+    padding: 0; 
+    background-color: #ffffff; 
+} 
+ 
+ 
+.individual-item *:not(h5):not(h4):not(h3):not(h2):not(h1) 
+{ 
+    font-size: 17px; 
+} 
+.bold, .tei-label, .label, h5, h4, h3, h2, h1 
+{ 
+    font-weight: 700; 
+} 
+.super 
+{ 
+    position: relative; 
+    display: inline-block; 
+    font-size: small; 
+    top: -9px; 
+} 
+.tei-italic,.italic 
+{ 
+    font-style: italic; 
+} 
+ 
+.layoutDesc 
+{ 
+    margin: 10px 0; 
+} 
+.tei-label 
+{ 
+    height: 18px; 
+} 
+ 
+h4 
+{ 
+    margin-top: 5px; 
+    margin-bottom: 5px; 
+} 
+ 
+h1 
+{ 
+    font-size: 32px; 
+} 
+ 
+.nestedmsItem { 
+    margin-left: 16px; 
+    padding-bottom: 16px; 
+    border-bottom: 1px solid #eaeaea; 
+    margin-bottom: 16px; 
+    text-align: justify; 
+} 
+ 
+p,.seg,.item,.head,.physDesc-p,.tei-title,.locus,.note,.decoNote-list,.decoNote,.item-number 
+{ 
+    margin: 0 0 5px; 
+    text-align: justify; 
+} 
+ 
+.msItem,.msPart,.msSummary 
+{ 
+    border-bottom: 1px solid #eaeaea; 
+    margin-bottom: 16px; 
+    padding-bottom: 16px; 
+} 
+ 
+.secFol .italic 
+{ 
+    font-style: normal; 
+} 
+.support, .form, .extent, .dimensions, .foliation, .condition  
+{ 
+    margin-top: 5px; 
+} 
+p.note:last-of-type { 
+    margin: 0; 
+} 
+ 
+.incipit,.explicit,.rubric, .finalRubric,.textLang, 
+.origPlace,.secFol,.objectDesc,.additional,.colophon,.origin, .msName 
+{ 
+    text-align: justify; 
+    margin-bottom: 5px; 
+} 
+.author,.bibl,.orgName,#zotero-bibliography-text,.origDate,.origPlace,.additions, .coveragewarning 
+{ 
+    margin-bottom: 5px; 
+} 
+.physDesc, .history { 
+    text-align: justify; 
+} 
+ 
+.additional ul.listBibl 
+{ 
+    padding: 0; 
+} 
+ 
+.small-caps, .author, .translator 
+{ 
+    font-variant: small-caps; 
+} 
+ 
+.content.tei-body ul 
+{ 
+    list-style: none; 
+}</style>
+   </head>
+   <body style="padding:2em ! important;">
+      <h1 itemprop="name">MS. Add. A. 2</h1>
+      <div class="content tei-body" id="manuscript_39">
+         <div class="msDesc" id="MS_Add_A_2-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">28744</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_2-item1">
+                  <div class="locus"></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_84975906">Johannes de Sacro Bosco</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_2592">Tractatus de sphera</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Incipit spera secundum M. Joannem Gallicum de Sacra Busco</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span><span class="supplied">⟨T⟩</span>ractatum de sp<span class="supplied">⟨er⟩</span>a quatuor capitulis distinguimus</span></div>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="seg"><span class="measure">i</span> + <span class="measure">56</span></span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">7.25</span> × <span class="width">5</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  </div>
+               
+               
+               <div class="handDesc">
+                  <h4>Hand(s)</h4>
+                  
+                  <p class="handNote">Humanistic script (<a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> ii. 820)</p>
+                  </div>
+               
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="summary"><a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> ii. 820
+                     </p>
+                  
+                  
+                  <p class="decoNote">
+                     Geometric diagrams (e.g. fols 8r and 49v). A representational diagram on
+                     <span class="head">
+                        <p>fol. 10r</p></span><ul class="list">
+                        
+                        
+                        <li><b>Type</b> 
+                           <span class="seg">diagram</span>
+                           </li>
+                        
+                        
+                        <li><b>Subject</b> 
+                           <span class="seg">Geometric diagram with walled city and boat on water</span>
+                           </li>
+                        
+                        </ul>
+                     </p>
+                  </div>
+               
+               
+               <div class="additions"><span class="tei-label">Additions: </span>With notes in the margins in various hands, from differing dates, and some correction
+                  of the main text; e.g. fol. 7v and fol. 28r</div>
+               
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">Red leather on boards with blind tooling, brass bosses and fore-edge clasp fittings
+                     (15th century)</p>
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century, middle</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>
+                     <span class="region">North</span>
+                     
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">Fol. 56v: '1452 (?) Visto; per mi Zohanne de Ipesoadan (?)'. For similar inscriptions,
+                     see 
+                     <a href="https://medieval.bodleian.ox.ac.uk/catalog/manuscript_3524" target="_blank">MS. Canon. Misc. 486</a>, <a href="https://medieval.bodleian.ox.ac.uk/catalog/manuscript_4149" target="_blank">MS. D'Orville 36</a>, 
+                     and <a href="https://medieval.bodleian.ox.ac.uk/catalog/manuscript_7622" target="_blank">MS. Laud Lat. 48</a>; also Edinburgh, Nat. Lib. Scotland, MS. Adv. 18. 3. 15. 
+                     Apparently to be read as <span class="persName">Giovanni dei Pescadori</span>: see Giuseppe Billanovich, 'Il testo di Livio', <span class="title italic">Italia medioevale e umanistica</span> 32 (1989), 53-99 at 85 and n. 93.</p>
+                  <p class="provenance">'V. g. 51', 'Pº xix. f. 3', 'V. E. 6'</p>
+                  <p class="acquisition">Purchased for 6<i>s</i> at Sotheby's on 20-21 June 1860, lot 245, along with <a href="https://medieval.bodleian.ox.ac.uk/?utf8=%E2%9C%93&amp;q=%22Sotheby%27s+on+20-21+June+1860%22" target="_blank">eight other manuscripts</a> 
+                     'formerly in the archives of two princely Roman families'</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (November 2024) by Stewart J. Brookes from the Summary Catalogue
+                     (1905). Decoration, localization and date follow Pächt and Alexander (1970)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0537.gif">Summary Catalogue, Vol. 5, p. 502</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2024-11-13: Description revised to incorporate all the information in the Summary Catalogue (1905)</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 4</h1>
+      <div class="content tei-body" id="manuscript_64">
+         <div class="msDesc" id="MS_Add_A_4-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">24750</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_4-item1">
+                  <div class="locus"></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_67528596">Pietro da Lucca (Petrus Lucensis)</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_3682">theological works</a></span>
+                  
+                  <p class="note">A transcript of 'Opusculo de trenta documenti per persone... spirituale. 
+                     Et doctrina del ben morire con molte utile resolutione de alcuni belli dubii Teologici'
+                     
+                     that was copied from the edition printed at Bologna by Hieronymus de Benedictis on
+                     20 June 1518 (see p. cxxxvii)</p>
+                  
+                  <p class="note">On pp. cxxxviii-cliv is 'Opera noua chiamata Luce di fede...'</p>
+                  
+                  <p class="note">There are also small theological lists and pieces that may be derived from the printed
+                     volume</p>
+                  
+                  <p class="note">Pietro da Lucca's name is in the dedications</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Italian</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>2 + <span class="measure">clvi</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">4.625</span> × <span class="width">3.5</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">16th century</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="acquisition">Purchased by the Bodleian at Sotheby's on 3 April 1859 from the collection of <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_19743305">Guillaume Libri</a></span>. 
+                     No. 797 in the <a href="https://archive.org/details/CatalogueLibriSothebys/page/n237/mode/1up" target="_blank">sale catalogue</a></p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (May 2025) by Stewart J. Brookes from the Summary Catalogue (1905)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0095.gif">Summary Catalogue, Vol. 5, p. 60</a></div>
+                        </div>
+                     
+                     </div>
+                  
+                  </div>
+               
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <div class="bibl">MSS. Add., handwritten catalogue by F. Madan [<a href="https://libguides.bodleian.ox.ac.uk/medieval-sc/unpublished-resources" target="_blank">Weston Library</a>, shelved at R. 6. 58]</div>
+                        </span>
+                     </ul>
+               </div>
+               
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-05-29: Description revised to incorporate all the information in the Summary Catalogue (1905)</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 5</h1>
+      <div class="content tei-body" id="manuscript_68">
+         <div class="msDesc" id="MS_Add_A_5-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">24753</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_5-item1">
+                  
+                  <div class="locus"><span class="item-number">1. </span>(fol. 1)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_95333965">Nicolaus de Auximo</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_3232">'Lo libro decto Quadriga spirituale'</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>... Lo libro decto Quagriga [corrected to <i>Quadriga</i>] spirituale</span></div>
+                  
+                  <p class="note">Some leaves are lost, the text ending 'le predicte cose necessarie', followed by two
+                     erased lines, to conceal the defect</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Italian</div>
+                  </div>
+               
+               
+               <div class="msItem" id="MS_Add_A_5-item2">
+                  
+                  <div class="locus"><span class="item-number">2. </span>(fol. 138)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_89209643">Antoninus of Florence</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_561">Confessionale 'omnis mortalium cura'</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>... Tractatus de vii<sup>tem</sup> uitijs capitalibus editus per 
+                        reuerendum patrem fratrem Antonium de Florentiam ordinis Predicatorum</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Omnis mortalium cura... Dice sancto Seuerino</span></div>
+                  
+                  <p class="note">Some leaves are lost at the end. The text ends 'moltitudine innumerabilj <span class="catchwords">di Christianj</span>'</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Italian</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>ii + <span class="measure">200</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">6</span> × <span class="width">4.5</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  
+                  
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p>2 cols</p>
+                     </div>
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="acquisition">Purchased by the Bodleian at Sotheby's on 3 April 1859 from the collection of <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_19743305">Guillaume Libri</a></span>. 
+                     No. 848 in the <a href="https://archive.org/details/CatalogueLibriSothebys/page/n249/mode/1up" target="_blank">sale catalogue</a>
+                     </p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (May 2025) by Stewart J. Brookes from the Summary Catalogue (1905)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0096.gif">Summary Catalogue, Vol. 5, p. 61</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <div class="bibl">MSS. Add., handwritten catalogue by F. Madan [<a href="https://libguides.bodleian.ox.ac.uk/medieval-sc/unpublished-resources" target="_blank">Weston Library</a>, shelved at R. 6. 58]</div>
+                        </span>
+                     </ul>
+               </div>
+               
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-05-29: Description revised to incorporate all the information in the Summary Catalogue (1905)
+               and other printed sources</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 6</h1>
+      <div class="content tei-body" id="manuscript_70">
+         <div class="msDesc" id="MS_Add_A_6-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">24712</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</p>
+               
+               <div class="msItem" id="MS_Add_A_6-item1">
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_72445530">Paulus Pergulensis</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_3465">Compendium logicae</a></span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Transcendentia sunt sex. Ens, Aliquid</span></div>
+                  </div>
+               
+               <div class="msItem" id="d73e116">
+                  
+                  <div class="locus">(fol. 51)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_72445530">Paulus Pergulensis</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_3466">De sensu composito et diuiso</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Tractatus sensus compositi &amp; diuisi</span></div>
+                  
+                  <p class="note">Written for Petrus de Guiditionibus</p>
+                  
+                  <p class="note"> Where the manuscript ends imperfect, Antonio Urceo has supplied the defect, signing
+                     
+                     'Finis per me <span class="persName scr"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_66577430">Codrum</a></span> Aretinum Marescottorum preceptor<span class="ex">(em)</span> die xxij mensis Septembris 1488'</p>
+                  </div>
+               
+               
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>ii + <span class="measure">58</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">5.875</span> × <span class="width">4.5</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  </div>
+               
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  <p class="decoNote">Numerous diagrams</p>
+               </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century, first half</span>, <span class="origDate">with addition, 1488</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">On fol. 56 (which like fol. 1 is a palimpsest) is 'Questa Logiccha e del pouero Codro
+                     Brentadore' who may be <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_66577430">Antonio Urceo</a></span>, surnamed Codro</p>
+                  <p class="provenance">In the 17th century the volume was 'Codice lxxxxvii' in the library of '<span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_5097">M. G.</a></span>' whose arms were a plain cross</p>
+                  <p class="acquisition">Purchased by the Bodleian at Sotheby's on 29 March 1859 from the collection of <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_19743305">Guillaume Libri</a></span>. 
+                     No. 266 in the <a href="https://archive.org/details/CatalogueLibriSothebys/page/n122/mode/1up" target="_blank">sale catalogue</a>
+                     </p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (May 2025) by Stewart J. Brookes from the Summary Catalogue (1905)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0084.gif">Summary Catalogue, Vol. 5, p. 49</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <div class="bibl">MSS. Add., handwritten catalogue by F. Madan [<a href="https://libguides.bodleian.ox.ac.uk/medieval-sc/unpublished-resources" target="_blank">Weston Library</a>, shelved at R. 6. 58]</div>
+                        </span>
+                     </ul>
+               </div>
+               
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-05-29: Description revised to incorporate all the information in the Summary Catalogue (1905)
+               and other printed sources</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 7</h1>
+      <div class="content tei-body" id="manuscript_73">
+         <div class="msDesc" id="MS_Add_A_7-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">28745</span>
+                  </p>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               
+               <div class="physDesc-p">Composite: fols 1–45 || fols 46–88 || fols 89ff.</div>
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment, paper</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>ii + <span class="measure">162</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">7.875</span> × <span class="width">5.5</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  </div>
+               
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">Black leather on boards with blind tooling, clasp lost, Italian work (15th century).
+                     Resewn.</p>
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">Fol. i verso: 'Nicolaus maior et minor [i.e. 'Antidotarium magnum et parvum'] magistri
+                     Simonis Cinozi (?) de Florentia | fl. 3 [<i>then, added</i>] 
+                     et autor qui dicitur larugerina pratica bona'. Magister <span class="persName fmo">Simon Cinozi</span> (?) (14th or 15th century) seems to have owned the whole manuscript</p>
+                  <p class="provenance">A series of numbers, 'no. 26', no. '27' and no. '29' (18th century) refer to a library
+                     (label on the spine)</p>
+                  <p class="acquisition">Bought for £2 10<i>s</i> at Sotheby's on 20-21 June 1860, lot 254, <a href="https://medieval.bodleian.ox.ac.uk/?utf8=%E2%9C%93&amp;q=%22along+with+eight+other+manuscripts%22" target="_blank">along with eight other manuscripts</a> 
+                     'formerly in the archives of two princely Roman families'</p>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_7-part1" style="padding-left:2rem; margin-top:1rem; border-bottom-color:#C0C0C0; border-top:1px #C0C0C0 solid;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 7 – Part 1</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  
+                  <div class="msItem" id="MS_Add_A_7-part1-item1" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     
+                     <div class="locus"><span class="item-number">1. </span>(fol. 1)</div>
+                     
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_10205">Antidotarium Nicolai</a></span>
+                     
+                     <p class="note">Annotated</p>
+                     
+                     
+                     <div class="nestedmsItem" id="MS_Add_A_7-part1-item2" style="margin-top:1rem;">
+                        
+                        <div class="locus"><span class="item-number">2. </span>(fol. 34)</div>
+                        <span class="tei-title">A glossary of medicinal plants</span>
+                        
+                           
+                        
+                        
+                        <div class="incipit"><span class="tei-label">Incipit: </span><span>Acantia id est sucus prunellorum</span></div>
+                        
+                        <p class="note">With a list of drugs which may be substituted for others not obtainable</p>
+                        
+                        <p class="note">In double columns</p>
+                        </div>
+                     
+                     
+                     
+                     <div class="nestedmsItem" id="MS_Add_A_7-part1-item3">
+                        
+                        <div class="locus"><span class="item-number">3. </span>(fol. 38)</div>
+                        <span class="tei-title">Hexameters containing medical precepts</span>
+                        
+                         
+                        
+                        
+                        <div class="incipit"><span class="tei-label">Incipit: </span><span>Multi splendoris antimomum melioris</span></div>
+                        
+                        <p class="note">With a list of drugs which may be substituted for others not obtainable</p>
+                        
+                        <p class="note">In double columns</p>
+                        </div>
+                     
+                     
+                     <div class="nestedmsItem" id="d76e266" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                        <p class="note">Followed by a few recipes</p>
+                     </div>
+                     
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                     </div>
+                  
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     </div>
+                  
+                  
+                  <div class="decoDesc">
+                     <h4>Decoration</h4>
+                     
+                     <p class="summary"><a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> ii. 164
+                        </p>
+                     
+                     <p class="decoNote">Good historiated border <span class="head">
+                           <p>fol. 1r</p></span><ul class="list">
+                           
+                           
+                           <li><b>Type</b> 
+                              <span class="seg">border, left and lower margin</span>
+                              </li>
+                           
+                           
+                           <li><b>Subject</b> 
+                              <span class="seg">Hybrid figures and grotesques</span>
+                              </li>
+                           
+                           </ul>
+                        </p>
+                     
+                     <p class="decoNote">Good initial</p>
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">14th century, first half</span>
+                     ; <span class="origPlace">
+                        <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>
+                        </span>
+                     </div>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_7-part2" style="padding-left:2rem; border-bottom-color:#C0C0C0;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 7 – Part 2</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  
+                  <div class="msItem" id="MS_Add_A_7-part2-item1" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     
+                     <div class="locus"><span class="item-number">1. </span>(fol. 46)</div>
+                     <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_16311">Medical treatise (antidotary)</a></span>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Antidotum. Aurea Alexandrina faciens ad reuma capitis</span></div>
+                     
+                     <p class="note">Ends abruptly in the section for <i>unguentum</i> with 'cumque liquefacta fuerit cera ab igne', 
+                        but various later recipes have been written in the gaps in the original and on some
+                        leaves that had been left blank  at the end</p>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                     </div>
+                  
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     </div>
+                  
+                  
+                  <div class="decoDesc">
+                     <h4>Decoration</h4>
+                     
+                     <p class="summary"><a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> ii. 57
+                        </p>
+                     
+                     
+                     <p class="decoNote">Initial, unfinished, possibly added in the 12th century, second half<span class="head">
+                           <p>fol. 46r</p></span><ul class="list">
+                           
+                           
+                           <li><b>Type</b> 
+                              <span class="seg">initial A</span>
+                              </li>
+                           
+                           
+                           <li><b>Subject</b> 
+                              <span class="seg">Unfinished initial with acanthus-leaf designs</span>
+                              </li>
+                           
+                           </ul>
+                        </p>
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">12th century, first half</span>
+                     ; <span class="origPlace">
+                        <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>
+                        </span>
+                     </div>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_7-part3" style="padding-left:2rem; border-bottom-color:#C0C0C0;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 7 – Part 3</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  
+                  <div class="msItem" id="MS_Add_A_7-part3-item1">
+                     
+                     <div class="locus"><span class="item-number">1. </span>(fol. 89)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_4371360">Roger de Baron</a></span>, 
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_4454">Rogerina major</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Incipitunum de tribus</span></div>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Sicut ab antiquis habemus auctoribus</span></div>
+                     
+                     <div class="explicit"><span class="tei-label">Explicit: </span><span>Explicit Rogerina. Explicit Pratica magistri Rogeri baronis</span></div>
+                     
+                     <p class="note">With notes</p>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                     </div>
+                  
+                  
+                  <div class="msItem" id="MS_Add_A_7-part3-item2">
+                     
+                     <div class="locus"><span class="item-number">2. </span>(fol. 146v)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_4371360">Roger de Baron</a></span>, 
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_4452">Medical texts</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Incipit conpendium Salerni</span></div>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span class="type">(prologue) </span><span>Duplici causa me cogente</span></div>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span class="type">(text) </span><span>Medicina est scientia</span></div>
+                     
+                     <p class="note">A few recipes follow at the end</p>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                     </div>
+                  
+                  
+                  <div class="msItem" id="d76e509">
+                     
+                     <div class="locus">(fol. 159v)</div>
+                     
+                     <p class="note">18 lines of Hebrew which A. E. Cowley judged to be a medical prescription in an Italian
+                        hand of about the 15th century</p>
+                     </div>
+                  
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     </div>
+                  
+                  <div class="decoDesc">
+                     <h4>Decoration</h4>
+                     
+                     <p class="decoNote">Red and blue initials with contrasting penwork</p>
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">13th or 14th century</span>
+                     ; <span class="origPlace">
+                        <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>
+                        </span>
+                     </div>
+               </div>
+            </div>
+            <h2><?ni?>Additional Information<?ni?></h2>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (July 2025) by Stewart J. Brookes from the Summary Catalogue (1905).
+                     Decoration, localization and date follow Pächt and Alexander (1973)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0537.gif">Summary Catalogue, Vol. 5, p. 502</a></div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0538.gif">Summary Catalogue, Vol. 5, p. 503</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-07-21: Description revised to incorporate all the information in the Summary Catalogue (1905)</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 8</h1>
+      <div class="content tei-body" id="manuscript_74">
+         <div class="msDesc" id="MS_Add_A_8-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">24757</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_8-item1">
+                  <div class="locus"></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_98148813">Richard of St. Victor</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_4318">Benjamin major</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>... Liber Ricardi de Sancto Victore de archa mistica, seu de contemplatione</span></div>
+                  
+                  <p class="note">At the end is a list of chapters, not quite perfect</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>ii + <span class="measure">112</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">8.125</span> × <span class="width">5.875</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  </div>
+               
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="summary"><a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> ii. 471
+                     </p>
+                  
+                  
+                  <p class="decoNote">Fine border</p>
+                  
+                  <p class="decoNote">Fine historiated initial<span class="head">
+                        <p>fol. 1r</p></span><ul class="list">
+                        
+                        
+                        <li><b>Type</b> 
+                           <span class="seg">initial M</span>
+                           </li>
+                        
+                        
+                        <li><b>Subject</b> 
+                           <span class="seg">Portrait of the author in monastic habit, kneeling, hands joined in prayer</span>
+                           </li>
+                        
+                        </ul>
+                  </p>
+                  
+                  <p class="decoNote">Fine initials. 6-line initials on gold background, decorated with floral and geometric
+                     designs</p>
+                  
+                  <p class="decoNote">3-line red and blue initials with contrasting penwork</p>
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century, second quarter</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>, <span class="settlement"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7018159">Venice</a></span> (?)</span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="acquisition">Purchased by the Bodleian at Sotheby's on 2 April 1859 from the collection of <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_19743305">Guillaume Libri</a></span>. 
+                     No. 864 in the <a href="https://archive.org/details/CatalogueLibriSothebys/page/n254/mode/1up?view=theater&amp;q=864" target="_blank">sale catalogue</a>
+                     </p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (May 2025) by Stewart J. Brookes from the Summary Catalogue (1905).
+                     Decoration, localization and date follow Pächt and Alexander (1970)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0098.gif">Summary Catalogue, Vol. 5, p. 63</a></div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0099.gif">Summary Catalogue, Vol. 5, p. 64</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <div class="bibl">MSS. Add., handwritten catalogue by F. Madan [<a href="https://libguides.bodleian.ox.ac.uk/medieval-sc/unpublished-resources" target="_blank">Weston Library</a>, shelved at R. 6. 58]</div>
+                        </span>
+                     </ul>
+               </div>
+               
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-05-29: Description revised to incorporate all the information in the Summary Catalogue (1905)
+               and other printed sources</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 9</h1>
+      <div class="content tei-body" id="manuscript_75">
+         <div class="msDesc" id="MS_Add_A_9-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">24748</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</p>
+               
+               <div class="msItem" id="MS_Add_A_9-item1">
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_24572572">Peter of Blois</a></span>, 
+                  
+                  
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_3525">Letters</a></span>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Explicit Summa magistri Petri Blesensis Bathoniensis archidiaconi</span></div>
+                  
+                  <p class="note">Ninety-two letters, some written in the names of other persons</p>
+                  
+                  <p class="note">Preceded by a list giving the subject and first words of each letter</p>
+                  
+                  
+                  </div>
+               <div class="msItem" id="d78e121">
+                  
+                  <div class="locus">(fol. 50)</div>
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_3522">de Hierosolymitana peregrinatione acceleranda</a></span>
+                  </div>
+               
+               
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>iii + <span class="measure">56</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">6.875</span> × <span class="width">5.625</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  <div>
+                     <h4>Condition</h4>
+                     <div class="condition">In parts stained</div>
+                  </div>
+                  
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">13th century, second half</span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">On fol. 3a is entered a Latin inventory of silver gilt cups, dishes, pots, etc., with
+                     their weight and value in sterling, perhaps belonging to 'Jo. de Magno Ponte', imperfect,
+                     written <i>c</i>. 1300 in England: 
+                     '<span class="persName fmo">Jo. de Magno Ponte</span> habet cupam cum operculo deaurato et cifum aureum et XXV coclearia argentea', etc.
+                     
+                                       
+                     
+                     
+                     </p>
+                  <p class="acquisition">Purchased by the Bodleian at Sotheby's on 31 March 1859 from the collection of <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_19743305">Guillaume Libri</a></span>. 
+                     No. 792 in the <a href="https://archive.org/details/CatalogueLibriSothebys/page/n235/mode/1up" target="_blank">sale catalogue</a>
+                     </p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (May 2025) by Stewart J. Brookes from the following sources:
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0094.gif">Summary Catalogue, Vol. 5, p. 59</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               
+               <div class="surrogates">
+                  <h3 class="msDesc-heading3">Surrogates</h3>
+                  <p><span class="bibl">
+                        A facsimile of the colophon of the <span class="title italic">Letters</span> is on <a href="https://archive.org/details/CatalogueLibriSothebys/page/n334/mode/1up" target="_blank">plate vii (no. 792)</a> of the Libri sale catalogue
+                        </span><br /></p>
+               </div>
+               
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <div class="bibl">MSS. Add., handwritten catalogue by F. Madan [<a href="https://libguides.bodleian.ox.ac.uk/medieval-sc/unpublished-resources" target="_blank">Weston Library</a>, shelved at R. 6. 58]</div>
+                        </span>
+                     </ul>
+               </div>
+               
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-05-29: Description revised to incorporate all the information in the Summary Catalogue (1897)
+               and other printed sources</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 10</h1>
+      <div class="content tei-body" id="manuscript_1">
+         <div class="msDesc" id="MS_Add_A_10-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">24731</span>
+                  </p>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="physDesc-p">Made up of three manuscripts.</div>
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="seg"><span class="measure">ii</span> + <span class="measure">109</span></span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">6.875</span> × <span class="width">5.75</span> in.
+                        
+                        </div>
+                  </div>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">The whole volume is annotated in more than one 16th cent. Italian hand: on fol. 8ov
+                     are notes of 1562-4 by 'Jo. Fr. Unto da Fuligno' that he entered on office on March
+                     1, 1562, the secondo priore being 'Ludovico figlolo di Seuerino di Carlo', etc., and
+                     on March 23 proposed 'Nichola di Bartolomeo Vitellischo' as member of the Council
+                     (at <span class="placeName"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7005040">Foligno</a></span> ?), etc.</p>
+                  <p class="provenance"><span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_19743305">Gugliemo Libri</a></span>, his sale at Sotheby's March 28-April 4, 1859: <span class="title italic">Catalogue of the ... collection of Splendid Manuscripts ... formed by M. Guglielmo
+                        Libri</span> no. 609*.</p>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_10-partAi" style="padding-left:2rem; margin-top:1rem; border-bottom-color:#C0C0C0; border-top:1px #C0C0C0 solid;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 10 - part A (upper text)</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Italian</p>
+                  
+                  <div class="msItem" id="MS_Add_A_10-partA-item1" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     
+                     <div class="locus">(fol. 1)</div>
+                     <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_13227">Medical treatise</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span><span class="editorialgap"> […] </span> Questo libra sie tracto di molti phylosophy, giudei greci &amp; latinj, el quale e tracto
+                           duno libro chiamato El Thesoro, e generalmente tinsegnia ogni cura in physica &amp; in
+                           cerugihca <span class="editorialgap"> […] </span></span></div>
+                     
+                     <p class="note">Especially about letting blood: two tables of contents precede: the text beg., after
+                        a letter from Hippocrates to the emperor Augustus (!)</p>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span><span class="locus">(fol. 5)</span> Prima e aquisita et humorj di sangue</span></div>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">14th century</span>
+                     ; <span class="origPlace"><span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span></span>
+                     </div>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_10-partAii" style="padding-left:2rem; border-bottom-color:#C0C0C0;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 10 - part A (lower text)</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</p>
+                  
+                  
+                  <div class="msItem" id="MS_Add_A_10-partAii-item1" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_12080">Gospel of St Mark (?)</a></span>
+                     
+                     <p class="note">Parts of this MS. are palimpsest, e.g. fols. 56-7, 62-3, seem to contain part of St.
+                        Mark's Gospel in Latin.</p>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">11th century (?)</span>
+                     
+                     </div>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_10-partB" style="padding-left:2rem; border-bottom-color:#C0C0C0;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 10 - part B</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</p>
+                  
+                  <div class="msItem" id="MS_Add_A_10-partB-item1" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     
+                     <div class="locus">(fol. 64)</div>
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_10205">Antidotarium Nicholai</a></span>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span class="type">(preface) </span><span>Ego Nicolaus rogatus a quibusdam</span></div>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span class="type">(text) </span><span>Aurea dicta est ab auro. Alexandrina ab Alexandro</span></div>
+                     
+                     <p class="note">There is no title given; a list of lemmata precedes; ends, some leaves being lost
+                        in 'Theriaca', with 'decoctione lilifagi.'</p>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">13th century, second half</span>
+                     </div>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_10-partC" style="padding-left:2rem; border-bottom-color:#C0C0C0;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 10 - part C</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</p>
+                  
+                  <div class="msItem" id="MS_Add_A_10-partC-item1" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     
+                     <div class="locus">(fol. 81)</div>
+                     <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_13209">Medical and other recipes</a></span>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Ad corodendos poros &amp; uerucas &amp; malas carnes. Aquam de capitello</span></div>
+                     
+                     <p class="note">Fols. 80-81, 106-7, bear 15th cent. notes.</p>
+                     </div>
+                  
+                  
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">14th century, late</span>
+                     </div>
+               </div>
+            </div>
+            <h2><?ni?>Additional Information<?ni?></h2>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Description adapted (May 2022) from the Summary Catalogue (1905). 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0091.gif">Summary Catalogue, Vol. 5, p. 56</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2022-05: Description revised to include all information in Summary Catalogue.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 11</h1>
+      <div class="content tei-body" id="manuscript_9">
+         <div class="msDesc" id="MS_Add_A_11-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">28746</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_A_11-item1">
+                  <div class="locus"></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_79253953">Gasparino Barzizza</a></span>, 
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_1631">De orthographia</a></span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span class="type">(preface) </span><span>Quoniam recta scriptura</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span class="type">(text) </span><span>Ad oppositionem cum quibusdam</span></div>
+                  
+                  <p class="note">Cf. G. L. Bursill-Hall, <span class="title italic">A census of medieval Latin grammatical manuscripts</span> (1981), p. 180 (188.158)</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="seg"><span class="measure">i</span>+<span class="measure">93</span></span> fols. 
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">200</span> × <span class="width">142</span> mm.
+                        
+                        </div>
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (written): </span>
+                        <span class="height">140</span> × <span class="width">85–90</span> mm.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p>34 lines, 1 col.</p>
+                     </div>
+                  </div>
+               
+               <div class="handDesc">
+                  <h4>Hand(s)</h4>
+                  
+                  <p class="handNote">'Hoc opus scriptum fuit per me <span class="persName scr"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_2741">Benedictum de gramignis notarium</a></span>. Anno domini currente Millesimo quadringintessimo quadragessimo tertio'.</p>
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">Coloured initials.</p>
+                  </div>
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">Green whittawed half-leather over boards (s. xv), with bosses, rebacked.</p>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span><span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>
+                     </span>; 
+                  <span class="origDate">1443</span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">'Donum R. P. D. <span class="persName dnr"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_2740">Honorati episcopi Vrbanię</a></span>' (1636–83), fol. 1.</p>
+                  <p class="acquisition">Purchased for £2 18<i>s</i> at Sotheby's on 20-21 June 1860, lot 103, along with <a href="https://medieval.bodleian.ox.ac.uk/?utf8=%E2%9C%93&amp;q=%22Sotheby%27s+on+20-21+June+1860%22" target="_blank">eight other manuscripts</a> 
+                     'formerly in the archives of two princely Roman families'</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Adapted (2017) with corrections (identification of text) from A. G. Watson, <span class="title italic"><a href="https://catalog.hathitrust.org/Record/000310664" target="_blank">Catalogue of Dated and Datable Manuscripts c.435–1600 in Oxford Libraries</a></span> (Oxford, 1984), no. 1, and the Summary Catalogue (1905). 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0538.gif">Summary Catalogue, Vol. 5, p. 503</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 12</h1>
+      <div class="content tei-body" id="manuscript_13">
+         <div class="msDesc" id="MS_Add_A_12-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">24759</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Italian</p>
+               
+               
+               <div class="msItem" id="MS_Add_A_12-item1">
+                  
+                  <div class="locus"><span class="item-number">1. </span>(fol. 1)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_39382430">Petrarch</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_3568">Trionfi</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Domini Francisci Petrarce Triompha</span></div>
+                  
+                  <p class="note">The poem begins on fol. 4 with 'Nel cor pien'</p>
+                  
+                  <p class="note">There are some corrections</p>
+                  
+                  </div>
+               
+               
+               <div class="msItem" id="MS_Add_A_12-item2">
+                  
+                  <div class="locus"><span class="item-number">2. </span>(fol. 31)</div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_14669">Sonnets and poems</a></span>, 
+                  
+                  <p class="note">74 sonnets and poems, partly by Petrarch, <span class="persName aut"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_29559625">Battista Alberti</a></span>, <span class="persName aut">F. de Malecanibus</span>, <span class="persName aut">N. di Tinucii</span>, 
+                     <span class="persName aut">Matteo Peruzzi</span> and <span class="persName aut"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_5165087">Carolo Aretino</a></span>.</p>
+                  
+                  <p class="note">A few are written in a rather later hand.</p>
+                  </div>
+               
+               
+               <div class="msItem" id="MS_Add_A_12-item3">
+                  
+                  <div class="locus"><span class="item-number">3. </span>(fol. 55)</div>
+                  <span class="tei-title">Recipes</span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Ricepte buone</span></div>
+                  </div>
+               
+               
+               <div class="msItem" id="MS_Add_A_12-item4">
+                  
+                  <div class="locus"><span class="item-number">4. </span>(fol. 60v)</div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_12237">Historical and other notes and extracts relating to <span class="placeName"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>, with a few religious sonnets, Florentine speeches (Mann, 1975, identifies texts
+                        by <span class="persName aut">Francesco Filelfi</span> and <span class="persName aut">Leonardo Bruni</span>), and the like.</a></span>
+                  </div>
+               
+               <div class="msItem" id="d16e187">
+                  
+                  <p class="note">The contents of fols. 31r-102v are itemized (and several printed) in C. Grayson, 'Una
+                     Miscellanea volgare del sec. XV (Cod. Bodleiano Add. A. 12)', <span class="title italic">La Bibliofilía</span>, 59, No. 2/3 (1957), 121-142 [<a href="https://www.jstor.org/stable/26206741" target="_blank">https://www.jstor.org/stable/26206741</a>].</p>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>ii + <span class="measure">105</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">9</span> × <span class="width">6.125</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  
+                  </div>
+               
+               
+               <div class="handDesc">
+                  <h4>Hand(s)</h4>
+                  
+                  <p class="handNote">
+                     In more than one hand
+                     </p>
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century, second half</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">The Libri sale catalogue states that the scribe of the volume was <span class="persName scr"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_309649566">Lorenzo Guidetti</a></span>, the basis for this being that his name 
+                     was on the cover of the manuscript; there was no trace of this when the Summary Catalogue
+                     was compiled.</p>
+                  <p class="acquisition">Purchased by the Bodleian at Sotheby's on 2 April 1859 from the collection of <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_19743305">Guillaume Libri</a></span> 
+                     No. 866 in the <a href="https://archive.org/details/CatalogueLibriSothebys/page/n255/mode/1up" target="_blank">sale catalogue</a>
+                     </p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (May 2025) by Stewart J. Brookes from the Summary Catalogue (1905)
+                     with additional reference to published literature as cited.
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0099.gif">Summary Catalogue, Vol. 5, p. 64</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <div class="bibl">N. Mann, ‘Petrarch Manuscripts in the British Isles’, <span class="title italic">Italia Medioevale e Umanistica</span>, 18 (1975), pp. 139–527, no. 156 (pp. 355-357)</div>
+                        
+                        
+                        <div class="bibl">MSS. Add., handwritten catalogue by F. Madan [<a href="https://libguides.bodleian.ox.ac.uk/medieval-sc/unpublished-resources" target="_blank">Weston Library</a>, shelved at R. 6. 58]</div>
+                        </span>
+                     </ul>
+               </div>
+               
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-05-29: Description revised to incorporate all the information in the Summary Catalogue (1905)
+               and other printed sources</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 13</h1>
+      <div class="content tei-body" id="manuscript_14">
+         <div class="msDesc" id="MS_Add_A_13-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">24775</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_13-item1">
+                  
+                  <div class="locus"><span class="item-number">1. </span>(fol. 1)</div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_14583">Sermon</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Vita Christi</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Si diligenter consideramus</span></div>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               
+               <div class="msItem" id="MS_Add_A_13-item2">
+                  
+                  <div class="locus"><span class="item-number">2. </span>(fol. 2)</div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_14583">Sermon</a></span>
+                  
+                                    
+                  
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>... Sermo beati Bernardi de miseria humana</span></div>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               
+               <div class="msItem" id="MS_Add_A_13-item3">
+                  
+                  <div class="locus"><span class="item-number">3. </span>(fol. 4)</div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_14362">Trattatello della umanità di Gesù Cristo</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Queste sonno le tre sotietade</span></div>
+                  
+                  <p class="note">Followed by a printed copy (on large blue paper) of the same. One of 50 copies printed
+                     at Venice in 1830, likely based on the text in this manuscript</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Italian</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment, paper</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>i + <span class="measure">12</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">9</span> × <span class="width">6.125</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="acquisition">Purchased by the Bodleian at Sotheby's on 5 April 1859 from the collection of <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_19743305">Guillaume Libri</a></span>. 
+                     No. 1060 in the <a href="https://archive.org/details/CatalogueLibriSothebys/page/n295/mode/1up" target="_blank">sale catalogue</a>
+                     </p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (May 2025) by Stewart J. Brookes from the Summary Catalogue (1905)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0106.gif">Summary Catalogue, Vol. 5, p. 71</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <div class="bibl">MSS. Add., handwritten catalogue by F. Madan [<a href="https://libguides.bodleian.ox.ac.uk/medieval-sc/unpublished-resources" target="_blank">Weston Library</a>, shelved at R. 6. 58]</div>
+                        </span>
+                     </ul>
+               </div>
+               
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-05-29: Description revised to incorporate all the information in the Summary Catalogue (1905)
+               and other printed sources</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 15</h1>
+      <div class="content tei-body" id="manuscript_16">
+         <div class="msDesc" id="MS_Add_A_15-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">24745</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_15-item1">
+                  <div class="locus"></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_39382430">Petrarch</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_3568">Trionfi</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Francisci Petrarce Florentini poete laureati Triumph[i]</span></div>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Italian</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>ii + <span class="measure">59</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">8.75</span> × <span class="width">5.625</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  
+                  </div>
+               
+               
+               <div class="handDesc">
+                  <h4>Hand(s)</h4>
+                  
+                  <p class="handNote">Humanistic script related to that of <span class="persName scr"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_572">Jacobus de Machariis of Venice</a></span>
+                      (<a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> ii. 555)</p>
+                  </div>
+               
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="summary"><a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> ii. 555, Pl. LII
+                     </p>
+                  
+                  <p class="decoNote">Each part has an <a href="https://digital.bodleian.ox.ac.uk/objects/07cc9bcc-f654-4e42-ab2a-619666905812/surfaces/7362f488-71ef-4545-9c3f-8f35e6c07856/" target="_blank">elaborate capital letter</a>, 
+                     and several pages bear finely drawn and in various attitudes:</p>
+                  
+                  <p class="decoNote">
+                     
+                     <p class="decoNote-p">Fine miniatures (coloured drawings)</p>
+                     <span class="head">
+                        <p>fol. 1v</p></span><ul class="list">
+                        
+                        
+                        <li><b>Type</b> 
+                           <span class="seg">miniature</span>
+                           </li>
+                        
+                        
+                        <li><b>Subject</b> 
+                           <span class="seg"><a href="https://digital.bodleian.ox.ac.uk/objects/07cc9bcc-f654-4e42-ab2a-619666905812/surfaces/849d1fc0-c653-49c3-b3fb-051668128790/" target="_blank">Nine philosophers seated in a cave</a>; above - figures of two hermits and two monks: above are the phrases 'Qui atendant'
+                              and 'viam invenient'</span>
+                           
+                           </li>
+                        
+                        </ul>
+                     <span class="head">
+                        <p>fol. 2r</p></span><ul class="list">
+                        
+                        
+                        <li><b>Type</b> 
+                           <span class="seg">miniature</span>
+                           </li>
+                        
+                        
+                        <li><b>Subject</b> 
+                           <span class="seg"><a href="https://digital.bodleian.ox.ac.uk/objects/07cc9bcc-f654-4e42-ab2a-619666905812/surfaces/9634b076-19c1-4746-b81c-9fc1b9f637df/" target="_blank">Petrarch and Laura</a>, seated between two trees by a stream</span>
+                           </li>
+                        
+                        </ul>
+                     <span class="head">
+                        <p>fol. 43r</p></span><ul class="list">
+                        
+                        
+                        <li><b>Type</b> 
+                           <span class="seg">miniature</span>
+                           </li>
+                        
+                        
+                        <li><b>Subject</b> 
+                           <span class="seg"><a href="https://digital.bodleian.ox.ac.uk/objects/07cc9bcc-f654-4e42-ab2a-619666905812/surfaces/aa0eef70-9510-4aa3-b94f-0050c90c86de/" target="_blank">Armoured king kneeling</a> in prayer</span>
+                           </li>
+                        
+                        </ul>
+                     <span class="head">
+                        <p>fol. 50r</p></span><ul class="list">
+                        
+                        
+                        <li><b>Type</b> 
+                           <span class="seg">miniature</span>
+                           </li>
+                        
+                        
+                        <li><b>Subject</b> 
+                           <span class="seg">Bearded man in long robe pointing to the text</span>
+                           </li>
+                        
+                        </ul>
+                     <span class="head">
+                        <p>fol. 52r</p></span><ul class="list">
+                        
+                        
+                        <li><b>Type</b> 
+                           <span class="seg">miniature</span>
+                           </li>
+                        
+                        
+                        <li><b>Subject</b> 
+                           <span class="seg">Bearded man in long robe pointing to the text</span>
+                           </li>
+                        
+                        </ul>
+                     <span class="head">
+                        <p>fol. 52v</p></span><ul class="list">
+                        
+                        
+                        <li><b>Type</b> 
+                           <span class="seg">miniature</span>
+                           </li>
+                        
+                        
+                        <li><b>Subject</b> 
+                           <span class="seg">Two musicians playing pipes</span>
+                           </li>
+                        
+                        </ul>
+                     <span class="head">
+                        <p>fol. 56r</p></span><ul class="list">
+                        
+                        
+                        <li><b>Type</b> 
+                           <span class="seg">miniature</span>
+                           </li>
+                        
+                        
+                        <li><b>Subject</b> 
+                           <span class="seg">Bearded man in long robe pointing to the text</span>
+                           </li>
+                        
+                        </ul>
+                     </p>
+                  
+                  <p class="decoNote">Fine border</p>
+                  
+                  <p class="decoNote"><a href="https://digital.bodleian.ox.ac.uk/objects/07cc9bcc-f654-4e42-ab2a-619666905812/surfaces/ff48ecf2-6740-44d4-be2f-5b9c7299d4d2/%C3%9F" target="_blank">Fine initials</a></p>
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate"><i>c</i>. 1470–1480</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>, <span class="settlement"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7018159">Venice</a></span>
+                     
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="acquisition">Purchased by the Bodleian at Sotheby's on 2 April 1859 from the collection of <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_19743305">Guillaume Libri</a></span>. 
+                     No. 786 in the <a href="https://archive.org/details/CatalogueLibriSothebys/page/n294/mode/1up?view=theater&amp;q=864" target="_blank">sale catalogue</a>
+                     </p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (May 2025) by Stewart J. Brookes from the Summary Catalogue (1905).
+                     Decoration, localization and date follow Pächt and Alexander (1970)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0094.gif">Summary Catalogue, Vol. 5, p. 59</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <div class="surrogates">
+                  <h3 class="msDesc-heading3">Digital Images</h3>
+                  <p><span class="bibl"><a href="https://digital.bodleian.ox.ac.uk/objects/07cc9bcc-f654-4e42-ab2a-619666905812/" target="_blank"><span class="title italic">Digital Bodleian</span></a>
+                        <span class="note">(10 images from 35mm slides)</span></span><br /></p>
+               </div>
+               
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <div class="bibl">N. Mann, ‘Petrarch Manuscripts in the British Isles’, <span class="title italic">Italia Medioevale e Umanistica</span>, 18 (1975), pp. 139–527, no. 157 (pp. 357-359)</div>
+                        
+                        <div class="bibl">MSS. Add., handwritten catalogue by F. Madan [<a href="https://libguides.bodleian.ox.ac.uk/medieval-sc/unpublished-resources" target="_blank">Weston Library</a>, shelved at R. 6. 58]</div>
+                        </span>
+                     </ul>
+               </div>
+               
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-05-29: Description revised to incorporate all the information in the Summary Catalogue (1905)
+               and other printed sources</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 17</h1>
+      <div class="content tei-body" id="manuscript_24">
+         <div class="msDesc" id="MS_Add_A_17-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">24760</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_17-item1">
+                  
+                  <div class="locus"><span class="item-number">1. </span>(fols 1, 9v, 18 )</div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_14346">Religious poems</a></span>
+                  
+                  
+                  <div class="nestedmsItem" id="d27e109" style="margin-top:1rem;">
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>O Try et Vno et uno senpre may te chiamo</span></div>
+                     
+                     <p class="note">A poem of fifty-one stanzas in ottava rima</p>
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d27e118">
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>O patre Eterno O Divina Potentia — Figliol de Dio Escelentia Divina</span></div>
+                     
+                     <p class="note">A poem of forty-five stanzas in ottava rima</p>
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d27e127">
+                     
+                     <div class="locus">(fol. 17)</div>
+                     
+                     <p class="note">Extracts in prose from patristic sources, respecting 'I Benefitii della Messa'</p> 
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d27e137" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Anima benedetta dall' alto Creatore</span></div>
+                     
+                     <p class="note">A hymn</p>
+                     </div>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Italian</div>
+                  </div>
+               
+               
+               <div class="msItem" id="MS_Add_A_17-item2">
+                  
+                  <div class="locus"><span class="item-number">2. </span>(fol. 18v)</div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_15422">Verse drama of the Life and Death of Christ</a></span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Como el peccatore domanda Maria del suo figliolo</span></div>
+                  
+                  <p class="note">Comprised of 126 quatrains. The first is:</p>
+                  
+                  <p class="note">'O gloriosa Matre Beata / 
+                     Matre de Christo sete chiamata / 
+                     Dime Madonna questa fiata / 
+                     Quando tu fusty sy adolorata.'</p>
+                  
+                  <p class="note">There are many interlocutors</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Italian</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>i + <span class="measure">29</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">8.5</span> × <span class="width">5.625</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century, second half</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="acquisition">Purchased by the Bodleian at Sotheby's on 2 April 1859 from the collection of <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_19743305">Guillaume Libri</a></span>. 
+                     No. 868 in the <a href="https://archive.org/details/CatalogueLibriSothebys/page/n255/mode/1up" target="_blank">sale catalogue</a>
+                     </p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (May 2025) by Stewart J. Brookes from the Summary Catalogue (1905)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0099.gif">Summary Catalogue, Vol. 5, p. 64</a></div>
+                        </div>
+                     
+                     </div>
+                  
+                  </div>
+               
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <div class="bibl">MSS. Add., handwritten catalogue by F. Madan [<a href="https://libguides.bodleian.ox.ac.uk/medieval-sc/unpublished-resources" target="_blank">Weston Library</a>, shelved at R. 6. 58]</div>
+                        </span>
+                     </ul>
+               </div>
+               
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-05-29: Description revised to incorporate all the information in the Summary Catalogue (1905)
+               and other printed sources</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 18</h1>
+      <div class="content tei-body" id="manuscript_31">
+         <div class="msDesc" id="MS_Add_A_18-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">24772</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_18-item1">
+                  <div class="locus"></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_207294048">Michele da Figline (?)</a></span>, 
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_10021">Viaggio in Terrasanta</a></span>
+                  
+                  <p class="note">An account, in Italian, of a pilgrimage from Genoa (see fol. iv, John the Baptist,
+                     patron of the city) or possibly Florence, 
+                     by Venice to Jerusalem. The traveller left Florence on 16 May 16 1489</p>
+                  
+                  <p class="note">Although the text is in Italian, the text is interspersed with the Latin text of the
+                     prayers and short offices used on the journey</p>
+                  
+                  <p class="note">At the end of the introduction, the writer presents a riddle as to their identify,
+                     saying that it can be uncovered by tracing the initial letters: 
+                     '&amp; dipoi tu lectore che leggemi non sapendo apertamente el nome di questo misero pechatore
+                     ma comincerai a questo primo lettero che 
+                     trouarrai &amp; finendo trouarrai el nome mio'.</p>
+                  
+                  <p class="note">Agrees in general with Florence, Biblioteca Riccardiana 1923 (see below) as far as
+                     p. 165 ('in secula seculorum') of the printed text (fol. 104v); fols. 105-109r contain
+                     additional Latin offices and prayers.</p>
+                  <span class="listBibl">
+                     
+                     <div class="bibl">Printed by Marina Montesacno, <span class="title italic">Da Figline a Gerusalemme ...</span> (2010), from Florence, Biblioteca Riccardiana 1923, which gives the author's name
+                        (apparently added in a different hand). The editor was not aware of the present copy.
+                        Another copy was recorded as being in the Bibliotheca Magliabechiana in Florence in
+                        1785 (Giovanni Mariti, <span class="title italic">Illustrazioni in un anonimo viaggiatore del secolo XV</span>, 1785).</div>
+                     </span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Italian and Latin</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>i + <span class="measure">111</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">8.5</span> × <span class="width">6.125</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">16th century</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="acquisition">Purchased by the Bodleian at Sotheby's on 5 April 1859 from the collection of <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_19743305">Guillaume Libri</a></span>. 
+                     No. 1044 in the <a href="https://archive.org/details/CatalogueLibriSothebys/page/n292/mode/1up" target="_blank">sale catalogue</a>
+                     </p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (May 2025) by Stewart J. Brookes and Matthew Holford from the
+                     Summary Catalogue (1905) with additional reference to published literature as cited.
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0105.gif">Summary Catalogue, Vol. 5, p. 70</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <div class="bibl">MSS. Add., handwritten catalogue by F. Madan [<a href="https://libguides.bodleian.ox.ac.uk/medieval-sc/unpublished-resources" target="_blank">Weston Library</a>, shelved at R. 6. 58]</div>
+                        </span>
+                     </ul>
+               </div>
+               
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-05-29: Description revised to incorporate all the information in the Summary Catalogue (1905)
+               and other printed sources</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 20</h1>
+      <div class="content tei-body" id="manuscript_40">
+         <div class="msDesc" id="MS_Add_A_20-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">24758</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_20-item1">
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_14346">Religious poems</a></span>
+                  
+                  
+                  <div class="nestedmsItem" id="d43e106" style="margin-top:1rem;">
+                     
+                     <div class="locus">(fols ii*-vi*)</div>
+                     
+                     <p class="note">Index</p>
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d43e115">
+                     
+                     <div class="locus">(fol. i)</div>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>... Laudes frat<span class="ex">(r)</span>is Jacobi de Tuderto</span></div>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Vita di Yhesu Cristo</span></div>
+                     
+                     <p class="note">Seventy-five in number</p>
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d43e133">
+                     
+                     <div class="locus">(fol. lxxviij)</div>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Seruentese di frate Domenico Caualcha Pisano...</span></div>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Po chesso facto frate</span></div>
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d43e145">
+                     
+                     <div class="locus">(fol. lxxxix)</div>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Seruentese di frate Domenico Caualcha Pisano...</span></div>
+                     
+                     <p class="note">151 religious poems (Laudi), 132 of which are anonymous. The rest are the rest by
+                        'Jacopo (di Messer Bertoldo) da Monte Pulciano' (fols clxv, clxvi, clxix); 
+                        Cristofano del Pera (fol. clxxv); Pace di Vanni (15 poems: fol. cxcii)</p>
+                     
+                     <p class="note"></p>
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d43e160" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                     
+                     <div class="locus">(fol. cc verso)</div>
+                     
+                     <p class="note">A poem on an apparition of 1399</p>
+                     </div>
+                  
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Italian</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>vii* + <span class="measure">ccxi</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">8.75</span> × <span class="width">6.75</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  <div>
+                     <h4>Condition</h4>
+                     <div class="condition">A leaf or two is wanting at the end</div>
+                  </div>
+                  
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">In 1820 owned by 'A. W.' (possibly 'S. W.' or 'W. A.' or 'W. S.') (monogram on fol.
+                     ii*)</p>
+                  <p class="acquisition">Purchased by the Bodleian at Sotheby's on 2 April 1859 from the collection of <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_19743305">Guillaume Libri</a></span>. 
+                     865 in the <a href="https://archive.org/details/CatalogueLibriSothebys/page/n254/mode/1up" target="_blank">sale catalogue</a>
+                     </p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (July 2025) by Stewart J. Brookes from the Summary Catalogue (1905)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0099.gif">Summary Catalogue, Vol. 5, p. 64</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <div class="bibl">MSS. Add., handwritten catalogue by F. Madan [<a href="https://libguides.bodleian.ox.ac.uk/medieval-sc/unpublished-resources" target="_blank">Weston Library</a>, shelved at R. 6. 58]</div>
+                        </span>
+                     </ul>
+               </div>
+               
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-07-21: Description revised to incorporate all the information in the Summary Catalogue (1905)
+               and other printed sources</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 22</h1>
+      <div class="content tei-body" id="manuscript_42">
+         <div class="msDesc" id="MS_Add_A_22-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">28470</span>
+                  </p>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="physDesc-p">Composite: fols. 1–8 || fols. 9–188 || fols. 189–216</div>
+               </div>
+            <div class="msPart" id="MS_Add_A_22-part1" style="padding-left:2rem; margin-top:1rem; border-bottom-color:#C0C0C0; border-top:1px #C0C0C0 solid;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 22 – Part 1</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <div class="msItem" id="MS_Add_A_22-part1-item1" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_10682">Calendar</a></span>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle French</div>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">15th century</span>
+                     ; <span class="origPlace">
+                        <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000070">French</a></span>
+                        </span>
+                     </div>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_22-part2" style="padding-left:2rem; border-bottom-color:#C0C0C0;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 22 – Part 2</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <div class="msItem" id="MS_Add_A_22-part2-item1" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_95220054">Guillaume de Lorris</a></span>; 
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_304922354">Jean de Meung</a></span>, 
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_1919">Le Roman de la Rose</a></span>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Old French</div>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     </div>
+                  
+                  <div class="decoDesc">
+                     <h4>Decoration</h4>
+                     
+                     <p class="decoNote">Fine minatures, some rubbed. </p>
+                     
+                     <p class="decoNote">Fine borders.</p>
+                     
+                     <p class="decoNote"> Fine historiated initials.</p>
+                     
+                     <p class="decoNote"> Fine initials. (<a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> i. 566, pl. XLII)</p>
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">c. 1300</span>
+                     ; <span class="origPlace">
+                        <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000070">French</a></span>
+                        </span>
+                     </div>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_22-part3" style="padding-left:2rem; border-bottom-color:#C0C0C0;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 22 – Part 3</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <div class="msItem" id="MS_Add_A_22-part3-item1" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_304922354">Jean de Meung</a></span>, 
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_2387">Testament</a></span>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Old French</div>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     </div>
+                  
+                  <div class="decoDesc">
+                     <h4>Decoration</h4>
+                     
+                     <p class="decoNote">Good initial. (<a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> i. 625)</p>
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">14th century, second half</span>
+                     ; <span class="origPlace">
+                        <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000070">French</a></span>
+                        </span>
+                     </div>
+               </div>
+            </div>
+            <h2><?ni?>Additional Information<?ni?></h2>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Summary description by Elizabeth Solopova and Matthew Holford, based on the Summary
+                     Catalogue and supplementary sources. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0493.gif">Summary Catalogue, Vol. 5, p. 458</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <div class="surrogates">
+                  <h3 class="msDesc-heading3">Digital Images</h3>
+                  <p><span class="bibl"><a href="https://digital.bodleian.ox.ac.uk/objects/8b7a53e8-05cd-437d-a846-4eb8a97db1e1/" target="_blank"><span class="title italic">Digital Bodleian</span></a>
+                        <span class="note">(10 images from 35mm slides)</span></span><br /></p>
+               </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Online resources:</h4>
+                        
+                        <div class="bibl"><a href="http://jonas.irht.cnrs.fr/manuscrit/39762" target="_blank"><span class="title italic">JONAS: Répertoire des textes et des manuscrits médiévaux d'oc et d'oïl</span></a></div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 23</h1>
+      <div class="content tei-body" id="manuscript_44">
+         <div class="msDesc" id="MS_Add_A_23-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">24721</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_23-item1">
+                  <div class="locus"></div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_12207">Herbal</a></span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Macer el qualle te scriue li vertu de alchune herbe</span></div>
+                  
+                  <p class="note">Describing the appearance, medical properties, etc., of eighty-six plants, each with
+                     a large coloured drawing, roughly executed</p>
+                  
+                  <p class="note">An index precedes</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Italy</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="seg"><span class="measure">ii</span> + <span class="measure">90</span></span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">8.625</span> × <span class="width">6.625</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  <div>
+                     <h4>Condition</h4>
+                     <div class="condition">Two leaves are lost after fol. 34, and the upper parts of some leaves at the end are
+                        injured</div>
+                  </div>
+                  
+                  
+                  
+                  </div>
+               
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="summary"><a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> ii. 929, <a href="https://babel.hathitrust.org/cgi/pt?id=uc1.32106006446402&amp;seq=261" target="_blank">Pl. LXXIX, fol.   19: Lucia</a>
+                     </p>
+                  
+                  <p class="decoNote">Miniatures (coloured drawings)
+                     </p>
+                  
+                  </div>
+               
+               
+               <div class="additions"><span class="tei-label">Additions: </span>There are some rather later corrections of the accounts</div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century, first half</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">There is an erased entry, beginning 'Bibliothecę ...'</p>
+                  <p class="provenance"><span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_19743305">Guiglelmo Libri, 1803-1869</a></span>.</p>
+                  <p class="acquisition">Purchased at his sale, Sotheby's, 31 March 1859, lot. 482.</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (January 2025) by Stewart J. Brookes from the Summary Catalogue
+                     (1905)
+                     
+                     <div class="listBibl">     
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0087.gif">Summary Catalogue, Vol. 5, p. 52</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-01-07: Description revised to incorporate all the information in the Summary Catalogue (1905)</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 25</h1>
+      <div class="content tei-body" id="manuscript_45">
+         <div class="msDesc" id="MS_Add_A_25-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">28398</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_A_25-item1">
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_19697406">M. Marulo</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_3035">Commentary on inscriptions found at Rome and in Italy and Dalmatia</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>M. Maruli ad Dominicum Papalem in Epigrammata priscorum commentarius</span></div>
+                  
+                  <p class="note">A commentary on  inscriptions found at Rome and other places in Italy, but especially
+                     
+                     (fol. 1-end) such as were found at Salona in Dalmatia, and were then in the museum
+                     of Papalis at Spalato</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>3 + <span class="measure">lxxii</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">8.875</span>
+                        </div>
+                     </div>
+                  
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">16th century, early</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">There is a criticism of the worth of this collection by John Wordsworth (<i>c</i>. 1875)</p>
+                  <p class="acquisition">Purchased for £1 3<i>s</i>.</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (July 2025) by Stewart J. Brookes from the Summary Catalogue (1905)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0478.gif">Summary Catalogue, Vol. 5, p. 443</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-07-25: Description revised to incorporate all the information in the Summary Catalogue (1905)
+               and other printed sources</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 26</h1>
+      <div class="content tei-body" id="manuscript_46">
+         <div class="msDesc" id="MS_Add_A_26-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">28566</span>
+                  </p>
+               </div>
+            <h4 class="msHead">Questions on Peter Lombard, Sentences, bk. IV; Germany, 15th century, second half</h4>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</p>
+               
+               <div class="msItem" id="d49e98">
+                  
+                  <div class="locus">(fol. i recto)</div>
+                  
+                  <p class="note">Eighteenth-century addition: see Provenance.</p>
+                  </div>
+               
+               <div class="msItem" id="d49e107">
+                  
+                  <div class="locus">(fol. 1r)</div>
+                  <span class="tei-title">Question on worthy recitation of the paternoster</span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Vtrum aliquis habens rancorem in corde debeat dicere pater noster an non.</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>potest dicere in fora ecclesie</span></div>
+                  </div>
+               
+               <div class="msItem" id="d49e122">
+                  
+                  <div class="locus">(fols. 2r–153v)</div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_11250">Questions on Peter Lombard, <span class="title italic">Sentences</span>, book 4</a></span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Samaritanus. Queritur quid sit sacramentum et diffinitur pluribus modis. Primo dicit
+                        magister Sacramentum est sacre rei signum, sed contra, Ymago crucifixi est sacre rei
+                        signum, non tamen est sacramentum</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span><span class="locus">(fol. 32)</span> Queritur utrum sacramenta debuerunt institui. Videtur quod non. Superfluum est fieri
+                        per plura quod potest fieri per pauciora, sed homo sufficienter potuit reparari per
+                        fidem et virtutes, ergo superfluunt sacramenta</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>sub racione sufficientissimi omnia reputantis</span></div>
+                  
+                  <p class="note">Listed by <span class="bibl">Frédéric Stegmüller, <span class="title italic">Repertorium commentarium in Sententias Petri Lombardi</span> (Würzburg, 1947), no. 1031; the incipit also resembles nos. 1080 and 1081, </span>; cf. Victorin Doucet, <span class="title italic">Commentaires sur les Sentences. Supplément au répertoire de M. Frédéric Stegmueller</span> (Firenze 1954), no. 1081.</p>
+                  
+                  <div class="nestedmsItem" id="d49e157" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                     
+                     <div class="locus">(fols. 154r–162v)</div>
+                     <span class="tei-title">Table of questions</span>
+                     </div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>Paper, folded in quarto; watermark, dreiberg with cross.</div>
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="seg"><span class="measure">i</span> + <span class="measure">162</span></span> leaves, 
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">215</span> × <span class="width">155</span> mm.
+                        
+                        </div>
+                     </div>
+                  
+                  <div class="foliation"><span class="tei-label">Foliation: </span>Modern foliation: i, 1-162.</div>
+                  
+                  <div class="collation">
+                     <h4>Collation</h4>
+                     <div class="collation">1(12)-12(12) (fols. 1-144), 13(18) (fols. 145-162). <span class="catchwords">Catchwords</span>.</div>
+                  </div>
+                  
+                  
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p>Frame-ruled in ink. 37 long lines, ruled space c. 
+                        <span class="height">158</span> × <span class="width">97</span> mm.
+                        
+                        
+                        </p>
+                     </div>
+                  </div>
+               
+               <div class="handDesc">
+                  <h4>Hand(s)</h4>
+                  
+                  <p class="handNote">Hybrida (with several cursive forms), likely written in a single hand.</p>
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">Two-line initials in red.</p>
+                  
+                  <p class="decoNote">Rubricated headings.</p>
+                  </div>
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">Contemporary, German. Red leather on boards, with plain ruled lines and five brass
+                     bosses on each side. Strap-and-pin fastenings closing on the front board, lost. A
+                     later title (?) on the spine (illegible) followed by shelfmark (?), perhaps '173'.</p>
+                  
+                  </div>
+               
+               <div class="accMat">
+                  <h4>Accompanying Material</h4>
+                  <p>Centres of quires strengthened with fragments of a 14th(?)-century medical (?) manuscript
+                     on parchment.</p>
+               </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century, second half</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7000084">Germany</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">
+                     <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_30286332">Rudolf Anton Fabricius</a></span> (1689–1772) (?): an eighteenth-century inscription (fol. i recto) reads ‘<span style="text-decoration:underline;">Hieronymi Seripandi</span>, Cardinalis, qui Concilio Tridentino interfuit, (mortui A. 1563) Tractatus non editus,
+                     <span style="text-decoration:underline;">de Sacramentis in genere, et in specie</span>, argumentisque aliis connexis. Contenta hujus libri vide sub finem. Fuit in Auctione
+                     Rud. Aug. Fabricii, Prof. Helmst., qui eum ex itinere Italico attullit.’.</p>
+                  <p class="acquisition">Bought for £1 in 1850 (<span class="title italic">Summary Catalogue</span>)</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Description by Andrew Dunning (April 2021). Previously described: 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0511.gif">Summary Catalogue, Vol. 5, p. 476</a></div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0512.gif">Summary Catalogue, Vol. 5, p. 477</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <div class="surrogates">
+                  <h3 class="msDesc-heading3">Digital Images</h3>
+                  <p><span class="bibl">
+                        <a href="https://digital.bodleian.ox.ac.uk/objects/89ad56ee-1b64-4ab8-8605-b141b9016cad/" target="_blank">
+                           <span class="title italic">Digital Bodleian</span></a>
+                        <span class="note">(full digital facsimile)</span>
+                        </span><br /></p>
+               </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Online resources:</h4>
+                        
+                        <div class="bibl"><a href="https://hab.bodleian.ox.ac.uk/en/" target="_blank"><span class="title italic">Manuscripts from German-Speaking Lands – A Polonsky Foundation Digitization Project</span></a></div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2021-04-15: <span class="persName">Andrew Dunning</span> Revised with consultation of original.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 27</h1>
+      <div class="content tei-body" id="manuscript_49">
+         <div class="msDesc" id="MS_Add_A_27-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">28747</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_27-item1">
+                  <div class="locus"></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_29576537">Domenico Cavalca</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_1414">Spechio de Croce</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Spechio de Croce</span></div>
+                  
+                  <p class="note">In 52 chapters with a preface</p>
+                  
+                  <p class="note">The volume is lettered outside and described inside as Savonarola's Trionfo della
+                     Croce</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Italian</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  
+                  <div class="extent"><span class="seg"><span class="measure">vii</span> + <span class="measure">84</span> leaves</span>
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">9.5</span> × <span class="width">6.75</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  </div>
+               
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">Illuminated capital</p>
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">14th century, second half</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="acquisition">Purchased for £4 at Sotheby's on 20-21 June 1860, lot 103, along with <a href="https://medieval.bodleian.ox.ac.uk/?utf8=%E2%9C%93&amp;q=%22Sotheby%27s+on+20-21+June+1860%22" target="_blank">eight other manuscripts</a> 
+                     'formerly in the archives of two princely Roman families'</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (June 2025) by Stewart J. Brookes from the Summary Catalogue (1905)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0538.gif">Summary Catalogue, Vol. 5, p. 503</a></div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0539.gif">Summary Catalogue, Vol. 5, p. 504</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-06-19: Description revised to incorporate all the information in the Summary Catalogue (1905)</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 29</h1>
+      <div class="content tei-body" id="manuscript_56">
+         <div class="msDesc" id="MS_Add_A_29-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">24754</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_A_29-item1">
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_14336">Religious meditations, treatises and sermons</a></span>
+                   <span class="note">(chiefly on the Passion of Christ)</span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Italian and Latin</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="physDesc-p">three parts</div>
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">16th century</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italian</a></span>
+                     </span>
+                  </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Summary description by Elizabeth Solopova and Matthew Holford based on the Summary
+                     Catalogue and supplementary sources. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0096.gif">Summary Catalogue, Vol. 5, p. 61</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 30</h1>
+      <div class="content tei-body" id="manuscript_57">
+         <div class="msDesc" id="MS_Add_A_30-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">30142</span>
+                  </p>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="physDesc-p">Composite: three parts. Parts 2 and 3 (fols. 237–255) were once a separate volume.</div>
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">19th century binding.</p>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">'<span class="persName sgn"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_2742">Jehan Hepworthe</a></span>', 16th cent. (fol. 255).</p>
+                  <p class="provenance">'<span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_5714087">Henrici Spelman</a></span>', fol. 1.</p>
+                  <p class="acquisition">Probably acquired before 1870.</p>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_30-part1" style="padding-left:2rem; margin-top:1rem; border-bottom-color:#C0C0C0; border-top:1px #C0C0C0 solid;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 30 – Part 1 (fols. 1–236)</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <div class="msItem" id="MS_Add_A_30-part1-item1" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_15216">Texts relating to the Order of the Knights Hospitallers of St John of Jerusalem</a></span>
+                     
+                     <div class="nestedmsItem" id="d60e187" style="margin-top:1rem;">
+                        
+                        <div class="locus">(fols. 1–7)</div>
+                        
+                        <p class="note">Index by 'Fernandus' to the statutes and customs of the Order</p>
+                        
+                        <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Portuguese</div>
+                        </div>
+                     
+                     <div class="nestedmsItem" id="d60e199">
+                        
+                        <div class="locus">(fol. 12v)</div>
+                        
+                        <p class="note">Account of the order</p>
+                        
+                        <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                        </div>
+                     
+                     <div class="nestedmsItem" id="d60e211">
+                        
+                        <div class="locus">(fol. 13)</div>
+                        
+                        <div class="rubric"><span class="tei-label">Rubric: </span><span>Ces sont les Rubriques de la Regle et des establymens de la saint Mayson del hospital
+                              de Jerusalem</span></div>
+                        
+                        <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle French</div>
+                        </div>
+                     
+                     <div class="nestedmsItem" id="d60e223">
+                        
+                        <div class="locus">(fol. 23)</div>
+                        
+                        <p class="note">Account of the order, with statutes, customs (fol. 168), etc., from about 1150 to
+                           1346</p>
+                        
+                        <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle French</div>
+                        </div>
+                     
+                     <div class="nestedmsItem" id="d60e236">
+                        
+                        <div class="locus">(fols. 97–167v)</div>
+                        
+                        <p class="note">Written later:</p>
+                        
+                        <div class="nestedmsItem" id="d60e244" style="margin-top:1rem;">
+                           
+                           <div class="locus">(fols. 97–101v)</div>
+                           
+                           <p class="note">Ordinances for 1352</p>
+                           
+                           <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Old Provençal</div>
+                           </div>
+                        
+                        <div class="nestedmsItem" id="d60e256">
+                           
+                           <div class="locus">(fols. 101v–110v)</div>
+                           
+                           <p class="note">Ordinances for 1354</p>
+                           
+                           <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle French</div>
+                           </div>
+                        
+                        <div class="nestedmsItem" id="d60e268">
+                           
+                           <div class="locus">(fols. 110v–116v)</div>
+                           
+                           <p class="note">Ordinances for 1356</p>
+                           
+                           <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Old Provençal</div>
+                           </div>
+                        
+                        <div class="nestedmsItem" id="d60e281">
+                           
+                           <div class="locus">(fols. 117–131)</div>
+                           
+                           <p class="note">Ordinances for 1373</p>
+                           
+                           <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle French</div>
+                           </div>
+                        
+                        <div class="nestedmsItem" id="d60e293">
+                           
+                           <div class="locus">(fols. 131v–137)</div>
+                           
+                           <p class="note">Ordinances for 1382</p>
+                           
+                           <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle French</div>
+                           </div>
+                        
+                        <div class="nestedmsItem" id="d60e305">
+                           
+                           <div class="locus">(fols. 137v–140)</div>
+                           
+                           <p class="note">Undated ordinances</p>
+                           
+                           <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle French</div>
+                           </div>
+                        
+                        <div class="nestedmsItem" id="d60e317" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                           
+                           <div class="locus">(fols. 140v–167v)</div>
+                           
+                           <p class="note">Ordinances for 1410</p>
+                           
+                           <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle French</div>
+                           </div>
+                        </div>
+                     
+                     <div class="nestedmsItem" id="d60e330">
+                        
+                        <div class="locus">(fol. 219)</div>
+                        
+                        <p class="note">List of the Masters of the Order to about 1350</p>
+                        
+                        <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle French</div>
+                        </div>
+                     
+                     <div class="nestedmsItem" id="d60e342" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                        
+                        <div class="locus">(fol. 223)</div>
+                        
+                        <p class="note">Treatise on the rights and duties of Masters of the Order</p>
+                        
+                        <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle French</div>
+                        </div>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     <div class="extent">
+                        
+                        <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                           <span class="height">240</span> × <span class="width">170</span> mm.
+                           
+                           </div>
+                        
+                        <div class="dimensions"><span class="tei-label">Dimensions (written): </span>
+                           <span class="height">160</span> × <span class="width">113</span> mm.
+                           
+                           </div>
+                        </div>
+                     
+                     
+                     <div class="layoutDesc">
+                        <h4>Layout</h4>
+                        
+                        <p>1 col., 24 lines</p>
+                        </div>
+                     </div>
+                  
+                  <div class="handDesc">
+                     <h4>Hand(s)</h4>
+                     
+                     <p class="handNote">Additions in cursive scripts except fols. 110v-116v, in hybrida.</p>
+                     </div>
+                  
+                  <div class="decoDesc">
+                     <h4>Decoration</h4>
+                     
+                     <p class="decoNote">Coloured initials. </p>
+                     
+                     <p class="decoNote">Rubrics.</p>
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">1350 with additions to c. 1410</span>
+                     ; <span class="origPlace">
+                        <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000070">French</a></span>, <span class="region">Provence</span> (?)</span>
+                     </div>
+                  <div class="provenance">
+                     <h4>Provenance</h4>
+                     <p class="provenance">Name of original scribe and owner erased, fol. 12v: 'Ista statuta sunt fratris f[erased,
+                        replaced by <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_2743">Petri Moronaej (?) de Villanoua</a></span> (?), also erased] Qui ea fierj fecit in domo sua. que conpleta fuerunt. Anno domini
+                        Mo.ccc.L. Et costauerant. Florenos xj gillatos vij.'</p>
+                     <p class="provenance">'<span class="persName sgn"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_2744">Guirardus de Pareto</a></span>', 15th century (fol. 236v).</p>
+                  </div>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_30-part2" style="padding-left:2rem; border-bottom-color:#C0C0C0;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 30 – Part 2</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <div class="msItem" id="MS_Add_A_30-part2-item1" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     
+                     <div class="locus">(fol. 237)</div>
+                     <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_13120">Manual of confession</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Cy commence la Confession en Rommant</span></div>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Premierement Tu te doys deuotement agenoillier</span></div>
+                     
+                     <p class="note">Includes a paraphrase of the Lord's Prayer, fol. 246.</p>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle French</div>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">15th century</span>
+                     ; <span class="origPlace">
+                        <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000070">French</a></span>
+                        </span>
+                     </div>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_30-part3" style="padding-left:2rem; border-bottom-color:#C0C0C0;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 30 – Part 3</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <div class="msItem" id="MS_Add_A_30-part3-item1" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     
+                     <div class="locus">(fol. 249)</div>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Sermo sancti Augustini Episcopi contra Iudaeos</span></div>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Vos inquam conuenio o iudei</span></div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_250796368">Quodvultdeus</a></span>, 
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_4164">Sermo contra iudaeos, paganos, et arianos</a></span>, 
+                     
+                     <p class="note">§§ 11–17, ed. PL 42, 1123–27 and CC 60, 241–50.</p>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">15th century</span>
+                     ; <span class="origPlace">
+                        <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000095">Spanish</a></span>
+                        </span>
+                     </div>
+               </div>
+            </div>
+            <h2><?ni?>Additional Information<?ni?></h2>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Adapted (2017) from A. G. Watson, <span class="title italic"><a href="https://catalog.hathitrust.org/Record/000310664" target="_blank">Catalogue of Dated and Datable Manuscripts c.435–1600 in Oxford Libraries</a></span> (Oxford, 1984), no. 2 [part 1 only], and from the Summary Catalogue (1905). 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0779.gif">Summary Catalogue, Vol. 5, p. 742</a></div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0780.gif">Summary Catalogue, Vol. 5, p. 743</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 42</h1>
+      <div class="content tei-body" id="manuscript_65">
+         <div class="msDesc" id="MS_Add_A_42-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">30149</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_42-item1">
+                  <div class="locus"></div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_11763">Exhortation addressed to Mary and Anne and other nuns of the convent of <span class="orgName"><a href="https://medieval.bodleian.ox.ac.uk/catalog/org_37">Amesbury</a></span>
+                        </a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Mary and Anne with all the other devo3th dyscyples of the scale of cryste in youre
+                        monastery of Amysbury</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>My dear susterys Mary and Anne</span></div>
+                  
+                  <p class="note">Extracts from the vow of profession show that Christiana was then prioress</p>
+                  <span class="listBibl">
+                     
+                     <div class="bibl">Yvonne Parrey, "‘Devoted disciples of Christ’: Early Sixteenth-Century Religious Life
+                        in the Nunnery at Amesbury",  <span class="title italic">Historical Research</span>, 67 (1994) 240-248</div>
+                     </span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>English</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>iii + <span class="measure">33</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">7.75</span> × <span class="width">5.125</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  <div>
+                     <h4>Condition</h4>
+                     <div class="condition">Imperfect and in places stained and injured by damp. One or more sheets of ten leaves
+                        appear to be missing after fol. 10</div>
+                  </div>
+                  
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">16th century, first half</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7002445">England</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">
+                     <span class="orgName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/org_37">Amesbury, Wiltshire, Priory (cell of Fontevrault) and later abbey of Sts Mary the
+                           Virgin and Melior, of Benedictine nuns</a></span> (?)</p>
+                  <p class="provenance">Owned by <span class="persName fmo">Cornelys Johnston</span> in 1590 (fol. 18v; cf. 4, 5v, 11, 13v)</p>
+                  <p class="acquisition">Probably acquired before 1860</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (May 2025) by Stewart J. Brookes from the Summary Catalogue (1905)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0781.gif">Summary Catalogue, Vol. 5, p. 744</a></div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0782.gif">Summary Catalogue, Vol. 5, p. 745</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Online resources:</h4>
+                        
+                        <div class="bibl">
+                           <a href="http://mlgb3.bodleian.ox.ac.uk/mlgb/book/273" target="_blank">
+                              <span class="title italic">MLGB3: Medieval Libraries of Great Britain</span> (<a href="https://web.archive.org/web/20180527201527/http://mlgb3.bodleian.ox.ac.uk/mlgb/book/273/" target="_blank">archive copy</a>)
+                              </a>
+                           </div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-05-29: Description revised to incorporate all the information in the Summary Catalogue (1905)
+               and other printed sources</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 44</h1>
+      <div class="content tei-body" id="manuscript_66">
+         <div class="msDesc" id="MS_Add_A_44-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">30151</span>
+                  </p>
+               
+               <p class="msName">The Bekynton anthology</p>
+               </div>
+            <h4 class="msHead">Secular and religious verse with some prose ('The Bekynton anthology');
+               England, early 13th century, additions 15th century.</h4>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msSummary"><span class="tei-label">Summary of Contents: </span>An anthology of secular and religious verse with some prose, mostly
+                  written in the early 13th century, with a 15th-century index and supplements
+                  (items here numbered 1, 4, 50–4, 74, 113).</div>
+               
+               <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</p>
+               
+               <div class="msItem" id="d69e116">
+                  
+                  <div class="locus">(fol. 2r–v)</div>
+                  
+                  <p class="note">13th-century table of contents for '100' items (the last is the present
+                     no. 111). Fol. 1r–v blank except for later names, an added sketch of a
+                     labyrinth (?), and the 15th century note ‘Centum <ins class="">\decem/</ins> contenta
+                     in isto volumine continentur’.</p>
+                  </div>
+               
+               <div class="msItem" id="d69e131">
+                  
+                  <div class="locus">(fols. 3r–6v)</div>
+                  
+                  <p class="note">15th-century table of contents for '110' items. </p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item1">
+                  
+                  <div class="locus"><span class="item-number">1. </span>(fols. 6v–7r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Epistola Veteris de Monte super purgacione infamie contra Regem Anglie
+                        Ricardum Cuir de Lyon exorte</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Vetus de Monte, principibus et omni populo Christiane religionis
+                        salutem. Quoniam audiuimus Illustri Anglorum Regi Ricardo necem Marchionis
+                        de Monte Ferrato a pluribus imputari tamquam eius machinatione ob quandam
+                        inter eos exortam simultatem interfectus sit, cum uterque esset in Orientis
+                        partibus constitutus, nostre honestatis interest ad purgandam eiusdem Regis
+                        famam falsi criminis suspicione denigratam, huius rei ueritatem, que
+                        hactenus pene nos latuit, declarare. Nolumus alicuius innocentiam</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>nec nos homini immerito malum moliri respectu honestatis nostre
+                        sineremus. Bene Valete</span></div>
+                  
+                  <p class="note"><span class="title italic">Chronicon Walteri de Hemingburgh</span>, ed. H. C. Hamilton
+                     (1848), 213 seq.</p>
+                  
+                  <p class="note">Added, 15th century.</p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item2">
+                  
+                  <div class="locus"><span class="item-number">2. </span>(fols. 7v–8v)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_82793219">Geoffrey of Vinsauf</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_1679">Poetria noua</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Planctus de morte Regis Ricardi Cuir de lyon. – Capitulum
+                        primum</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Neustria sub clipeo regis defensa Ricardi</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Quam brevis est risus, quam longa est lacrima mundi</span></div>
+                  
+                  <p class="note">Lines 368–430 (ed. E. Faral, 1923, pp. 208–210) </p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=11750" target="_blank">Walther 11750</a></span>
+                  </div>
+               
+               <div class="msItem" id="d69e194">
+                  
+                  <p class="note">For fols. 9r–12v see art. 113 below.</p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item3">
+                  
+                  <div class="locus"><span class="item-number">3. </span>(fols. 13r–16v)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_95147024">Jerome</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_2409">Aduersus Iouinianum</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Inuectio Ieronimi contra Iouinianum et dissuasio uxorandi, et contra
+                        amorem carnalem. – Caᵐ II.dum</span></div>
+                  
+                  <div class="nestedmsItem" id="d69e214" style="margin-top:1rem;">
+                     
+                     <div class="nestedmsItem" id="d69e216" style="margin-top:1rem;">
+                        
+                        <div class="incipit"><span class="tei-label">Incipit: </span><span>Supra in transitu ubi nobis aduersarius proposuerat Salomonem
+                              multinubam</span></div>
+                        
+                        <div class="explicit"><span class="tei-label">Explicit: </span><span>uirginitati in euangelio seruiamus</span></div>
+                        </div>
+                     
+                     <div class="nestedmsItem" id="d69e225" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                        
+                        <div class="incipit"><span class="tei-label">Incipit: </span><span> Amor forme rationis obliuio est</span></div>
+                        
+                        <div class="explicit"><span class="tei-label">Explicit: </span><span>viros esse desinere</span></div>
+                        </div>
+                     
+                     <p class="note">I, 28–29 (PL 23, ed. 1845, col. 249B–251D); 49 (ib., 280C, l.
+                        7–282C)</p>
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d69e239" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Non latet angelos crebro electis inuisibili adesse presentia, ut
+                           eos ab hostis callidi defendant insidiis</span></div>
+                     
+                     <div class="explicit"><span class="tei-label">Explicit: </span><span>quatinus et in conspectu angelorum digni efficiamur, et dominus ad
+                           nos ueniens non quid contempnat in nobis, set pocius quod remuneret
+                           inueniat</span></div>
+                     </div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item4">
+                  
+                  <div class="locus"><span class="item-number">4. </span>(fols. 17r–24r)</div>
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_11301">Commentary on Walter Map, Dissuasio Valerii</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Exposicio sequentis epistole Valerii ad Rufinum et cetera.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span><i>Loqui prohibeor</i> ut infra in textu. In hac epistola
+                        intellige quod per mulierem sensualitas et illud quod carnis fragilitas
+                        suggerit, per uirum racio et quod docet fortitudinis sinceritas designatur.
+                        Sicut patet in glosa prima ad Cor<span class="ex">(inthios)</span> II</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span><i>Amice si non es</i> ut infra. Amice hic
+                        concludit et diuiditur prima pars <i>Examina</i>. sunt proprie
+                        societates apum, quia in maxima multitudine simul habitant, cetera sunt
+                        plana et ideo dicit <i>Amice</i>
+                        <span class="supplied">⟨ethicum⟩</span>
+                        <span class="defective">||</span></span></div>
+                  
+                  <p class="note">Ends imperfect; added, 15th century.</p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item5">
+                  
+                  <div class="locus"><span class="item-number">5. </span>(fols. 25r–29v)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_98031958">Walter Map</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_4964">De nugis curialium dist. IV, III–V: Dissuasio Valerii ad
+                        Ruffinum philosophum ne uxorem ducat</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>De dissuasione muliebris amoris. Ca<sup>m</sup>
+                        III</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Loqui prohibeor et tacere non possum. Grues odi et uocem
+                        ulule</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Sed ne Orestem scripsisse uidear. Vale</span></div>
+                  
+                  <p class="note">ed. M. R. James, 1914, pp. 143–158</p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item6">
+                  
+                  <div class="locus"><span class="item-number">6. </span>(fols. 29v–30r)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_95147024">Jerome</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_2409">Aduersus Iouinianum</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Aureolus Theophrastus libro de nupciis. – Quartum</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Fertur Aureolus Theophrasti liber de nupciis, in quo querit an uir
+                        sapiens ducat uxorem</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>quos judicio eligas, quam quos uelis nobis habere cogaris</span></div>
+                  
+                  <p class="note">I 47 (PL 23, col. 276B, l. 14–278B, l. 10). </p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item7">
+                  
+                  <div class="locus"><span class="item-number">7. </span>(fol. 30r–v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Querelosa lamentacio contra falsum amatorem et optacio mortis. – Ca<sup>m</sup> quintum</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Anna soror| ut quid mori| tandem moror|</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>|ne semper moriar | me semel perime</span></div>
+                  
+                  <p class="note">ed. Wilmart, Appendix, 35–90, no. I </p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=1061" target="_blank">Walther 1061</a></span>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=23007" target="_blank">Chevalier 23007</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item8">
+                  
+                  <div class="locus"><span class="item-number">8. </span>(fols. 30v–44v)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_88800528">Bernard Silvestris</a></span>, 
+                  <span class="tei-title italic">Liber mathematicus</span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Carmen metricum de filio nominato per matrem patricida, qui secundum
+                        fata Rome imperaret, set patrem interficeret, fatum suum superante. –Ca<sup>m</sup> VItum</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Semper ut ex aliqua felices parte querantur| Leges humanae
+                        condicionis habent </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Pono citus trabeam, uestrum citus exuo regem, | Liber et
+                        explicitus ad mea uota meus</span></div>
+                  
+                  <p class="note">PL 172 col. 1365–1380</p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=17506" target="_blank">Walther 17506</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item9">
+                  
+                  <div class="locus"><span class="item-number">9. </span>(fol. 45r–v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Carmen ritmicum, de variis hominum affectibus et uoluptatibus. – Ca<sup>m</sup> VII</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Ridere solitus | Democritus | ad occursus singulos</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>par sequitur uoluptas.| Varia etc</span></div>
+                  
+                  <p class="note">ed. Wilmart, Appendix, 35–90, no II </p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=16807" target="_blank">Walther 16807</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item10">
+                  
+                  <div class="locus"><span class="item-number">10. </span>(fols. 45v–46r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Carmen ritmicum contra simoniam et cupiditates presulum, et precipue
+                        curie Romane. – VIII</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Ni lauare laterem | me crederem | corrigendis uiciis |
+                        operam inpenderem</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>ibis Homere foras. | Roma potens et cetera</span></div>
+                  
+                  <p class="note">ed. Wilmart, Appendix, 35–90, no. III. </p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=11758" target="_blank">Walther 11758</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item11">
+                  
+                  <div class="locus"><span class="item-number">11. </span>(fol. 46r–v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Dialogus inter euntem ad curiam et uenientem a Roma, de malis moribus
+                        curie. – IX.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Bene ueneritis, caretis socio. | Quid solus queritis, que uie
+                        racio? </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Hunc sequar cicius. Vale per omnia.</span></div>
+                  
+                  <p class="note"> ed. Wilmart, Appendix, 35–90, no. IV. </p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=2136" target="_blank">Walther 2136</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item12">
+                  
+                  <div class="locus"><span class="item-number">12. </span>(fols. 47r–53r)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_62342032">Mathieu de Vendôme</a></span>, 
+                  <span class="tei-title italic">Miles gloriosus</span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Carmen metricum quomodo miles adolescens Rome in mechiam inductus manus
+                        exploratorum euaserit. – Ca<sup>m</sup> X.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Vernat eques, uix prima genis lanugo susurrat| maturumque uigor
+                        clamitat esse uirum</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Dum sua corpus habet sua sunt connubia cordi | Illis uer animos
+                        nulla perurit hiemps.</span></div>
+                  
+                  <p class="note">ed. G. Cohen, 1931, t. II, pp. 196–210: v. 3–366.</p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=20216" target="_blank">Walther 20216</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item13">
+                  
+                  <div class="locus"><span class="item-number">13. </span>(fols. 53r–54r)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_1578145857026422921111">Pierre Bérenger</a></span>, 
+                  <span class="tei-title italic">Epistula contra Carthusienses</span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Epistola Berengarii ad fratres Cartusie de malis eorum iudiciis. –
+                        XI</span></div>
+                  
+                  <div class="nestedmsItem" id="d69e554" style="margin-top:1rem;">
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Fratribus in Cartusie professione iuratis, Berengarius cum Lazaro
+                           quondam paupere eternam habere requiem. Loquar ad dominos meos cum sim
+                           puluis et cinis </span></div>
+                     
+                     <div class="explicit"><span class="tei-label">Explicit: </span><span>Vt breviter dicam, sine crimine nullus apud uos</span></div>
+                     
+                     <p class="note">PL 178, col. 1875 – 1876C, l. 8.</p>
+                     </div>
+                  
+                  <div class="nestedmsItem" id="d69e567" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Cum sederit filius hominis</span></div>
+                     
+                     <div class="explicit"><span class="tei-label">Explicit: </span><span>Valete et si deum diligitis linguam dei gladio
+                           amputate.</span></div>
+                     
+                     <p class="note">ed. Wilmart, Appendix, 35–90, no V. </p>
+                     </div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item14">
+                  
+                  <div class="locus"><span class="item-number">14. </span>(fols. 54v–55r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Carmen ritmicum Eraclii contra auaros et contra luxuriosos et abbates
+                        querentes pontificari. – Ca<sup>m</sup> XII</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Omnis vere confitens vere Christum colit| Quisquis in se uicia
+                        frangit, terit, molit</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Prauos mores condiens ueritatis sale</span></div>
+                   <span class="note">(ed. Wilmart, Appendix, 35–90, no VI.) </span>
+                  
+                  <p class="note">Not in Walther.</p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item15">
+                  
+                  <div class="locus"><span class="item-number">15. </span>(fols. 55v–56v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>De albo monacho in episcopum promoto et a deo remoto. – XIII</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Ab humilitate in superbiam cadens, a quo bono in quod malum non
+                        corruit? </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Videant hoc pauperes et letentur. </span></div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item16">
+                  
+                  <div class="locus"><span class="item-number">16. </span>(fols. 56v–57r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Quomodo eligunt sibi similes malos, et abiciunt sibi dissimiles malos.
+                        – Ca<sup>m</sup> XIIII</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Ecce quales entes quales habent, et unde magis dolendum est quales
+                        abiciunt </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>et ab eis cauendum predicant per plateas</span></div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item17">
+                  
+                  <div class="locus"><span class="item-number">17. </span>(fol. 57r–v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Contra nepotes pontificum subito exaltatos. – Ca<sup>m</sup> XV</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>In instructione rudium nepotum episcoporum primum occurrit fortune </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Heccine uiget optima generacio pontificalis, praua et
+                        exasperans.</span></div>
+                  
+                  <p class="note">ed. Wilmart, Appendix, 35–90, no. VII. </p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item18">
+                  
+                  <div class="locus"><span class="item-number">18. </span>(fols. 57r–58v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Carmen ritmicum contra abbates et priores querentes curiosas et
+                        delicatas escas. – Ca<sup>m</sup> XVI</span></div>
+                  
+                  <div class="nestedmsItem" id="d69e672" style="margin-top:1rem;">
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Satis uobis notum est et res manifesta </span></div>
+                     
+                     <div class="explicit"><span class="tei-label">Explicit: </span><span>Verba legis recitat in rebelles date</span></div>
+                      <span class="note">(Strophes 1–13: ed. Flacius, 1557, pp. 113–115.)</span>
+                     <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=17296" target="_blank">Walther 17296</a></span>
+                     </div>
+                  
+                  <div class="nestedmsItem" id="d69e688" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Ergo seruientibus omnibus accitis</span></div>
+                     
+                     <div class="explicit"><span class="tei-label">Explicit: </span><span>Quando uos persequitur Nero scire pati</span></div>
+                     
+                     <p class="note">ed. Wilmart, Appendix, 35–90, no VIII. </p>
+                     
+                     <p class="note">Not in Walther.</p>
+                     </div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item19">
+                  
+                  <div class="locus"><span class="item-number">19. </span>(fols. 58v–59r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Item carmen ritmicum quod uinum sit limphandum. – XVII</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Reuerendi iudices quorum habet cura | et stare pro legibus et
+                        tueri iura</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Meam si repleuerint, ego non refutem</span></div>
+                  
+                  <p class="note">Collection de Bâle, no XXVI (ed. I. Werner, <span class="title italic">Nachrichten de
+                        Göttingen</span>, 1908, p. 468 sq.). </p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=16696" target="_blank">Walther 16696</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item20">
+                  
+                  <div class="locus"><span class="item-number">20. </span>(fol. 59r–v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Contra uinum limphatum et quod uinum limphari non debeat. –
+                        XVIII</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Suspicor superfluum iudices preclari | prece siue precio uobis
+                        adulari</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Venerem non Thetidem Bacho copulate</span></div>
+                  
+                  <p class="note">ed. Wilmart, Appendix, 35–90, no IX. </p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=18966" target="_blank">Walther 18966</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item21">
+                  
+                  <div class="locus"><span class="item-number">21. </span>(fols. 59v–60v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Item carmen ritmicum contra auariciam et ypocrisim presulum et abbatum.
+                        – Capitulum XIX</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Anglorum pater presulum | noster archiepiscope | Audi quid
+                        preter solitum, nostra plangat Calliope </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Vbi pausat et calefit, bibit mansit et cetera</span></div>
+                  
+                  <p class="note">ed. C. L. Kingsford, EHR 5 (1890), 321 sq. </p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=1035" target="_blank">Walther 1035</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item22">
+                  
+                  <div class="locus"><span class="item-number">22. </span>(fols. 60v–61r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Collatio iocosa de diligendo Lieo. – Ca<sup>m</sup>
+                        XX.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>De ueteri testamento aliqua uobis memoranda proponimus </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>ab omnibus uenter tueatur aduersis. Qui uiuis <span class="editorialgap"> […] </span>
+                        </span></div>
+                  
+                  <p class="note">ed. P. Lehmann, <span class="title italic">Parodistische Texte</span> (1923), pp. 57–59: no
+                     15.</p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item23">
+                  
+                  <div class="locus"><span class="item-number">23. </span>(fol. 61r–v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Dialogus inter dehortantem a curia et curialem. – Ca<sup>m</sup> XXIm</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Quod amicus suggerit | fer cum paciencia</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>mutabitur iocun ditas | in eternum supplicium</span></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_24572572">Peter of Blois</a></span>
+                  
+                  <p class="note">[no IV] 1: PL 207, col. 1133–1136 (str. 21–31).</p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=16242" target="_blank">Walther 16242</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item24">
+                  
+                  <div class="locus"><span class="item-number">24. </span>(fol. 62r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Contra cupiditatem opum et dignitatum. – XXI/m.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Vanitas uanitatum| et omnia uanitas,| sed nostra sic
+                        malignitas | cor habet induratum</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>sarcina temporalium| currat procul abiecta.</span></div>
+                  
+                  <p class="note"> ed. G. Dreves, Analecta hymnica XXI (1895), p. 100: no 149. </p>
+                  <span class="listBibl">
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=20037" target="_blank">Walther 20037</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=21118" target="_blank">Chevalier 21118</a></div>
+                     </span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item25">
+                  
+                  <div class="locus"><span class="item-number">25. </span>(fol. 62r–v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Contra peccata cleri et quod graviter a deo punientur. –
+                        XXIII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Fontis in riuulum| sapor ut defluit|</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>| primus et nouissimus | quadrans exquiretur.</span></div>
+                  
+                  <p class="note"> ed. G. Dreves, ib., p. 146 sq.: no 208. </p>
+                  <span class="listBibl">
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=6754" target="_blank">Walther 6754</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=26742" target="_blank">Chevalier 26742</a></div>
+                     </span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item26">
+                  
+                  <div class="locus"><span class="item-number">26. </span>(fol. 62v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>De spe ponenda in domino, et de die iudicii. – XXIIII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Bonum est confidere|</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>omissis secularibus.</span></div>
+                  
+                  <p class="note"> Carmina Burana: ed. 1930, no XXVII, p. 46. </p>
+                  <span class="listBibl"> 
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=2220" target="_blank">Walther 2220</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=2504" target="_blank">Chevalier 2504</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item27">
+                  
+                  <div class="locus"><span class="item-number">27. </span>(fol. 62v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>De Christi misericordia et potentia. – XXV.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Veritas ueritatum|
+                        </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>| surge, tolle grabatum</span></div>
+                  
+                  <p class="note">Carmina Burana (ib.) : no. XXI, Str. I, p. 40. </p>
+                  <span class="listBibl"> 
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=20205" target="_blank">Walther 20205</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=21432" target="_blank">Chevalier 21432</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item28">
+                  
+                  <div class="locus"><span class="item-number">28. </span>(fols. 62v–63r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Contra curas hominum, et maxime aulicorum. – XXVI.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> O curas hominum| quos curat curia</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>unde locus si queritur</span></div>
+                  
+                  <p class="note">Carmina Burana: ed. Schmeller, 1847, no CLXX, p. 65. </p>
+                  <span class="listBibl"> 
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=12566" target="_blank">Walther 12566</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=30337" target="_blank">Chevalier 30337</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item29">
+                  
+                  <div class="locus"><span class="item-number">29. </span>(fol. 63r–v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Dialogus inter uolentem mentiri seu adulari, et instruentem ad
+                        contrarium, et inducuntur sub nomine Diogenis et Aristippi. – XXVII</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Aristippe quamuis sero</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>cuius semper declinaui| fraudis artificium.</span></div>
+                  
+                  <p class="note"> Carmina Burana: ed. Schmeller, no. CLXXI, str. 1–7, pp. 65–67. </p>
+                  <span class="listBibl"> 
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=1479" target="_blank">Walther 1479</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=23122" target="_blank">Chevalier 23122</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item30">
+                  
+                  <div class="locus"><span class="item-number">30. </span>(fol. 63v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Querela nescientis adulari et contra adulatores. – XXVIII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Adulari nesciens | ab amicis deseror|
+                        </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>potestates misere | affectantes temere, non corde sed auribus
+                        | bene putant facere | falsis fulti laudibus.</span></div>
+                  
+                  <p class="note"> Ed. G. Dreves, Analecta hymnica, XXI, p. 124 sq.: no. 180. </p>
+                  <span class="listBibl"> 
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=551" target="_blank">Walther 551</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=22619" target="_blank">Chevalier 22619</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item31">
+                  
+                  <div class="locus"><span class="item-number">31. </span>(fol. 63v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Contra nolentem trahi a curia et nichilominus dampnantem curiales. –
+                        XXIX.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Cur Tigelli| nec auelli| sustines a curia |
+                        </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span> a te prius ablue. </span></div>
+                   <span class="note">(ed. Wilmart, Appendix, 35–90, no. X.) </span>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=3954" target="_blank">Walther 3954</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item32">
+                  
+                  <div class="locus"><span class="item-number">32. </span>(fols. 63v–64r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Optime consulitur episcopus quomodo uitam corrigat. – XXX.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Non te lusisse pudeat</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>sed cece mentis tenebras | purga uirtutis radio. </span></div>
+                  
+                  <p class="note">Carmina Burana: ed. 1930, no XXXIII, p. 54 sq. </p>
+                  <span class="listBibl">
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=12193" target="_blank">Walther 12193</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=28979" target="_blank">Chevalier 28979</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item33">
+                  
+                  <div class="locus"><span class="item-number">33. </span>(fol. 64r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Planctus de translatione episcopi Cenonensium. – Ca<sup>m</sup> XXXIm.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Ver pacis aperit| telluris gremium|</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>ceduntur gladiis | more bidencium. </span></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100212859">Walter of Chatillon</a></span>
+                   <span class="note">(I): ed. K. Strecker (1925), p. 55 sq.: no XXX.</span>
+                  <span class="listBibl">
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=20133" target="_blank">Walther 20133</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=21314" target="_blank">Chevalier 21314</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item34">
+                  
+                  <div class="locus"><span class="item-number">34. </span>(fol. 64r–v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Contra simoniacos in ecclesia sacra uendentes. – XXXII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Ecce sonat in aperto | uox clamantis in deserto</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>penas luat in eternum amen. </span></div>
+                  
+                  <p class="note">Carmina Burana: ed. 1930, no. X, p. 14. </p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=5149" target="_blank">Walther 5149</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item35">
+                  
+                  <div class="locus"><span class="item-number">35. </span>(fol. 64v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>De eodem, et plangitur contemptus ordinis clericalis. – XXXIII</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Licet eger cum egrotis</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>nectaris illiciti| hauriunt uenenum</span></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100212859">Walter of Chatillon</a></span>
+                  
+                  <p class="note"> (I): ed. K. Strecker, p. 46: no XXVII; = Carmina Burana: ed. 1930, no
+                     VIII, p. 10 sq: str. I, III–IV, VI–VII. </p>
+                  <span class="listBibl">
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=10307" target="_blank">Walther 10307</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=29159" target="_blank">Chevalier 29159</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item36">
+                  
+                  <div class="locus"><span class="item-number">36. </span>(fols. 64v–65r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Adhuc de eodem et de simonia Romanorum et quod Roma dicitur quasi
+                        rodens manus. – XXXIIII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Frigescente caritatis | in terris igniculo </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Vnde recte dicitur: | Roma quasi rodens manus | per quam
+                        mundus roditur.</span></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100212859">Walter of Chatillon </a></span>
+                  
+                  <p class="note"> (I): ed. K. Strecker, p. 17 sq.; no XI. Str. I–VII. </p>
+                  <span class="listBibl">
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=6909" target="_blank">Walther 6909</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=26800" target="_blank">Chevalier 26800</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item37">
+                  
+                  <div class="locus"><span class="item-number">37. </span>(fol. 65r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Quod maxime congruebat dei filio mortem paciendo nos redimere. –
+                        XXXV</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Dum medium silencium | tenerent apices</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>collatum est ex gracia totum Marie filio. | De tenebris
+                        historie</span></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100212859">Walter of Chatillon </a></span>
+                  
+                  <p class="note"> (II), ed. K. Strecker, pp. 49–51: no III, 35, str. I–V. </p>
+                  <span class="listBibl">
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=4904" target="_blank">Walther 4904</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=25778" target="_blank">Chevalier 25778</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item38">
+                  
+                  <div class="locus"><span class="item-number">38. </span>(fol. 65r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>De eodem, et arguitur cecitas Iudeorum. – XXXVI.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Purgator criminum | de patris dextera | uenit ad
+                        hominum</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>frumentis misticis | preponens ordeum.</span></div>
+                  
+                  <p class="note"> ed. G. Dreves, Analecta hymnica, XX (1895), p. 48: no. 16, str. I–II. </p>
+                  <span class="listBibl">
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=14938" target="_blank">Walther 14938</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=32043" target="_blank">Chevalier 32043</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item39">
+                  
+                  <div class="locus"><span class="item-number">39. </span>(fol. 65r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Quod nusquam sit tuta fides. XXXVII</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>O mores perditos et morum federa</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>in dolo dolus est et dolo tollitur</span></div>
+                  
+                  <p class="note">Collection de Bâle, no XXII (ed. WERNER, p. 464 sq.): str. I–V. </p>
+                  <span class="listBibl">
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=12792" target="_blank">Walther 12792</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=30745" target="_blank">Chevalier 30745</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item40">
+                  
+                  <div class="locus"><span class="item-number">40. </span>(fol. 65v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Quod omnes iura ledunt, auaricia quoque et cetera mala regnant, et
+                        nemini nunc fidendum est. – XXXVIII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Ecce torpet probitas | uirtus sepelitur</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>si quis uiuit ita.| Omnes iura ledunt, et fidem in opere |
+                        quolibet excedunt</span></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100212859">Walter of Chatillon</a></span>
+                  
+                  <p class="note"> (I): ed. K. Strecker, p. 53: no XXIX; = Carmina Burana: ed. 1930, no.
+                     III p.3 sq. </p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=5169" target="_blank">Walther 5169</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item41">
+                  
+                  <div class="locus"><span class="item-number">41. </span>(fols. 65v–66r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Querimonia, quod ecclesia ad questum prosternitur, nepotes eriguntur et
+                        mors incauta non preuidetur. – XXXIX.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> In noua fert animus | mutare querimoniam</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Tunc mors amara separat</span></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_24572572">Peter of Blois</a></span>
+                  
+                  <p class="note"> (no II): PL 207, col. 1131 sq. (str. 9–13). </p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=9026" target="_blank">Walther 9026</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item42">
+                  
+                  <div class="locus"><span class="item-number">42. </span>(fol. 66r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Anxia querela contra prodicionem ducis Austrie et planttus super
+                        capcione Ricardi Cuir de lyon Regis Anglie. – XL.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Quis aquam tuo capiti,| quis dabit tibi lacrimas</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>firmat in Dauid solio | tirannum Babilonis</span></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_24572572">Peter of Blois</a></span>
+                  
+                  <p class="note"> (no III): ib. col. 1132 sq. (str. 14–20). </p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=16049" target="_blank">Walther 16049</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item43">
+                  
+                  <div class="locus"><span class="item-number">43. </span>(fol. 66r–v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Planctus in mortem cuiusdam nobilissimi Regis Henrici, – XLI.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Da plaudens organo| plausus cum tympano,| et choro
+                        reici</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>nichil est, si recolis | cineres Henrici</span></div>
+                  
+                  <p class="note">ed. C. L. Kingsford, EHR 5 (1890), 315 sq. </p>
+                  <span class="listBibl"> 
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=4022" target="_blank">Walther 4022</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=25246" target="_blank">Chevalier 25246</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item44">
+                  
+                  <div class="locus"><span class="item-number">44. </span>(fols. 66v–70r)</div>
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_10241">Apocalipsis Goliae</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Sequitur Apocalipsis M<span class="ex">(agistri)</span> Walteri Mape arcium magistri
+                        uniuersitatis Oxon<span class="ex">(iensis)</span>. – Ca<sup>m</sup>
+                        XLII.</span></div>
+                  
+                  <p class="note"> A tauro torrida lampade Cincii</p>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>nisi papaueris cena sophistica | mentis uestigia fecisset
+                        lubrica</span></div>
+                  
+                  <p class="note">ed. K. Strecker, <span class="title italic">Die Apocalypse des Golias</span> (1928). </p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=91" target="_blank">Walther 91</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item45">
+                  <div class="item-number">45. </div>
+                   <span class="note">(fol. 70r–70v).</span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Quod Hercules qui omnia uicit monstra que hoc capitulo specificantur a
+                        puelle stulto amore uincitur, et quod Venus melius fugiendo fugatur. –
+                        XLIII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Olim sudor Herculis | monstra late conterens</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>ab amore spiritum| solliciter remoui. Amor.</span></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_24572572">Peter of Blois (?)</a></span>
+                  
+                  <p class="note">Carmina Burana: ed. Schmeller (1847), no 30, pp. 125–127. </p>
+                  <span class="listBibl">
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=13179" target="_blank">Walther 13179</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=31239" target="_blank">Chevalier 31239</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item46">
+                  
+                  <div class="locus"><span class="item-number">46. </span>(fol. 70v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Carmen Venereum lasciuum et non utile. – Ca. XLIIII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Ver prope florigerum, flaua Licori| iam rosam
+                        aspicis|</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>tibi Licori milito,| tuis concedo partibus.</span></div>
+                  
+                  <p class="note">ed. Wilmart, no. XI.</p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=20138" target="_blank">Walther 20138</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item47">
+                  
+                  <div class="locus"><span class="item-number">47. </span>(fol. 71r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Simile et de partu ueris et solacio estiui temporis. – Ca<sup>m</sup> XLV.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> De terre gremio rerum pregnacio </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>ingreditur| et sequitur amorem.</span></div>
+                  
+                  <p class="note">ed. Du Meril, <span class="title italic">Poésies populaires</span> (1847), p. 232; cf.
+                     Wilmart, Appendix : no. XII. </p>
+                  <span class="listBibl"> 
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=4167" target="_blank">Walther 4167</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=25296" target="_blank">Chevalier 25296</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item48">
+                  
+                  <div class="locus"><span class="item-number">48. </span>(fol. 71r–v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Adhuc simile, et de recessu rigidi hiemis. – XLVI.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Bruma, grando, glacies,| nix, rigor hiemalis | cedunt, redit
+                        species </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>me qui non nouit talia | heu pacior. | Serenus est
+                        aer</span></div>
+                  
+                  <p class="note">ed. Wilmart, Appendix, 35–90, no XIII. </p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=2243" target="_blank">Walther 2243</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item49">
+                  
+                  <div class="locus"><span class="item-number">49. </span>(fol. 71v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Carmen et laus bene potancium et precipue forte uinum. –
+                        XLVII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> O potores exquisiti| licet sitis sine siti</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>recalescit in amore | mens saucia</span></div>
+                  
+                  <p class="note">Carmina Burana: ed. Schmeller, no 179, p. 240 sq.; cf. Wilmart, Appendix,
+                     no. XIV. </p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=12869" target="_blank">Walther 12869</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item50">
+                  
+                  <div class="locus"><span class="item-number">50. </span>(fols. 72r–74v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Disputacio inter aquam et uinum. – Ca<sup>m</sup>
+                        XLVIII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Dum tenerent omnia media tumultum</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>terminans in gloria dei patris amen</span></div>
+                  <span class="bibl">ed. T. Wright, <span class="title italic">The Latin Poems attributed to Walter Mapes</span>
+                     (1841), p. 87 sq. 2 </span>
+                  
+                  <p class="note">Added, 15th century.</p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=4975" target="_blank">Walther 4975</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item51">
+                  
+                  <div class="locus"><span class="item-number">51. </span>(fol. 74v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Contra mores monachorum. – Ca<sup>m</sup>
+                        XLIX.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Quis nescit quam sit monochorum mobile uulgus | “In omnem terram
+                        exiuit sonus eorum et in fi<span class="ex">(nes)</span> et cetera.” </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Ergo quid pocius quid dignius imprecer illis :| "Fiat habitacio
+                        eorum deserta et in taber naculum et cetera.”</span></div>
+                  
+                  <p class="note">ed. Wattenbach, <span class="title italic">Anzeiger für Kunde der d. Vorzeit</span>, 20
+                     [1873), 74</p>
+                  
+                  <p class="note">Added, 15th century.</p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=16086" target="_blank">Walther 16086</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item52">
+                  
+                  <div class="locus"><span class="item-number">52. </span>(fol. 75r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>De regibus et modis eorum circa largitatem et auariciam. – Ca<sup>m</sup> L.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Reges sunt IIIIor: Rex largus sibi et largus subditis </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>quia regnum ipsius destruetur cito. </span></div>
+                  
+                  <p class="note">Added, 15th century.</p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item53">
+                  <div class="item-number">53. </div>
+                   <span class="note">(fol. 75r–v)</span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>De largitate et auaricia Regum. – LIm.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Oportet nos itaque subtiliter inquirere de istis uirtutibus et
+                        uiciis</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>cui debet committere res publicas dispensandas, et regis diuicias
+                        gubernandas </span></div>
+                  
+                  <p class="note">Added, 15th century.</p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item54">
+                  
+                  <div class="locus"><span class="item-number">54. </span>(fol. 75v)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_2581859">Ps.-Aristotle</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_3861">Secretum secretorum</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Doctrina Aristotilis in uirtutibus largitatis et cetera – LII</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Alexander firmiter dico quod si quis regum superflue continuat
+                        donaciones</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>stulti stulticiam fingere et ignorare</span></div>
+                  
+                  <p class="note"> l. I, SS 5–6: ed. R. Steele, 1920, p. 42, l. 31- p. 45, l. 7. </p>
+                  
+                  <p class="note">Added, 15th century.</p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item55">
+                  
+                  <div class="locus"><span class="item-number">55. </span>(fols. 76r–78r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>De cuiusdam claustralis dissolucione et castracionis euentu. –
+                        LIII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Fratres illustrissimi, parumper disserere cupiens, ad reuerentiam
+                        uestram subsistere dignum duxi et ideo loqui prohibeor </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span> Et factus est Rachel plorans calculos suos, et noluit consolari quia
+                        non sunt.</span></div>
+                  
+                  <p class="note"> ed. P. Lehmann, <span class="title italic">Parodistische Texte</span>, pp. 50–57: no 14.
+                     </p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item56">
+                  
+                  <div class="locus"><span class="item-number">56. </span>(fol. 78r–v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Execracio salmonis rumpentis uentrem abbatis. – Ca<sup>m</sup> LIIII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Audi pater optime decus monachorum | Factum quam nefarium et quam
+                        inhonorum</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Hunc uentre perambulo continere totum. </span></div>
+                  <span class="listBibl">
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=1704" target="_blank">Walther 1704</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=23215" target="_blank">Chevalier 23215</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item57">
+                  
+                  <div class="locus"><span class="item-number">57. </span>(fols. 78v–79r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Allegacio salmonis contra abbatem et monachos. – LV.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Qui penis afficitur merito peccati</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Vt mendacis monachi punias delicta. </span></div>
+                  
+                  <p class="note">ed. Wilmart, Appendix, 35–90, no. XV. </p>
+                  <span class="listBibl"> 
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=15606" target="_blank">Walther 15606</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=32431" target="_blank">Chevalier 32431</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item58">
+                  
+                  <div class="locus"><span class="item-number">58. </span>(fol. 79r–v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Contra uenalitatem et auariciam curie romane. – LVI.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Vtar contra uicium carmine rebelli </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Omnes bursam strangulant et expirat statim.</span></div>
+                  
+                  <p class="note"> Carmina Burana: ed. 1930, no XLII, pp. 76–78: str. I-XVI. </p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=19917" target="_blank">Walther 19917</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item59">
+                  
+                  <div class="locus"><span class="item-number">59. </span>(fols. 79v–80r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span> Contra scorta et inconstanciam ac mutabilitatem eorum. –
+                        LVII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Qui seruare puberem | uagam claudere | studet, lauat laterem </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>minus soluit gracie | cui magis debuit </span></div>
+                  
+                  <p class="note">ed. G. Dreves, Analecta hymnica XXI, p. 157: no. 224. </p>
+                  <span class="listBibl"> 
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=15659" target="_blank">Walther 15659</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=32448" target="_blank">Chevalier 32448</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item60">
+                  
+                  <div class="locus"><span class="item-number">60. </span>(fol. 80r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Quod lex noui testamenti est lex libertatis, ex quo celestis figulus
+                        uniuit sibi futile. – LVIII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Relegentur ab area fidelis consciencie </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Nouellae uetus pagina | spiritu conplanatur. </span></div>
+                  
+                  <p class="note">ed. G. Dreves, ib., XX, p. 85: no. 80. </p>
+                  <span class="listBibl">
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=16562" target="_blank">Walther 16562</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=17295" target="_blank">Chevalier 17295</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item61">
+                  
+                  <div class="locus"><span class="item-number">61. </span>(fol. 80r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Carmen de natiuitate Christi ex uirgine. – LIX.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Sol oritur in sidere </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Indulcans legis gracia | nostris unit celica.</span></div>
+                  
+                  <p class="note"> ed. G. Dreves, ib., p. 82 sq.: no. 75. </p>
+                  <span class="listBibl">
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=18383" target="_blank">Walther 18383</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=19101" target="_blank">Chevalier 19101</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item62">
+                  
+                  <div class="locus"><span class="item-number">62. </span>(fol. 80r–v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Aliud dulce et curiosum carmen de eadem. – LX.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Sol sub nube latuit </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>ad quem nos cum gaudio | perducat para clitus. Gaude.</span></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100212859">Walter of Chatillon</a></span>
+                   <span class="note">(I): ed. K. Strecker, p. 61 sq.: no. XXXIII. </span>
+                  <span class="listBibl">
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=18394" target="_blank">Walther 18394</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=19105" target="_blank">Chevalier 19105</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item63">
+                  
+                  <div class="locus"><span class="item-number">63. </span>(fols. 80v–81r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Dolorosa meditacio matris Marie super moriente filio. – LXI.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Planctus ante nescia | planctu lassor anxia</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>uicem queso reddite, | matris dampnum reddite</span></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_261910300">Geoffroi de St-Victor</a></span>
+                  
+                  <p class="note">ed. G. Dreves, ib., XX, pp. 156–158: no 199. </p>
+                  
+                  <p class="note">Not in Walther.</p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item64">
+                  <div class="item-number">64. </div>
+                   <span class="note">(fol. 81r–83v)</span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Carmen ritmicum contra sodomiam, et dialogus super hoc inter Ganimedem
+                        et Helenam. – LXII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Taurum sol intrauerat et uer parens florum</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Deus si hoc fecero sis oblitus mei.</span></div>
+                  
+                  <p class="note"> ed. W. Wattenbach, <span class="title italic">Zeitschrift für deutsches Altertum</span>, 18
+                     (1875), 127–136. </p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=19029" target="_blank">Walther 19029</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item65">
+                  
+                  <div class="locus"><span class="item-number">65. </span>(fols. 83r–91v)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_26607670">Vitalis of Blois</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_4927">Geta</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Carmen metricum super raptu Alcmene coniugis Amphitrionis facto per
+                        Iouem.- LXIII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Grecorum studia nimiumque diuque secutus </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Letantur sompno Amphitrion, nidore coquine | Birria, Geta hominem
+                        se fore; queque placent</span></div>
+                  
+                  <p class="note">ed. G. Cohen, 1931, t. I, pp. 34–57. </p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=7272" target="_blank">Walther 7272</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item66">
+                  <div class="item-number">66. </div>
+                   <span class="note">(fols. 92r–93v). </span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Sermo utilis super hunc textum. – LXIIII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Beatus quem tu erudieris domine et cetera. Post primum inobediencie
+                        peccatum iusto iudicio dominus homini lapso dupplicem inflixit penam, carnem
+                        scilicet subiciens infirmitati et animam ignorancie tenebris
+                        inuoluens</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>et hec inuenies in glosatura magistri G<span class="ex">(illeberti)</span>
+                        apertissime. </span></div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item67">
+                  
+                  <div class="locus"><span class="item-number">67. </span>(fols. 93v–98v)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_74648663">Stephen of Tournai</a></span>, 
+                  <span class="tei-title italic">Sermo in synodo </span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Item alius sermo utilis super hunc textum. – LXV.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>
+                        <i>Qui habet sponsam sponsus est ... quia audit uocem suam.</i>
+                        Sacros et solempnes conuentus in ecclesia et amicus amplectitur</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span> Quotquot enim sacri baptismatis unda lauasti, tottot officio
+                        predicacionis edoces. Filii tibi sunt ex hac copula nati. Vere es consecutus
+                        fructum benedictionis illius prime qua dicitur: Crescite et multiplicamini,
+                        et cetera. Augeatur et crescat de die in diem fructus officii tui, et cum
+                        spiritualibus filiis filiorum usque in terciam et quartam generacionem
+                        uideas deum deorum in Sion, prestante domino nostro Iesu Christo qui cum
+                        patre ...</span></div>
+                   <span class="note">(PL 211, col. 567–574B)</span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item68">
+                  <div class="item-number">68. </div>
+                   <span class="note">(fol. 98v–101v). </span>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_74648663">Stephen of Tournai</a></span>, 
+                  <span class="tei-title italic">Sermon for Christmas</span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Item tercius sermo super hunc textum. – Ca<sup>m</sup>
+                        LXVI.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>
+                        <i>Misericordia et ueritas obuiau erunt sibi.</i> Se debat iudex pro
+                        tribunali, sine personarum acceptione iudicans, constante et perpetua
+                        uoluntate reddens unicuique quod suum est. Et ecce addu citur reus ante eum,
+                        et posita est iusticia eius in statera, et inuenta est minus habens.
+                        Meticulosa res est ire ad iudicem et periculo proximum loco apparitoris ad
+                        supplicium trahi. Timebat et tremebat miser </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span> Securitas est, ubi sublato hoste nulla timetur aduersitas.
+                        Tranquillitas, ubi firma pace plena habetur prosperitas. Hec autem nunquam
+                        et nusquam simul erunt ubi et quomodo erit eterna felicitas, ad quam
+                        perducat nos dominus noster Iesus Christus. Amen.</span></div>
+                  
+                  <p class="note"> (cf. Du Molinet, Elenchus sermonum M. Stephani, no 2: PL 211, col.
+                     573D). </p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item69">
+                  
+                  <div class="locus"><span class="item-number">69. </span>(fols. 101v–105r)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_67710985">Martin of Braga</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_3110">Formula honestae uitae </a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Tractatus qui dicitur formula honeste uite, qui de IIIIor uirtutibus
+                        cardinalibus traétat et compilatus erat a Martino episcopo Mironi regi. –
+                        LXVII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Quatuor uirtutum species multorum sapientum sententiis definite sunt
+                        ... Quisquis ergo prudenciam sequi desideras, tunc per racionem recte uiues </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>aut deficientem contempnat ignauiam.</span></div>
+                   <span class="note">(PL 72, col. 23B-28D). </span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item70">
+                  
+                  <div class="locus"><span class="item-number">70. </span>(fols. 105r–122r)</div>
+                  
+                  <div class="nestedmsItem" id="d69e2263" style="margin-top:1rem;">
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_95289837">Gregory of Tours</a></span>, 
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_1859">Historia Francorum</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Gregorius Turonensis in gestis Francorum. De passione et
+                           resurrectione domini hec.</span></div>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Apprehensus autem et Ioseph qui cum aromatibus corpus Christi
+                           conditum in suo monumento recondidit </span></div>
+                     
+                     <div class="explicit"><span class="tei-label">Explicit: </span><span> pro eo quod non ad eum aduenisset. </span></div>
+                     
+                     <p class="note"> I, S 21, § 241 (ed. B. Krusch, 1884, p. 44, I. 5–14, p. 45, l. 4–9).
+                        </p>
+                     </div>
+                  
+                  <div class="nestedmsItem" id="d69e2285" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_11737">Euangelium Nicodemi</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span> Tractatus de passione et resurrectione domini, qui euangelium
+                           Nichome didicitur.-LXVIII.</span></div>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Factum est in anno XXIIIo imperii Tiberii Cesaris</span></div>
+                     
+                     <div class="explicit"><span class="tei-label">Explicit: </span><span>Direxique potestati uestre omnia que gesta sunt de Iesu in
+                           pretorium meum.</span></div>
+                      <span class="note">(ed. C. Tischendorf, <span class="title italic">Euangelia Apocrypha</span>, 1876, pp.
+                        335–416).</span>
+                     </div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item71">
+                  
+                  <div class="locus"><span class="item-number">71. </span>(fols. 122r–123r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Prophecia Danielis de quatuor imperiis. – LXIX.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Quatuor sunt bestie terribiles et mirabiles quas Daniel in prima
+                        uisione sua inter se pugnantes et in mari stantes uidit. Prima bestia leena,
+                        habens duas alas ut aquila, que significat regnum Babilonis, due ale
+                        superbiam et sublimitatem regni</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Et ecce oculi quasi hominis in cornu paruulo erant. Idest ne eum
+                        putemus esse demonem, set unum de hominibus in quo totus Sathanas
+                        habitaturus est corporaliter, et os loquens ingencia. Est enim homo peccati
+                        filius perditionis qui tunc uocabitur antichristus. </span></div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item72">
+                  
+                  <div class="locus"><span class="item-number">72. </span>(fol. 123r–v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>De antichristo. – Ca<sup>m</sup> LXX</span></div>
+                  
+                  <div class="nestedmsItem" id="d69e2333" style="margin-top:1rem;">
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span> Antichristus itaque quis est aut unde est, de qua gente orietur et
+                           nascetur, quomodo nasciturus et regnaturus et interfecturus et moriturus,
+                           a quo interficietur et in quo loco peribit interfectus, hec omnia
+                           breuiter dicamus, quia ad alia festinamus. Antichristus ergo est qui in
+                           principio lucifer dicebatur et quasi signaculum dei uiui
+                           uidebatur</span></div>
+                     
+                     <div class="explicit"><span class="tei-label">Explicit: </span><span>talis pugna crudelis et terribilis erit ut nullatenus antea ei
+                           pugna alia sit equalis.</span></div>
+                     </div>
+                  
+                  <div class="nestedmsItem" id="d69e2342" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>In illo ergo horribili et crudeli certamine Enoch et Helias milites
+                           Christi coronam martyrii tenebunt. Et postea cum omnibus sanctis in celo
+                           gloriose coram deo gaudebunt. Tunc Michael miles maximus terribiliter
+                           superueniet, et in monte Oliveti draconem dirissimum igneo gladio
+                           interficiet in illo loco ubi Christus ascendit in celis. </span></div>
+                     </div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item73">
+                  
+                  <div class="locus"><span class="item-number">73. </span>(fols. 123v–124r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Quod uita regentis instruit aut inficit subditos. – LXXI.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Fontis in riuulum</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>quadrans requiretur.</span></div>
+                  
+                  <p class="note"> (See art. 25 above.) </p>
+                  
+                  <p class="note">According to the 13th-century table of contents this was followed by
+                     'Vita beati Thome et eius exilium', now lost (and not mentioned in the
+                     15th-century table).</p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item74">
+                  
+                  <div class="locus"><span class="item-number">74. </span>(fol. 124r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Professio seu uotum pape Calixti tercii pro recuperacione urbis
+                        Constantinopolitane per magnum Teucrum capte. – LXXII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Ego papa Calixtus tercius promicto et uoueo sanctissime trinitati
+                        patri et filio et spiritui sancto ac beate Marie dei gracia semper uirgini
+                        et sanctis apostolis Petro et Paulo totique curie celesti quod usque ad
+                        effusionem sanguinis proprii si opus fuerit dabo operam</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>sic me deus adiuuet et hec sancta dei euangelia </span></div>
+                  
+                  <p class="note">A 15th-century addition. Fol. 124v is blank.</p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item75">
+                  <div class="item-number">75. </div>
+                   <span class="note">(fol. 125r–v)</span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Contra malam uitam ecclesiasticorum. – LXXIII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Qui habet aures audiat | sub quanta mole criminum</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>erubescens temere | ligaturam uulneris</span></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_24572572">Peter of Blois</a></span>
+                  
+                  <p class="note"> (no l): PL 207, col. 1129–1131B (str. 1–8). </p>
+                  <span class="listBibl">
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=15497" target="_blank">Walther 15497</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=32401" target="_blank">Chevalier 32401</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item76">
+                  <div class="item-number">76. </div>
+                   <span class="note">(fol. 125v). </span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Contra promocionem indignorum. – LXXIIII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> O uirtutes perditas | o morum dispendium </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>concludit uerissima famam nugatoriam</span></div>
+                   <span class="note">(ed. Wilmart, Appendix, 35–90, no. XVI.) </span>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=13053" target="_blank">Walther 13053</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item77">
+                  <div class="item-number">77. </div>
+                   <span class="note">(fol 125v–126). </span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Contra pontifices pilatisantes. – LXXV.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Heu quo progreditur | preuaricatio</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>uel Christo parcite | quem crucifigitis</span></div>
+                  
+                  <p class="note">ed. C. L. Kingsford, EHR 5, (1890), 323. </p>
+                  <span class="listBibl"> 
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=7804" target="_blank">Walther 7804</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=27613" target="_blank">Chevalier 27613</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item78">
+                  
+                  <div class="locus"><span class="item-number">78. </span>(fol. 126r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Contra auariciam Romane curie. – LXXVI.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Virtus moritur | uiuit uicium</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Rome curia. </span></div>
+                  
+                  <p class="note">ed. DELISLE, <span class="title italic">Annuaire-Bulletin de la Société H. Fr.</span>
+                     (1885), p. 115 sq.; cf. Wilmart, Appendix, no. XVII. </p>
+                  <span class="listBibl"> 
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=20600" target="_blank">Walther 20600</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=34670" target="_blank">Chevalier 34670</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item79">
+                  
+                  <div class="locus"><span class="item-number">79. </span>(fol. 126r–v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Contra indignos ad dignitates assumptos. – LXXVII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> In Gedeonis area | uellus aret extentum</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>nec literis est fretum</span></div>
+                  
+                  <p class="note">Carmina Burana: ed. 1930, no XXXVII, p. 60 (str. I-III, V, IV). </p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=8916" target="_blank">Walther 8916</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item80">
+                  
+                  <div class="locus"><span class="item-number">80. </span>(fols. 126v–127r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Contra corrupciones munerum. – LXXVIII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Migrat in exilium | ueritas cum fide </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>tantum habet fidei</span></div>
+                  
+                  <p class="note">ed. Wilmart, Appendix, no. XVIII. </p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=11002" target="_blank">Walther 11002</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item81">
+                  
+                  <div class="locus"><span class="item-number">81. </span>(fol. 127r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Bonum consilium, ut episcopus sit uere penitens. – LXXIX.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Nulli beneficium | iuste penitudinis | amputatur</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>nunc sustinens considerat | peccatorem</span></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_24572572">Peter of Blois (?)</a></span>
+                  
+                  <p class="note"> Carmina Burana: ed. 1930, no. XXXVI, p. 58 (str. I-III: premier groupe). </p>
+                  <span class="listBibl">
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=12375" target="_blank">Walther 12375</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=12422" target="_blank">Chevalier 12422</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item82">
+                  
+                  <div class="locus"><span class="item-number">82. </span>(fol. 127r–v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>De fragilitate hominis ex pondere carnis. – LXXX.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Homo natus ad laborem| tui status tue morem| sortis considera </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>si iudices | uel claudices | a rectis semitis.</span></div>
+                  
+                  <p class="note"> ed. G. Dreves, Analecta hymnica, XXI, p. 115: no 169 ; cf. Wilmart,
+                     Appendix, no. XIX. </p>
+                  <span class="listBibl"> 
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=8391" target="_blank">Walther 8391</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=7975" target="_blank">Chevalier 7975</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item83">
+                  
+                  <div class="locus"><span class="item-number">83. </span>(fols. 127v–128r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Quod peccatum Ade omnia conclusit sub peccato, et contra mala exempla
+                        prelatorum. LXXXI.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Veritas ueritatum</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>dum cunctis male uiuitur | ad formam exem plaris.</span></div>
+                  
+                  <p class="note"> Carmina Burana: ed. 1930, no XXI, p. 40 sq. </p>
+                  <span class="listBibl"> 
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=20205" target="_blank">Walther 20205</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=21432" target="_blank">Chevalier 21432</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item84">
+                  
+                  <div class="locus"><span class="item-number">84. </span>(fol. 128r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Contra predicantes et non facientes. – LXXXII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Vehemens indignatio | pacem perturbat spiritus</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>pretextu uestium| humilium| colorent.</span></div>
+                  
+                  <p class="note"> ed. G. Dreves, Analecta hymnica, XXI, p. 147: no. 210 (pour les strophes
+                     I, IV et V); cf. appendix, no XX. </p>
+                  <span class="listBibl">
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=20055" target="_blank">Walther 20055</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=34351" target="_blank">Chevalier 34351</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item85">
+                  
+                  <div class="locus"><span class="item-number">85. </span>(fol. 128r–v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Exclamacio in ulcionem captiuitatis et impresonacionis Regis Ricardi. –
+                        LXXXIII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Insurgant in Germaniam | reges communi gladio </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>ut reges a populis | discernant supplicia. </span></div>
+                  
+                  <p class="note">ed. C. L. Kingsford, EHR 5 (1890), 320. </p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=9426" target="_blank">Walther 9426</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item86">
+                  
+                  <div class="locus"><span class="item-number">86. </span>(fols. 128v–129r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Quod omnia obediunt nummis. – Ca<sup>m</sup>
+                        LXXXIIII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Qui seminant in loculis</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>nec uiuunt bachanalia</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>ed. G. Dreves, Analecta hymnica, XXI, p. 152: no. 218 (pour les
+                        strophes I et II); cf. Appendix, no. XXI. </span></div>
+                  <span class="listBibl">  
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=12655" target="_blank">Walther 12655</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=32446" target="_blank">Chevalier 32446</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item87">
+                  
+                  <div class="locus"><span class="item-number">87. </span>(fol. 129r–v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Carmen super admirabili partu beate uirginis. – LXXXV.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Stupeat natura | fracta sua iura | uirgine fecunda </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>flos expers ruine | in regno uirtutis. </span></div>
+                  
+                  <p class="note">ed. G. Dreves, ib., XX, p. 185: no 245 (str. I and II); cf. Appendix: no.
+                     XXII. </p>
+                  <span class="listBibl">
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=18649" target="_blank">Walther 18649</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=19541" target="_blank">Chevalier 19541</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item88">
+                  
+                  <div class="locus"><span class="item-number">88. </span>(fols. 129v–130r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Contra ingratos Christianos et specialiter de santuario domini uolentes
+                        iterum Christum crucifigere. LXXXVI.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Quid ultra tibi facere | uinea mea potui </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>dum licet conuerti mini | ad me et salui eritis.</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span> ed. Rev. Benedictine 49 (1937), 164 sq.</span></div>
+                  <span class="listBibl">
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=15941" target="_blank">Walther 15941</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=16680" target="_blank">Chevalier 16680</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item89">
+                  
+                  <div class="locus"><span class="item-number">89. </span>(fol. 130r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Iterum de miris contingentibus in partu uirginis. – LXXXVII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> In rosa uernat lilium</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>hyemis tedium | ad uerum fugit florem</span></div>
+                  
+                  <p class="note"> ed. G. Dreves, Analecta hymnica, ib., p. 69: no. 46. </p>
+                  
+                  <p class="note">Not in Walther</p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item90">
+                  
+                  <div class="locus"><span class="item-number">90. </span>(fol. 130r–v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Planctus super mortem Henricis comitis Campanie. – LXXXVIII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Omnis in lacrimas | uberrimas | soluatur oculus </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Quod uanitatum uanitas | sit tota sors humana, | Henrici
+                        probat exitus</span></div>
+                  
+                  <p class="note"> ed. G. Dreves, ib., XXI, p. 180 sq.: no. 253. </p>
+                  <span class="listBibl">
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=13363" target="_blank">Walther 13363</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=14129" target="_blank">Chevalier 14129</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item91">
+                  
+                  <div class="locus"><span class="item-number">91. </span>(fols. 130v–131r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Magna commendacio cuiusdam boni presulis – LXXXIX.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Excuset que uim intulit | uirtutis preminentia </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span> nec ab eo preficitur| nisi dignus imperio. </span></div>
+                  
+                  <p class="note">ed. G. Dreves, ib., p. 137: no I96. </p>
+                  <span class="listBibl">
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=6054" target="_blank">Walther 6054</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=26309" target="_blank">Chevalier 26309</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item92">
+                  
+                  <div class="locus"><span class="item-number">92. </span>(fol. 131r–v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Commendacio comitis Campanie pro terra sancta. – XC.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Sede Sion in puluere </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>reges docet stirps regia | quod uictrice constancia |
+                        coronanda sunt opera. </span></div>
+                  
+                  <p class="note">ed. C. L. Kingsford, EHR 5 (1890), 319 sq. </p>
+                  <span class="listBibl">
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=17467" target="_blank">Walther 17467</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=33427" target="_blank">Chevalier 33427</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item93">
+                  
+                  <div class="locus"><span class="item-number">93. </span>(fols. 131v–134r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Inuectio cuiusdam in prelatos. – XCI.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Quam sit lata scelerum et quam longa tela | Sub qua latent
+                        pectora uiciis hanela </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Omnem crede diem tibi deluxisse supremum. </span></div>
+                  
+                  <p class="note">ed. T. Wright, <span class="title italic">Political Songs of England</span> (1837), pp.
+                     27–36. </p>
+                  <span class="listBibl">
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=15164" target="_blank">Walther 15164</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=32207" target="_blank">Chevalier 32207</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item94">
+                  
+                  <div class="locus"><span class="item-number">94. </span>(fols. 134r–135v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Carmen iocosum monacho curioso in lautis epulis. – XCII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Strenue bos Abrahe, leue ferens onus </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Genius ingenium addat et aceruet</span></div>
+                   <span class="note">(ed. Wilmart, Appendix, 35–90, no. XXIII.) </span>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=18635" target="_blank">Walther 18635</a></span>
+                  
+                  <p class="note">Rest of fol. 135v blank; fol. 136r blank.</p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item95">
+                  
+                  <div class="locus"><span class="item-number">95. </span>(fol. 136v)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100179090"> Cyprian of Carthage</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_6302">De zelo et liuore</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Exposicio Gregorii super illud Petri: sobrii estote et cetera –
+                        XCIII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Petrus apostolus. <i>Sobrii estote ... querens quem
+                           deuoret.</i> Gregorius Super uerbis Cipriani. In huius exposicione
+                        sentencie, non nostra uerum beati Cipriani dicta ponamus: “Circuit, inquid,
+                        ille nos singulos et tanquam hostis clausos obsidens muros explorat, et
+                        temptat an sit aliqua pars membrorum minus stabilis et minus fida cuius
+                        aditu ad interiora penetretur </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span> ad impugnandum semper paratus inimicus.”</span></div>
+                  
+                  <p class="note">2–3a (ed. Hartel, 1868, p. 420, 11, 1–18). </p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item96">
+                  
+                  <div class="locus"><span class="item-number">96. </span>(fols. 136v–138r)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100184667">Gregory I</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_1876">Moralia</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Item exposicio Gregorii super illud Iob. – XCIIII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> De consiliis diaboli. Et que sit differentia inter consilia et
+                        suggestiones. Gregorius super Iob. Ossa Leuiathan uelud fistule eris. Per
+                        ossa illius consilia designantur</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>ut unde mulcet, inde decipiat. </span></div>
+                  
+                  <p class="note">I.XXXII.40–44 (PL 76, col. 659B, l. 12 – 661D, l. 1). </p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item97">
+                  
+                  <div class="locus"><span class="item-number">97. </span>(fol. 138v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Multa singularia in concepcione uirginis. – XCV.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Exceptiuam actionem | uerbum patris excipit</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>In defectum dans effectum | lumen in caligine</span></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_29676447">Alain de Lille (?)</a></span>
+                   <span class="note">(PL 210, col. 577). </span>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=6042" target="_blank">Walther 6042</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item98">
+                  
+                  <div class="locus"><span class="item-number">98. </span>(fols. 138v–139r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Lamentacio quod sepulcrum Christi deseritur. – XCVI.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Iuxta trenos Ieremie | uere Syon lugent uie</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>expendit in uicti mam| pro me moriendo</span></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_22528730">Bertier d'Orléans</a></span>
+                  
+                  <p class="note">Gesta regis Henrici Secundi, ed. Stubbs, II (1867), pp. 26–28; cf.
+                     appendix no. XXIV. </p>
+                  <span class="listBibl">  
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=10035" target="_blank">Walther 10035</a></div>
+                     
+                     <div class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1003&amp;var=Chev&amp;nr_char=32207" target="_blank">Chevalier 32207</a></div></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item99">
+                  
+                  <div class="locus"><span class="item-number">99. </span>(fol. 139r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Quod artes liberales non promouent sed leges et canones.
+                        XCVII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Vt uerum fatear | mentiri ueritus | nil habet meriti |
+                        studens emeri tus</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>sic me spes reficit | assis assidui</span></div>
+                   <span class="note">(ed. Wilmart, Appendix, 35–90, no. XXV.) </span>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=19910" target="_blank">Walther 19910</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item100">
+                  
+                  <div class="locus"><span class="item-number">100. </span>(fol. 139r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Planctus super desolacione Iherusalem. – XCVIII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Ierusalem, Ierusalem, | que occidis et lapidas</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Vide ne uacet dextera,| quia decurso stadio | mortem
+                        sequuntur opera</span></div>
+                  
+                  <p class="note"> ed. G. Dreves, Analecta hymnica, XXI, p. 181: no. 254. </p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=9811" target="_blank">Walther 9811</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item101">
+                  
+                  <div class="locus"><span class="item-number">101. </span>(fol. 139v)</div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Beatus qui non <span class="supplied">⟨abiit⟩</span> in malorum consilio |
+                        peccatorum in inuio | nec stetit nec appeciit | cathedram
+                        pestilencie </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>et ad uerum iusticie | solem translatus fuerit, ubi uiuet in
+                        seculum. O felix et cetera</span></div>
+                  
+                  <p class="note"> ed. G. Dreves, ib., p. 121: no 174.; cf. appendix, no. XXVI. </p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=2103" target="_blank">Walther 2103</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item102">
+                  
+                  <div class="locus"><span class="item-number">102. </span>(fols. 141r–218r)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_12354302">Jean de Hanville</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_2228">Architrenius</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Liber Architrenii. – XCIX.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Velificatur Athos, dubio mare ponte ligatur </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Hic liber et fame ueterum feliciter annos | Equet, in eternum
+                        populus dilectus et ultra.</span></div>
+                  
+                  <p class="note"> ed. T. Wright, <span class="title italic">The Anglo-Latin satirical Poets</span>, I (1872),
+                     pp. 240–392. </p>
+                  
+                  <p class="note">Capitula, fols. 139v–140v.</p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=20057" target="_blank">Walther 20057</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item103">
+                  
+                  <div class="locus"><span class="item-number">103. </span>(fols. 218v–219r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Consulitur Eliensis pontifex Cancellarius Anglie ne credat fortune uel
+                        fauori populi. – Ca<sup>m</sup> C.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Discat cancellarius | quam uarius | sit rerum exitus|
+                        </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>supplicium | dans loco perdit spolia.</span></div>
+                  
+                  <p class="note"> ed. C. L. Kingsford, EHR 5 (1890), 317–319. </p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=4520" target="_blank">Walther 4520</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item104">
+                  
+                  <div class="locus"><span class="item-number">104. </span>(fols. 219r–222r)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_2868552">Hugo de Nonant</a></span>, 
+                  <span class="tei-title italic">De deiectione Willelmi</span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Epistola de malis moribus et de casu tandem eiusdem Eliensis episcopi.
+                        – CIm</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Omnibus ad quos presentes litere peruenerint, Clericus sine nomine
+                        Salutem. Que litterarum apicibus annotantur posteritati profutura
+                        signantur</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span> Set de eius regimine clerus et populus merito debeat
+                        gloriari</span></div>
+                  
+                  <p class="note"> (cf. <span class="title italic">Chronica Rogeri de Houedene</span>, ed. Stubbs, III, 1870,
+                     pp. 141–147). </p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item105">
+                  
+                  <div class="locus"><span class="item-number">105. </span>(fols. 222v–223v)</div>
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_16459">De excidio Troiae </a></span> 
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Metrum de excidio Troie et de causa excidii. – Ca<sup>m</sup> CIIdum.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Pergama flere uolo fatis Danaum data solo | Solo capta dolo,
+                        capta redacta solo </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Causa rei talis meretrix fuit exicialis | Femina fatalis, femina
+                        feta malis.</span></div>
+                  
+                  <p class="note">B. Haureau, no. 31.</p>
+                  <span class="bibl">Cf. <a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=13985" target="_blank">Walther 13985</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item106">
+                  
+                  <div class="locus"><span class="item-number">106. </span>(fols. 224r–225r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Item de mutacione fortune et querimonia contra ipsam. – CIII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Nuper eram locuplex, multisque beatus amicis</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Quicquid uult in me digerat, eius ero</span></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_282035032">Hildebert</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_2056">Carmina minora </a></span>
+                  
+                  <p class="note">Miscellanea, 75 (PL 171, col. 1418C–1420); ed. Brian Scott (2001), no. 22.</p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=12488" target="_blank">Walther 12488</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item107">
+                  
+                  <div class="locus"><span class="item-number">107. </span>(fols. 225v–226r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Quod hec tria : femina, sensus, honos, solent euertere mores sacros, et
+                        multa contra feminas. – CIIII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Plurima cum soleant mores euertere sacros | Altius euertunt:
+                        femina, sensus, honos </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>sustinet hic gladios in patrem ferre, nec unquam| Fraude, cruore,
+                        dolis mens, manus, ora uacant</span></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_282035032">Hildebert</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_2056">Carmina minora </a></span>
+                  
+                  <p class="note">Miscellanea 110 (ib., col. 1428C-1429); ed. Brian Scott (2001), no. 50</p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=14193" target="_blank">Walther 14193</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item108">
+                  
+                  <div class="locus"><span class="item-number">108. </span>(fol. 226r)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_82793219">Geoffrey of Vinsauf</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_1679">Poetria noua</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Preces imperatori pro liberacione Regis Ricardi, et laudes eiusdem
+                        Regis. – CV.</span></div>
+                  
+                  <div class="nestedmsItem" id="d69e3437" style="margin-top:1rem;">
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span> Imperialis apex, cui seruit poplite flexo | Roma capud
+                           mundi</span></div>
+                     
+                     <div class="explicit"><span class="tei-label">Explicit: </span><span>Attamen esto | Flexibilis. Et stet ei melius racione petentis. </span></div>
+                     
+                     <p class="note">Lines 2081–2098 (ed. E. Faral, p. 261 sq.).</p>
+                     <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=8782" target="_blank">Walther 8782</a></span>
+                     </div>
+                  
+                  <div class="nestedmsItem" id="d69e3458" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Pingitur hic auro, rex auree, laus tua tota</span></div>
+                     
+                     <div class="explicit"><span class="tei-label">Explicit: </span><span>Plurima cum faceres alias, hiis omnibus auctor | Extiteras. Et
+                           ad hec omnia solus eras</span></div>
+                     
+                     <p class="note">ed. C. L. Kingsford, EHR 5 (1890), 321. </p>
+                     <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=14123" target="_blank">Walther 14123</a></span>
+                     </div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item109">
+                  
+                  <div class="locus"><span class="item-number">109. </span>(fols. 227r–235v)</div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_11335">Debate between Body and Soul</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Concertacio inter carnem et spiritum metrice. – CVI.</span></div>
+                  
+                  <div class="nestedmsItem" id="d69e3489" style="margin-top:1rem;">
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Incipit prefacio Tur. monachi ad amicum suum in sequens
+                           opusculum</span></div>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Cogis me litem describere spiritualem | Qua sibi dissidunt
+                           spiritus atque caro </span></div>
+                     
+                     <div class="explicit"><span class="tei-label">Explicit: </span><span> ne quis | Aut prebet aut culpet que minus esse uidet. </span></div>
+                     <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=3004" target="_blank">Walther 3004</a></span>
+                     </div>
+                  
+                  <div class="nestedmsItem" id="d69e3509" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span> Incipit tractatus de contemptu mundi uel timore mortis.
+                           Caro.</span></div>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span> Dum tibi leta salus, dum res blanditur et etas,| Afflue
+                           deliciis, tristia queque fuge </span></div>
+                     
+                     <div class="explicit"><span class="tei-label">Explicit: </span><span> Gracia que nulli deerit, si subdita uere ! Sit caro spiritui,
+                           spiritus ipse deo. Explicit.</span></div>
+                     <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=4979" target="_blank">Walther 4979</a></span>
+                     </div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item110">
+                  
+                  <div class="locus"><span class="item-number">110. </span>(fols. 235r–236r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Versus de sancto Thoma martire. CVII.</span></div>
+                  
+                  <div class="nestedmsItem" id="d69e3536" style="margin-top:1rem;">
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Rex, miles, presul, edictis, ense, cruore | Impugnat, uiolat,
+                           protegit ecclesiam</span></div>
+                     
+                     <div class="explicit"><span class="tei-label">Explicit: </span><span>Corpus adit, fama perfundit, spiritus ornat, | Ima soli, mundi
+                           climata, summa poli</span></div>
+                     
+                     <p class="note"> ed. C. L. Kingsford, EHR 5 (1890), 324.</p>
+                     <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=16742" target="_blank">Walther 16742</a></span>
+                     </div>
+                  
+                  <div class="nestedmsItem" id="d69e3556" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Annus millenus centenus septuagenus | Primus erat </span></div>
+                     
+                     <div class="explicit"><span class="tei-label">Explicit: </span><span>et fructus incipit esse poli</span></div>
+                     
+                     <p class="note">Ib., 324 (v. 31–34). </p>
+                     <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=1267" target="_blank">Walther 1267</a></span>
+                     </div>
+                  
+                  <p class="note">Rest of fol. 236r blank.</p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item111">
+                  
+                  <div class="locus"><span class="item-number">111. </span>(fols. 236v–251v)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_803890">Isidore of Seville</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_2269">Synonyma</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Tractatus utilis per modum dialogi, scilicet deflentis hominis et
+                        admonentis racionis. – CVIII.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Venit nuper ad manus meas quedam scedula quam sinonima dicunt...
+                        Anima mea in angustia posita est, spiritus meus estuat</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span> Refuge ergo fallatiam... prebe effectum sine
+                        simulacione <span class="defective">||</span></span></div>
+                  
+                  <p class="note"> I-II.56 (PL 83, col. 827–858B) </p>
+                  
+                  <p class="note">Ends imperfect due to loss of leaves after fol. 251.</p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item112">
+                  <div class="item-number">112. </div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Exhortacio bona peccatori ut cito se corrigat: Ad cor tuum. –
+                        CIX.</span></div>
+                  
+                  <p class="note">Now missing; noted in the 15th-century table of contents. Carmina Burana:
+                     ed. 1930, no XXVI, p. 45 sq. 101 </p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_44-item113">
+                  
+                  <div class="locus"><span class="item-number">113. </span>(fols. 9r–12r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Reuelacio falta Magistro Waltero Mape de non ineundo coniugio. –
+                        CX.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span> Sit deo gloria et benediccio | Iohanni pariter Petro Laurencio
+                        | Quos misit trinitas in hoc naufragio | Ne me permitterent uti
+                        coniugio </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Respondi breuiter : uobis consencio</span></div>
+                  
+                  <p class="note"> ed. T. Wright, <span class="title italic">The Latin Poems ... attributed to Walter
+                        Mapes</span> (1841), pp. 77–85. </p>
+                  <span class="bibl"><a href="http://webserver.erwin-rauner.de/php_ancarm/ancarm_refwerke.php?opus=1000&amp;var=WIC&amp;nr_char=18302" target="_blank">Walther 18302</a></span>
+                  
+                  <p class="note">15th century.</p>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment (HFFH)</div>
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="seg"><span class="measure">iv (paper)</span> + <span class="measure">254</span> + <span class="measure">1 (parchment endleaf)</span> + <span class="measure">iv (paper)</span></span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">175</span> × <span class="width">118</span> mm.
+                        
+                        </div>
+                  </div>
+                  
+                  <div class="foliation"><span class="tei-label">Foliation: </span>i–iv, 1–256, including 12a, 12b, 12c, 29a, 29b.</div>
+                  
+                  <div class="collation">
+                     <h4>Collation</h4>
+                     <div class="collation">1(eight leaves: two thirteenth-century bifolia, fols. 1, 8 and 2,
+                        7) with two 15th-century bifolia added, fols. 3,6 and 4,5), [fols. 9–12c:
+                        see quire 31], 2(4) fols. 13–16), 3(8) (fols. 17–24, added 15th century),
+                        4(8)–9(8) (fols. 25–71, including 29a, 29b), 10(4) (fols. 72–5, added
+                        15th century), 11(8)–12(8) (fols. 76–91), 13(12) (fols. 92–103), 14(10)
+                        (fols. 104–113), 15(12–1) (probably lacking final leaf, probably
+                        cancelled, blank; fols. 114–124) | 16(8) (fols. 125–132), 17(12) (fols.
+                        133–144), 18(8)–25(8) (fols. 145–208), 26(10) (fols. 209–218),
+                        27(8)–30(8) (fols. 219–250), 31(one) (fol. 251, the first leaf of a
+                        quire), 32(8–2, probably 1–2 cancelled; misbound, now fols. 9–12a, 12b,
+                        12c).
+                        </div>
+                  </div>
+                  
+                  
+                  
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p>1 or 2 columns, c. 28–32 lines;
+                        ruled space typically 
+                        <span class="height">130–5</span> × <span class="width">80–5</span> mm.
+                        
+                        ; written above top line.</p>
+                     </div>
+                  </div>
+               
+               <div class="handDesc">
+                  <h4>Hand(s)</h4>
+                  
+                  <p class="handNote">Protogothic script by several hands.
+                     </p>
+                  
+                  <p class="handNote">15th-century additions in textualis </p>
+                  
+                  <p class="handNote">15th-century additions in (fol. 124r) secretary.</p>
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">Typically alternating red and blue initials, often
+                     with penwork in the contrasting colour; fols. 224r–251r, red initials with
+                     flourishing in blue, and green initials flourished in red.</p>
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">13th century,
+                     early</span> (after 1198, the date of art. 100); <span class="origDate">additions, 15th century</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7002445">English</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance"><span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_39733678">Thomas Bekynton (1443–65)</a></span>, bishop of Wells: 
+                     ‘Liber Thome de Bekynton
+                     episcopi Bathon. et Wellen.’, fol. 8v.</p>
+                  <p class="provenance">
+                     <span class="orgName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/org_136008586">Wells, Somerset, Cathedral church of St
+                           Andrew</a></span>: 'ex dono reuerende in christo patris domini Thome de
+                     Bekyntona Bathon. et Wellen. episcopi oretis pro eo' (fol. 13r) (<a href="http://mlgb3.bodleian.ox.ac.uk/mlgb/book/5610" target="_blank">MLGB3</a>: inferred
+                     evidence). </p>
+                  <p class="provenance">'J. Grenehalgh' (fol. 85v), i.e. <span class="persName sgn"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_57675116">James Grenehalgh(d. 1529 or 1530)</a></span>, who was
+                     magister scholarium at Wells Cathedral in 1488 (Michael G. Sargent,
+                     <span class="title italic">James Grenehalgh as textual critic</span> (1984)).</p>
+                  <p class="provenance">
+                     <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_3546">John Hill, rector of Combe Flory in
+                           Somerset</a></span> (foll. ii, 1 etc.), and Richard and Blanche Hill (fol.
+                     252v: all 17th cent.).</p>
+                  <p class="acquisition"> Probably acquired before 1860.</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Adapted by Matthew Holford (August 2022) from A. Wilmart, ‘Le
+                     Florilège Mixte de Thomas Bekynton’, <span class="title italic">Mediaeval and Renaissance
+                        Studies</span> 1 (1941), 41–84 and 4 (1958), 35–90 ('Appendix'), with
+                     additional physical descripton and reference to published literature as
+                     cited. Wilmart's description provides further detail on the textual
+                     affiliations of several items. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0782.gif">Summary Catalogue, Vol. 5, p.
+                              745</a></div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0783.gif">Summary Catalogue, Vol. 5, p.
+                              746</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <div class="surrogates">
+                  <h3 class="msDesc-heading3">Digital Images</h3>
+                  <p><span class="bibl">
+                        <a href="https://digital.bodleian.ox.ac.uk/objects/569f9616-8df3-4fc4-b845-4d4118f7bd6b/" target="_blank">
+                           <span class="title italic">Digital Bodleian</span></a> <span class="note">(full digital facsimile)</span>
+                        </span><br /></p>
+               </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Online resources:</h4>
+                        
+                        <div class="bibl">
+                           <a href="https://www.mirabileweb.it/manuscript/oxford-bodleian-library-add-a-44-(s-c-30151)-bekyn-manuscript/14480" target="_blank">
+                              <span class="title italic">Mirabile</span>
+                              </a>
+                           </div>
+                        
+                        <div class="bibl">
+                           <a href="http://mlgb3.bodleian.ox.ac.uk/mlgb/book/5610" target="_blank">
+                              <span class="title italic">MLGB3: Medieval Libraries of Great Britain</span>
+                              </a>
+                           </div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2022-08: Description revised for digitization.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 46</h1>
+      <div class="content tei-body" id="manuscript_67">
+         <div class="msDesc" id="MS_Add_A_46-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">30153</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_46-item1">
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_10694">Calendar from a Psalter</a></span>
+                  
+                  <p class="note">Probably taken from a 13th century Flemish Psalter</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>iii + <span class="measure">6</span> + <span class="measure">iii</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">8.375</span> × <span class="width">5.75</span> in.
+                        
+                        </div>
+                     
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">204</span> × <span class="width">135</span> mm.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  <div>
+                     <h4>Condition</h4>
+                     <div class="condition">Fols ii-iii and 7-end are blank
+                        </div>
+                  </div>
+                  
+                  
+                  </div>
+               
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="summary"><a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> i. 286, Pl. XXI
+                     </p>
+                  
+                  <p class="decoNote"><a href="https://digital.bodleian.ox.ac.uk/objects/5b5a488d-cf31-4bab-a347-b5ae26c01f12/surfaces/4b67e0af-6240-42cc-aead-e5967630da72/" target="_blank">Fine miniatures</a></p>
+                  
+                  <p class="decoNote">Fine initials</p>
+                  
+                  <p class="decoNote">Each page of fols 1-6 bears two illuminations, of the season and of the signs of the
+                     zodiac</p>
+                  
+                  <p class="decoNote">
+                     
+                     <p class="decoNote-p">The following saints are in red: Servatius (13 May);Remaclus (3 September); Lambert
+                        (17 September); Hubert (3 November). 
+                        With the 'Triumphus Sancti Lamberti' on 13 October, this points to Liége, or that
+                        district</p>
+                     
+                     <p class="decoNote-p">
+                        Also in red are: Ursmar (18 April); Domitianus (7 May); Gengulf (11 May); Gallicanus
+                        (25 June); Monegundis (1 July); Fredegaud (17 July); 
+                        Philibert (20 August); Theodard (10 September); the octave of Lambert (24 September);
+                        Amor (8 October); and Trudo (24 November)</p>
+                     </p>
+                  
+                  <p class="decoNote"><a href="https://digital.bodleian.ox.ac.uk/objects/5b5a488d-cf31-4bab-a347-b5ae26c01f12/surfaces/595ef52d-4bcf-4e55-92a0-9f1dba8cf929/" target="_blank">The Gemini on fol. 3r</a> bear a coat of arms: -azure a cross gules between four choughs (?) argent</p>
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">13th century, third quarter</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7024097">Flanders</a></span>, <span class="settlement"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7007945">Liège</a></span>
+                     
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="acquisition">Probably acquired before 1860</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (July 2025) by Stewart J. Brookes from the Summary Catalogue (1905).
+                     Decoration, localization and date follow Pächt and Alexander (1966). 
+                     Extent and leaf dimensions are from van Dijk (1957) 
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0783.gif">Summary Catalogue, Vol. 5, p. 746</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <div class="surrogates">
+                  <h3 class="msDesc-heading3">Digital Images</h3>
+                  <p><span class="bibl">
+                        <a href="https://digital.bodleian.ox.ac.uk/objects/5b5a488d-cf31-4bab-a347-b5ae26c01f12/" target="_blank">
+                           <span class="title italic">Digital Bodleian</span>
+                           </a>
+                        <span class="note">(15 images from 35mm slides)</span>
+                        </span><br /></p>
+               </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Printed descriptions:</h4>
+                        
+                        <div class="bibl">S. J. P. van Dijk, <span class="title italic">Latin Liturgical Manuscripts in the Bodleian Library, Oxford, vol. 3: Rituals and
+                              Directories</span> (typescript, 1957), <span class="citedRange">p. 141</span>
+                           </div>
+                        </span>
+                     
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Online resources:</h4>
+                        
+                        <div class="bibl">
+                           <a href="https://iiif.biblissima.fr/collections/manifest/5a22fe191ce37f567ad237d2bb00c87c9ea6514e" target="_blank">
+                              <span class="title italic">Biblissima</span>
+                              </a>
+                           </div>
+                        
+                        </span>
+                     </ul>
+               </div>
+               
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-07-21: Description revised to incorporate all the information in the Summary Catalogue (1905)</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 50</h1>
+      <div class="content tei-body" id="manuscript_69">
+         <div class="msDesc" id="MS_Add_A_50-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">30156</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_50-item1">
+                  <div class="locus"></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_88598818">Charles V, Emperor</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_1225">Interim Declaration</a></span>
+                  
+                  <p class="note">May 15, 1548</p>
+                  
+                  <p class="note">A proposed formulary of faith and church discipline</p>
+                  
+                  <p class="note">Latin translation, transcribed from the printed text <span class="title italic">Sacre Cesarie Maiestatis Declaratio</span> 
+                     (Augsburg: Philip Ulhard [1548])</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>i + <span class="measure">63</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">8.375</span> × <span class="width">6.375</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">16th century, middle</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7000084">Germany</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="acquisition">Probably acquired before 1860</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (May 2025) by Stewart J. Brookes from the Summary Catalogue (1905)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0784.gif">Summary Catalogue, Vol. 5, p. 747</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-05-29: Description revised to incorporate all the information in the Summary Catalogue (1905)
+               and other printed sources</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 61</h1>
+      <div class="content tei-body" id="manuscript_71">
+         <div class="msDesc" id="MS_Add_A_61-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">28843</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</p>
+               
+               <div class="msItem" id="MS_Add_A_61-item1">
+                  
+                  <div class="locus">(fols 1ra–53vb)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_89028232">Geoffrey of Monmouth</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_1677">Historia regum Britanniae</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Hic incipit brutus Anglie</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Cum mecum multa &amp; de multis.</span></div>
+                  
+                  </div>
+               
+               
+               <div class="msItem" id="d74e122">
+                  
+                  <div class="locus">(fol. 54v)</div>
+                  
+                  <p class="note">15th century note on the Dionysiac cycle</p>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="seg"><span class="measure">i</span> + <span class="measure">55</span></span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">7.25</span> × <span class="width">5.375</span> in.
+                        
+                        </div>
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">170</span> × <span class="width">130</span> mm.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  <div class="collation">
+                     <h4>Collation</h4>
+                     <div class="collation">1-2<sup>8</sup>, 3<sup>12</sup>, 4<sup>8</sup>, 
+                        5<sup>14</sup>, 6<sup>4</sup> (51-54). Quires 2 and 4 are in the wrong order (4 should follow 2) but there is no
+                        loss of text: 
+                        fols 29-36 (§58 'Dominum Iulii abicientes' - §90 'Plebs usus belli <span class="sic">ignaria[<i>sic</i>]</span>' should precede fols 17-28 (§90 'que ceteris negotiis'). No catchwords</div>
+                  </div>
+                  
+                  
+                  
+                  
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p>In 2 cols of <i>c</i>. 38-46 written lines. Pricking marks occasionally visible at the outer edges. 
+                        Sometimes written below the top ruled line. Double or single boundary lines
+                        </p>
+                     </div>
+                  
+                  </div>
+               
+               
+               <div class="handDesc">
+                  <h4>Hand(s)</h4>
+                  
+                  <p class="handNote">
+                     Written with varying degrees of informality and irregularity by several small and
+                     often cursive hands of the glossing type. The least formal hand has
+                     deeply-split ascenders and uses simple, crude letter-forms; the tall decorated ascenders
+                     on the first line of a page reflect documentary practice. 
+                     The shaft of the Tironian nota is crossed in places; <b>a</b> has both the Caroline minuscule and two-compartment forms; the only ligature 
+                     in use is <b>de</b>; round-backed <b>d</b> is standard; tall <b>s</b> is used in final position; 
+                     <b>g</b> is crank-tailed. The Insular <i>enim</i>-compendium occurs. The ink is dark brown
+                     </p>
+                  </div>
+               
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">Small plain red capitals withut filigree except (in ink) at §1 and §5</p>
+                  
+                  <p class="decoNote">Shield drawn on 53v with a different shield on the facing recto</p>
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">13th century</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7002445">England</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">On fol. 54v, now barely visible, is 'Iste liber est <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_5055">fratris Guillelmi de Buria</a></span> de [...] Roberti ordinis fratrum Pred<span class="supplied">⟨icatorum⟩</span>' (15th century)</p>
+                  <p class="provenance">'hanauilla' is written at the foot of the page (15th century)</p>
+                  <p class="acquisition">Bought from the rev. <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_71503387">W. D. Macray</a></span> on March 17, 1863, for £1 10<i>s</i></p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (January 2025) by Stewart J. Brookes from Julia C. Crick, <span class="title italic">The Historia Regum Britannie of Geoffrey of Monmouth. III: A Summary Catalogue of
+                        the Manuscripts</span> 
+                     (D. S. Brewer, 1989). Described previously in the Summary Catalogue (1905)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0550.gif">Summary Catalogue, Vol. 5, p. 515</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-01-21: Description revised to incorporate information from Julia C. Crick, <span class="title italic">The Historia Regum Britannie of Geoffrey of Monmouth</span> (1989) and the Summary Catalogue (1905)</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 62</h1>
+      <div class="content tei-body" id="manuscript_72">
+         <div class="msDesc" id="MS_Add_A_62-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">28844</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_62-item1">
+                  <div class="locus"></div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_11218">Commentary on Job 1:1–13:17</a></span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Uir erat in terra Hus nomine Iob. Iob dolens, Hus consulator interpretatur</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>figuratas se locutiones habere demonstrat</span></div>
+                  
+                  <p class="note">Notes in the margin seem to suggest that very much of this commentary is from Gregory's
+                     <span class="title italic">Moralia on Job</span></p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  
+                  
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>ii + <span class="measure">44</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">8.875</span> × <span class="width">6.5</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  <div>
+                     <h4>Condition</h4>
+                     <div class="condition">Injured by sea water</div>
+                  </div>
+                  
+                  
+                  </div>
+               
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">Coloured capitals.</p>
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">12th century, second half</span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">'<span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_1563669">William Reader</a></span>'s Book, 1808'. Reader has added 'Belonged to a French Bishop. Damaged by sea water.
+                     
+                     Taken out of the wreck of a French vessel on the coast of Dorsetshire'</p>
+                  <p class="acquisition">Bought from <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_1563669">William Reader</a></span>, of 16 Alma St., Hoxton, for £2 on 
+                     20 August 1863</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (May 2025) by Stewart J. Brookes from the Summary Catalogue (1905)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0550.gif">Summary Catalogue, Vol. 5, p. 515</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-05-29: Description revised to incorporate all the information in the Summary Catalogue (1905)</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 92</h1>
+      <div class="content tei-body" id="manuscript_76">
+         <div class="msDesc" id="MS_Add_A_92-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">28897</span>
+                  </p>
+               </div>
+            <h4 class="msHead">Autograph proverb collection of Martin Luther; Germany, 16th century, first half</h4>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_A_92-item1">
+                  
+                  <div class="locus">(pp. 1–34)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_14773105">Martin Luther</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_6566">Sprichwörtersammlung</a></span>
+                   <span class="note">(autograph)</span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Art gehet vber künst | Da steckts sagitta scz <span class="note">[i.e. scilicet]</span> perfecte iacta | Ist lange nicht zum bad gewest |
+                        </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Er hat das liebe brot semmel geheissen | Was nicht dein ist, das las ligen | Was dich nicht bornet das lessche nicht</span></div>
+                  
+                  <p class="note">With some duplications, deletions, interlinear and marginal insertions, etc.</p>
+                  <span class="bibl">Edited by Ernst Thiele, <span class="title italic">Luthers Sprichwörtersammlung</span> (Weimar, 1900), and ‘Luthers Sprichtwörtersammlung’ in <span class="title italic">D. Martin Luthers Werke: Kritische Gesammtausgabe</span>, 51 (Weimar, 1914), pp. 634–44 (introduction), 645–662 (text), and 663–64 (further
+                     notes by D. Brenner). </span>
+                  
+                  
+                  <p class="note">MS. Add. C. 309 includes a transcript made c.1700 of pp. 1–10; attestations to the
+                     genuineness of the writing; and a clipping from the 1862 bookseller catalogue (originally
+                     loose papers in the case of this volume).</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>German, with some Latin</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>Paper. Thiele notes that the watermark (monogram) is also found on the manuscript
+                     (also in this note-paper format) of Luther’s tract Wider Hans Worst, which was written
+                     and published in 1541</div>
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="measure">20</span> leaves 
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">c. 140</span> × <span class="width">105</span> mm.
+                        
+                        </div>
+                  </div>
+                  
+                  <div class="foliation"><span class="tei-label">Foliation: </span>Paginated 1.–34. in 19th-century ink; the blank leaves paginated 35–40 in purple pencil
+                     at the Bodleian.</div>
+                  
+                  <div class="collation">
+                     <h4>Collation</h4>
+                     <div class="collation">1(8), 2–3(6); the first two quires signed on their first rectos in the middle of the
+                        lower margin, A and C: these signatures and a change of ink from p. 16 to p. 17 suggest
+                        that a quire is missing at this point.</div>
+                  </div>
+                  
+                  
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p> Unruled; typically written with 15–19 lines per page. Written space variable, typically
+                        c. 
+                        <span class="height">125–30</span> × <span class="width">65–75</span> mm.
+                        
+                        
+                        </p>
+                     </div>
+                  </div>
+               
+               <div class="handDesc">
+                  <h4>Hand(s)</h4>
+                  
+                  <p class="handNote">Cursive, by <span class="persName scr"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_14773105">Martin Luther</a></span>, in several shades of reddish brown and pink ink. </p>
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">None</p>
+                  </div>
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">The gutter margin has holes from earlier stab-stitching. Now apparently sewn on two
+                     bands and bound in thin pasteboards covered with comb-marbled paper; the spine with
+                     a green paper label inscribed ‘Luthers eigne Hand’. Kept in a dark blue leather slipcase
+                     lettered in gilt capitals ‘M. Luther. Autograph.’ on the spine and on one side.</p>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">16th century, first half</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7000084">Germany</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">Successive members of the Lingke family, including <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_69808547">Johann Theodor Lingke (1720–1801)</a></span>, theologian of at Wittenberg and Torgau, who wrote a number of works about Luther.</p>
+                  <p class="provenance">At his death the manuscript passed to his son, <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_3438">August Theodor Lingke</a></span>, who died celibate in Dresden in 1838</p>
+                  <p class="provenance">Inherited by his nephew <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_3439">Wilhelm Becher</a></span>, who sold it in 1862.</p>
+                  <p class="provenance">H. Skutsch, bookseller, Breslau, Catalogue 89 (1862), no. 1412, priced 300 Thaler.</p>
+                  <p class="provenance">Deighton, Bell, &amp; Co., booksellers, Cambridge.</p>
+                  <p class="acquisition">Bought by the Bodleian, 10 March 1865, for £45. Former Bodleian shelfmarks: ‘MS. Addit.
+                     Bodl. II. C. 12.’ and ‘Addit. A. 92.’ A set of photos taken in 1890 is now MS. Add.
+                     A. 92* (SC 31001).</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Summary description (March 2021) by Peter Kidd, edited by Matthew Holford. Previously
+                     described in the Summary Catalogue. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0557.gif">Summary Catalogue, Vol. 5, p. 522</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <div class="surrogates">
+                  <h3 class="msDesc-heading3">Digital Images</h3>
+                  <p><span class="bibl">
+                        <a href="https://digital.bodleian.ox.ac.uk/objects/394d2233-8981-42b0-bc76-10585a97c7b6/" target="_blank">
+                           <span class="title italic">Digital Bodleian</span></a>
+                        <span class="note">(full digital facsimile)</span>
+                        </span><br /></p>
+               </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Online resources:</h4>
+                        
+                        <div class="bibl"><a href="https://hab.bodleian.ox.ac.uk/en/" target="_blank"><span class="title italic">Manuscripts from German-Speaking Lands – A Polonsky Foundation Digitization Project</span></a></div>
+                        </span>
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Printed descriptions:</h4>
+                        
+                        <div class="bibl">James C. Cornette, Jr., <span class="title italic">Proverbs and Proverbial Expressions in the German Works of Martin Luther</span>, Sprichwörterforschung 19 (Bern 1997</div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2021-03-30: Description fully revised for Polonsky German digitization project.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 100</h1>
+      <div class="content tei-body" id="manuscript_2">
+         <div class="msDesc" id="MS_Add_A_100-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">28962</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_A_100-item1">
+                  <div class="locus"></div>
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_15479">Vita Sancti Honorati archiepiscopi Arelatensis</a></span>
+                   <span class="note">(<span class="bibl">
+                        <abbr style="cursor:default;">BHL</abbr>
+                        <span class="citedRange">3976</span>
+                        </span>)</span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Cum dyabolus pronus et sollicitus humagni generis inimicus</span></div>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="seg"><span class="measure">v</span> + <span class="measure">76</span></span> fols. 
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">220</span> × <span class="width">150</span> mm.
+                        
+                        </div>
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (written): </span>
+                        <span class="height">145</span> × <span class="width">110</span> mm.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p>26 lines</p>
+                     </div>
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote"> Good initial (rubbed). Written with calligraphic flourishes, by <span class="persName scr"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_1230">Vincentius Marun</a></span> at the college of <span class="orgName"><a href="https://medieval.bodleian.ox.ac.uk/catalog/org_116">St. Martial, in Avignon</a></span>. (<a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> i. 671)</p>
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">1449</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000070">French</a></span>, <span class="settlement"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7008799">Avignon</a></span>
+                     
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">Fol. 75v: 'Explicit uita beati honorati scripta per me dompnum Vincencium marum Religiosum
+                     studentem in collegio sancti marcialis auinione ob reuerenciam dicti sancti nec non
+                     domini burgensis Iacobi pharandis [<i>corrected from</i> pharandii?] auinione sui benefactorum singularissimi Anno domini millesimo cccc.mo
+                     xlix et finita et completa in prima ebdomada maij'.</p>
+                  <p class="provenance">Fol. iv, written over another name: '<span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_2748">f. G. Champeheuryoulx carme d'Orleans docteur et predicateur a Rouen</a></span> 1599'.</p>
+                  <p class="provenance">
+                     <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_2749">Robert Le Tellyer</a></span>, 1610, fol. 76.</p>
+                  <p class="provenance">
+                     <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_2750">John Calder</a></span>, at Lisbon, Apr. 16 1766, who then presented it <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_2751">rev. Gavin Mitchell, minister of Kineller</a></span>, fol. iii.</p>
+                  <p class="acquisition">Purchased 1869.</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Adapted (2017) from A. G. Watson, <span class="title italic">Catalogue of Dated and Datable Manuscripts</span>; Pächt and Alexander; and the Summary Catalogue (1905). 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0568.gif">Summary Catalogue, Vol. 5, p. 533</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <div class="surrogates">
+                  <h3 class="msDesc-heading3">Digital Images</h3>
+                  <p><span class="bibl">
+                        <a href="https://digital.bodleian.ox.ac.uk/objects/8e4dd812-6a54-4df9-a38b-ca2f6c8e72c1/" target="_blank">
+                           <span class="title italic">Digital Bodleian</span></a> <span class="note">(full digital facsimile)</span>
+                        </span><br /></p>
+               </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Printed descriptions:</h4>
+                        
+                        <div class="bibl">A. G. Watson, <span class="title italic">
+                              <a href="https://catalog.hathitrust.org/Record/000310664" target="_blank">Catalogue of Dated and Datable Manuscripts c.435–1600 in Oxford Libraries</a>
+                              </span> (Oxford, 1984), no. 4</div>
+                        
+                        <div class="bibl">Otto Pächt and J. J. G. Alexander, <span class="title italic">
+                              <a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Illuminated Manuscripts in the Bodleian Library, Oxford</a>
+                              </span>, I (1966), no. 671</div>
+                        
+                        <div class="bibl">S. J. P. van Dijk, <span class="title italic">Latin Liturgical Manuscripts in the Bodleian Library, Oxford, vol. 2: Office Books</span> (typescript, 1957), <span class="citedRange">p. 375</span>
+                           </div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 103</h1>
+      <div class="content tei-body" id="manuscript_3">
+         <div class="msDesc" id="MS_Add_A_103-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">28964</span>
+                  </p>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="physDesc-p">Composite: three parts</div>
+               </div>
+            <div class="msPart" id="MS_Add_A_103-part1" style="padding-left:2rem; margin-top:1rem; border-bottom-color:#C0C0C0; border-top:1px #C0C0C0 solid;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 103 – Part 1</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <div class="msItem" id="MS_Add_A_103-part1-item1" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     <div class="item-number">1. </div>
+                     <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_10707">Calendarial and astrological notes</a></span>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">14th century</span>
+                     ; <span class="origPlace">
+                        <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italian</a></span>
+                        </span>
+                     </div>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_103-part2" style="padding-left:2rem; border-bottom-color:#C0C0C0;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 103 – Part 2</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <div class="msItem" id="MS_Add_A_103-part2-item1" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     <div class="item-number">1. </div>
+                     <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_15038">Treatises on gems</a></span>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                     
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">15th century</span>
+                     ; <span class="origPlace">
+                        <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italian</a></span>
+                        </span>
+                     </div>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_103-part3" style="padding-left:2rem; border-bottom-color:#C0C0C0;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 103 – Part 3</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <div class="msItem" id="MS_Add_A_103-part3-item1">
+                     <div class="item-number">1. </div>
+                     <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_15037">Treatise on gems (in verse)</a></span>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                     </div>
+                  
+                  <div class="msItem" id="MS_Add_A_103-part3-item2">
+                     <div class="item-number">2. </div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_82939845">Lanfranc</a></span>, 
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_2914">De corpore et sanguine Domini</a></span>
+                      <span class="note">(metrical abbreviation)</span>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                     
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">15th century</span>
+                     ; <span class="origPlace">
+                        <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italian</a></span>
+                        </span>
+                     </div>
+               </div>
+            </div>
+            <h2><?ni?>Additional Information<?ni?></h2>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Summary description by Elizabeth Solopova and Matthew Holford, based on the Summary
+                     Catalogue and supplementary sources. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0569.gif">Summary Catalogue, Vol. 5, p. 534</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 105</h1>
+      <div class="content tei-body" id="manuscript_4">
+         <div class="msDesc" id="MS_Add_A_105-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29002</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_A_105-item1">
+                  <div class="locus"></div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_14572">Wycliffite sermons on the Sunday Gospels throughout the year</a></span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="measure">95</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">9.5</span> × <span class="width">6.125</span> in.
+                        
+                        </div>
+                  </div>
+                   
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p>2 cols.</p>
+                     </div>
+                  </div>
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">White leather on boards, wormeaten and worn, clasps lost,
+                     contemporary.</p>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century, early</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7002445">English</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance"><span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_1441">Col. J. Sidney North</a></span></p>
+                  <p class="acquisition">Purchased from him by the Bodleian on Jan. 18, 1871.</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Description adapted (2024) from the Summary Catalogue (1905). 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0575.gif">Summary Catalogue, Vol. 5, p. 540</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2024-12: Description revised to incorporate all information from Summary Catalogue.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 106</h1>
+      <div class="content tei-body" id="manuscript_5">
+         <div class="msDesc" id="MS_Add_A_106-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29003</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_A_106-item1">
+                  <div class="item-number">1. </div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_13203">Medical recipes</a></span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English</div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_106-item2">
+                  <div class="item-number">2. </div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_14344">Religious poems</a></span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="physDesc-p">six parts</div>
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  </div>
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">Brown leather on boards, ruled with lines, with leather thong,
+                     contemporary.</p>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7002445">English</a></span>, <span class="region">North</span>
+                     
+                     </span>
+                  </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Summary description by Elizabeth Solopova and Matthew Holford, based on the Summary
+                     Catalogue and supplementary sources. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0575.gif">Summary Catalogue, Vol. 5, p. 540</a></div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0576.gif">Summary Catalogue, Vol. 5, p. 541</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2022-04-04: Add binding information from Summary Catalogue.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 107</h1>
+      <div class="content tei-body" id="manuscript_6">
+         <div class="msDesc" id="MS_Add_A_107-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29004</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin and Anglo-Norman</p>
+               
+               <div class="msItem" id="MS_Add_A_107-item-1">
+                  
+                  <div class="locus"><span class="item-number">1. </span>(fol. 1)</div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_10687">Calendar</a></span>
+                  
+                  <p class="note">Generally of the Sarum type, with many interesting additions (1330-1472) connecting
+                     the volume with Arundel and the families of Tanke (1360-75), Fitzalan (1449 April
+                     11, William son of William earl of Arundel born), Stafford (1458-69) and others: at
+                     Oct. 11 is added 'Sancti Necasij dedicacio ecclesie Arundell'</p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_107-item2">
+                  
+                  <div class="locus"><span class="item-number">2. </span>(fol. 11)</div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_14739">Statutes of England (statuta vetera)</a></span>
+                  
+                  <p class="note">Statutes of England from Magna Charta to the Statutum de Karleolo, 1307, preceded
+                     by lists of contents, including some undated statutes not here transcribed (for which
+                     fourteen blank leaves are left after fol. 89a), and all the treatises which follow
+                     in art. 3. Foll. 49, 50, 88 are injured.</p>
+                  
+                  </div>
+               
+               
+               <div class="msItem" id="MS_Add_A_107-item-3">
+                  
+                  <div class="locus"><span class="item-number">3. </span>(fol. 90)</div>
+                  
+                  <p class="note">Short legal treatises, twenty-one in number: the first is the '<span class="title tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_4181">Magna Hengam</a></span>' and the last 'Dilaciones breuium.'</p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_107-item-">
+                  
+                  <p class="note">Some curious miscellaneous notes occur on foll. 168-9, chiefly local: and on fol.
+                     iv 'Les nomis des grauntz seigneurs de Fraunce oscis en la bataille a Crecy ...' Aug.
+                     26, 1346.</p>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="seg"><span class="measure">iv</span> + <span class="measure">185 ('171')</span></span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">10.375</span> × <span class="width">7.5</span> in.
+                        
+                        </div>
+                  </div>
+                  
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">Good borders.</p>
+                  
+                  <p class="decoNote"> Good initials. (<a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> iii. 586) </p>
+                  </div>
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">Faded pink leather on boards, worn, with one leather clasp (out of two) lost,
+                     contemporary.</p>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">c. 1330</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7002445">English</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance"><span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_1441">Col. J. Sidney North</a></span></p>
+                  <p class="acquisition">Purchased from him by the Bodleian on Jan. 18, 1871.</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Description adapted (2024) from Summary Catalogue (1905). Decoration, localization
+                     and date follow Pächt and Alexander (1973).  
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0576.gif">Summary Catalogue, Vol. 5, p. 541</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Online resources:</h4>
+                        
+                        <div class="bibl">
+                           <a href="http://jonas.irht.cnrs.fr/manuscrit/79110" target="_blank">
+                              <span class="title italic">JONAS: Répertoire des textes et des manuscrits médiévaux d'oc et d'oïl</span>
+                              </a>
+                           </div>
+                        </span>
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Printed descriptions:</h4>
+                        
+                        <div class="bibl">S. J. P. van Dijk, <span class="title italic">Latin Liturgical Manuscripts in the Bodleian Library, Oxford, vol. 3: Rituals and
+                              Directories</span> (typescript, 1957), <span class="citedRange">p. 143</span>
+                           </div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2024-12: Description revised to incorporate all information from printed catalogues.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 108</h1>
+      <div class="content tei-body" id="manuscript_7">
+         <div class="msDesc" id="MS_Add_A_108-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">28994</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_108-item1">
+                  <div class="locus"></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_24572572">Peter of Blois</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_3525">Epistolae</a></span>
+                  
+                  <p class="note">Seventeen letters (1-11; 14; 12; 13; 15; 75; 78), ending with 'angelus inimicus' and
+                     the catchword 'assistit'</p>
+                  
+                  <p class="note">The rest of the manuscript is lost</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>i + <span class="measure">21</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">8.875</span> × <span class="width">6.25</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century</span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="acquisition">Presented by <span class="persName dnr"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_5099">H. A. Pottinger</a></span>, M.A., in December 1870</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (May 2025) by Stewart J. Brookes from the Summary Catalogue (1905)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0573.gif">Summary Catalogue, Vol. 5, p. 538</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-05-29: Description revised to incorporate all the information in the Summary Catalogue (1905)
+               and other printed sources</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 109</h1>
+      <div class="content tei-body" id="manuscript_8">
+         <div class="msDesc" id="MS_Add_A_109-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">30165</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_A_109-item1">
+                  <div class="locus"></div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_12187">Harmony of the Gospels</a></span>
+                  
+                  <p class="note">Fols. 34–54 fragmentary.</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Italian</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="seg"><span class="measure">i</span> + <span class="measure">70</span></span> fols. 
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">285</span> × <span class="width">215</span> mm.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p>2 columns, 
+                        <span class="height">202</span> × <span class="width">55–65</span> mm.
+                        
+                        , 30–40 lines.</p>
+                     </div>
+                  </div>
+               
+               <div class="musicNotation"><span class="tei-label">Musical Notation: </span>
+                  
+                  <p>Neums (see van Dijk 1957).</p>
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">Coloured initials.</p>
+                  
+                  <p class="decoNote">Rubrics.</p>
+                  </div>
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">Red (?) whittawed leather over boards (s. xv ex?), rebacked.</p>
+                  
+                  </div>
+               
+               <div class="accMat">
+                  <h4>Accompanying Material</h4>
+                  <p>Fol. iii is a leaf and a half from a 12th century Latin antiphonal on parchment.</p>
+               </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">1388</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italian</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">Fol. 1.: 'In nomine domini nostri Iesu christi millesimo cccºlxxxviijº die 8. Julij
+                     conpletus per me <span class="persName scr"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_2752">petrum de Florentia</a></span> indictione X.' (forming a heading at the beginning of the list of chapters, but the
+                     text carries on without a break and script and decoration are the same). </p>
+                  <p class="acquisition">Perhaps acquired about 1870.</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Adapted (2017) from A. G. Watson, <span class="title italic">Catalogue of Dated and Datable Manuscripts</span>, and from the Summary Catalogue (1905). 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0786.gif">Summary Catalogue, Vol. 5, p. 749</a></div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0787.gif">Summary Catalogue, Vol. 5, p. 750</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Printed descriptions:</h4>
+                        
+                        <div class="bibl">A. G. Watson, <span class="title italic">
+                              <a href="https://catalog.hathitrust.org/Record/000310664" target="_blank">Catalogue of Dated and Datable Manuscripts c.435–1600 in Oxford Libraries</a>
+                              </span> (Oxford, 1984), no. 5</div>
+                        
+                        <div class="bibl">S. J. P. van Dijk, <span class="title italic">Latin Liturgical Manuscripts in the Bodleian Library, Oxford, vol. 6: Fragments -
+                              Office Books, Rituals, Directories</span> (typescript, 1957), <span class="citedRange">p. 93</span>
+                           </div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 113</h1>
+      <div class="content tei-body" id="manuscript_10">
+         <div class="msDesc" id="MS_Add_A_113-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">27824</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_113-item1">
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_14868">Tacuinum sanitatis</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Tacuinum sanitatis in medicina ad narrandum .6. res necessarias &amp; in narratione iuuamenti
+                        ciborum &amp; potuum &amp; indumentorum 
+                        nocumenti ipsius [<i>sic</i>, <i>pro</i> &amp; nocumentis ipsorum]. Et in remotione nocumentorum iuxta consilia meliorum ex antiquis.
+                        Composuit 
+                        autem librum istum Elbuchasem Elmuchear filius Hahaduni filii Buccellani medici de
+                        Baldach.</span></div>
+                  
+                  <p class="note">With many tables, and an alphabetical index at the end</p>
+                  
+                  <p class="note">A few 15th century medical recipes, etc, are at fol. 1v and 45v</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>ii + <span class="measure">50</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">10.5</span> × <span class="width">7.5</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">14th century, end</span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">'<span class="persName fmo">Ja. de Girodon</span>' (? <i>c</i>. 1500</p>
+                  <p class="provenance">'<span class="persName fmo">Geo: Ham:</span>' (late 17th century)</p>
+                  <p class="acquisition">'Feb. 1754 Bibl. Bodl<sup>æ</sup> D. D. <span class="persName dnr"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_56957239">Geo. Ballard</a></span> Magdalenensis.'</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (July 2025) by Stewart J. Brookes from the Summary Catalogue (1905)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0398.gif">Summary Catalogue, Vol. 5, p. 363</a></div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0399.gif">Summary Catalogue, Vol. 5, p. 364</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-07-25: Description revised to incorporate all the information in the Summary Catalogue (1905)
+               and other printed sources</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 117</h1>
+      <div class="content tei-body" id="manuscript_11">
+         <div class="msDesc" id="MS_Add_A_117-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29076</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_117-item1">
+                  <div class="locus"></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_269003442">Johannes Sulpicius</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_2523">Commentaria in Valerium Maximum</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Sulpitii . Verulani . in Valerium Maximum commentaria</span></div>
+                  
+                  <p class="note">Ends (imperfect) in Book II, chapter 4, §5 'primus consul re vera.'</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>ii + <span class="measure">66</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">9.25</span> × <span class="width">6.25</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">16th century</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="acquisition">Presented to the Library in 1874 by <span class="persName fmo dnr"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_71765457">Henry Gough, esq.</a></span></p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (May 2025) by Stewart J. Brookes from the Summary Catalogue (1905)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0589.gif">Summary Catalogue, Vol. 5, p. 554</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-05-29: Description revised to incorporate all the information in the Summary Catalogue (1905)
+               and other printed sources</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 118</h1>
+      <div class="content tei-body" id="manuscript_12">
+         <div class="msDesc" id="MS_Add_A_118-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29083</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_118-item1">
+                  <div class="locus"></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_2614028">Martinus Polonus</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_3116">Chronicon summorum pontificum et imperatorum Romanorum</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Conmença la Cronicha de Frate Martino deli Summi Pontifici</span></div>
+                  
+                  <p class="note">Partly a translation, and partly an abridgement, of portions of the Latin chronicle,
+                     
+                     with continuations to 1470. Contains only the parts which refer to the popes</p>
+                  
+                  <p class="note">A list of popes from the chronicle is at fol. 1</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Italian</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>i + <span class="measure">38</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">9</span> × <span class="width">6.375</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century, last quarter</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="acquisition">Bought from <span class="persName">G. E. Mason</span>, bookseller, on April 14, 1875, for 3<i>s</i> 6<i>d</i></p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (May 2025) by Stewart J. Brookes from the Summary Catalogue (1905)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0591.gif">Summary Catalogue, Vol. 5, p. 556</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-05-29: Description revised to incorporate all the information in the Summary Catalogue (1905)
+               and other printed sources</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 135</h1>
+      <div class="content tei-body" id="manuscript_15">
+         <div class="msDesc" id="MS_Add_A_135-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">30170</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_135-item1">
+                  <div class="locus"></div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_11494">Defence of Protestantism against Roman Catholic attack</a></span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Gnadt vnd frid mere sych bey euch gebenedeiit sei Gott</span></div>
+                  
+                  <p class="note">In fourteen sections</p>
+                  
+                  <p class="note">There seems to be a reference to <span class="persName"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100185986">Johann von Eck</a></span> on fol. 9</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>German</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>iii + <span class="measure">67</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">8.5</span> × <span class="width">6.375</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">16th century, second half</span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="acquisition">Perhaps acquired <i>c</i>. 1865</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (June 2025) by Stewart J. Brookes from the Summary Catalogue (1905)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0788.gif">Summary Catalogue, Vol. 5, p. 751</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-06-10: Description revised to incorporate all the information in the Summary Catalogue (1905)</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 163</h1>
+      <div class="content tei-body" id="manuscript_17">
+         <div class="msDesc" id="MS_Add_A_163-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">24773</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_A_163-item1">
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_8194433">Virgil</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_4920">Aeneid</a></span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">
+                     
+                     <p class="decoNote-p">Penwork initials. Good penwork initials, fol. I, perhaps added 15th century. (<a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> ii. 197)</p>
+                     </p>
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">14th century, end</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italian</a></span>, <span class="region">North</span>
+                     
+                     </span>
+                  </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Summary description by Elizabeth Solopova and Matthew Holford, based on the Summary
+                     Catalogue and supplementary sources. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0105.gif">Summary Catalogue, Vol. 5, p. 70</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 164</h1>
+      <div class="content tei-body" id="manuscript_18">
+         <div class="msDesc" id="MS_Add_A_164-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">24720</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_164-item1">
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>[A rather later title] In quatuor Georgicorum Virgilij libros per <span class="note">[?]</span> B. C. argumenta et declarationes</span></div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_11300">Commentary on Virgil, <span class="title italic">Georgics</span></a></span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span><i>Quid faciat laetas segetes</i>. Diuidimus in duas partes, in auctorem &amp; opus. Auctorem intelligimus.</span></div>
+                  
+                  <p class="note">A commentary on the Georgics, with an index of the lemmata and a few later notes</p>
+                  
+                  <p class="note">A leaf is wanting at the end of the index, and one also at the end of the text</p>
+                  
+                  <p class="note">Fol. iv is a 19th cent. paper by G. Negrini (1826?) suggesting that the whole is in
+                     the hand of, if not composed by, 
+                     Battista Guarini (d. 1513), but this was seen by the writer himself in 1837 to be
+                     not likely; and Guarini is quoted in 
+                     the later notes as expressing an opinion different from that of the commentary (e.g.
+                     fols. 5, 33 and 123v), while the author 
+                     (and probably writer) seems to be clearly stated to be 'B. C.'</p>
+                  
+                  <p class="note"></p>
+                  
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>xii + <span class="measure">125</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">8.875</span> × <span class="width">6.625</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century, second half</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">No. 'CXV' and 'Miscellanea tomo 12°' in a public library in Italy with which G. Negrini
+                     (see above) was connected in 1826 and 1837, 
+                     perhaps Ferrara. Manuscript no. 129 of the same library had been 'confrontato' with
+                     this manuscript, perhaps as being an autograph of Guarini. 
+                     See "<a href="https://archives.bodleian.ox.ac.uk/repositories/2/archival_objects/175230" target="_blank">MS. Add. A. 19</a>" for similar library marks
+                     
+                                       
+                     
+                     </p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (July 2025) by Stewart J. Brookes from the Summary Catalogue (1905)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0087.gif">Summary Catalogue, Vol. 5, p. 52</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-07-25: Description revised to incorporate all the information in the Summary Catalogue (1905)
+               and other printed sources</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 165</h1>
+      <div class="content tei-body" id="manuscript_19">
+         <div class="msDesc" id="MS_Add_A_165-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">24728</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_A_165-item1">
+                  
+                  <div class="locus"><span class="item-number">1. </span>(fol. 1)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_83985148">Juvenal</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_2896">Satires</a></span>
+                   <span class="note">(with gloss)</span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_165-item2">
+                  
+                  <div class="locus"><span class="item-number">2. </span>(fol. 93)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100198157">Persius</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_3489">Satires</a></span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               <div class="msItem" id="d22e143">
+                  
+                  <div class="locus"><span class="item-number">3. </span>(fol. 112)</div>
+                  <span class="tei-title">Form of a letter to a friend</span>
+                  
+                  <p class="note">Later addition.</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin and Italian</div>
+                  </div>
+               
+               <div class="msItem" id="d22e158">
+                  
+                  <div class="locus"><span class="item-number">4. </span>(fol. 113)</div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_5567">Commentary on Juvenal, Sat. i.1 to ii.3</a></span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>In expositione poetarum</span></div>
+                  <span class="listBibl">
+                     
+                     <div class="bibl">See <a href="http://catalogustranslationum.org/index.php/archives/volume-i" target="_blank"><span class="title italic">Catalogus Translationum et Commentariorum</span></a> I (1960), 200-1 (Eva M. Sanford) for summary.</div>
+                     </span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="measure">126</span> fols. 
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">215</span> × <span class="width">145</span> mm.
+                        
+                        </div>
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (written): </span>
+                        <span class="height">145–55</span> × <span class="width">80–90</span> mm.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p>20 long lines.</p>
+                     </div>
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">Ink initials.</p>
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">1475</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italian</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">Fol. 91v: 'Explicit Juuenalis Deo Gratias Amen .M.CCCC.Lxxv Die Aprilis iij'. The
+                     rest of the MS to fol. 126 (except 112r-v) if in the same hand and at least as far
+                     as fol. 110 was probably written at the same time as fols. 1–91v.</p>
+                  <p class="provenance"><span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_19743305">Guglielmo Libri</a></span>, no. 564 in his sale, 1859.</p>
+                  <p class="acquisition">Purchased by the Bodleian.</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Adapted (2017) from A. G. Watson, <span class="title italic">Catalogue of Dated and Datable Manuscripts</span>, and from the Summary Catalogue (1905). 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0090.gif">Summary Catalogue, Vol. 5, p. 55</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">                         
+                        <div class="bibl">A. G. Watson, <span class="title italic"><a href="https://catalog.hathitrust.org/Record/000310664" target="_blank">Catalogue of Dated and Datable Manuscripts c.435–1600 in Oxford Libraries</a></span> (Oxford, 1984), no. 6</div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 166</h1>
+      <div class="content tei-body" id="manuscript_20">
+         <div class="msDesc" id="MS_Add_A_166-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">24729</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_A_166-item1">
+                  <div class="item-number">1. </div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_13052">Lives of <span class="persName"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_83985148">Juvenal</a></span></a></span>
+                   <span class="note">(three short lives)</span>
+                  
+                  <div class="nestedmsItem" id="d23e120" style="margin-top:1rem;">
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span><span class="supplied">⟨I⟩</span>unius Iuuenalis libertino locupletis</span></div>
+                     </div>
+                  
+                  <div class="nestedmsItem" id="d23e128">
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span><span class="supplied">⟨I⟩</span>uuenalis satiricus Aquinates oppido fuit</span></div>
+                     </div>
+                  
+                  <div class="nestedmsItem" id="d23e136" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span><span class="supplied">⟨I⟩</span>uuenalis proprium illy fuit Aquinates</span></div>
+                     </div>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_166-item2">
+                  <div class="item-number">2. </div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_83985148">Juvenal</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_2896">Satires</a></span>
+                  
+                  <p class="note">With partial glosses (sat. i and part of ii) and arguments in verse to eight satires.</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               <div class="msItem" id="d23e164">
+                  
+                  <div class="locus"><span class="item-number">3. </span>(fol. 93)</div>
+                  
+                  <p class="note">Later additions:</p>
+                  
+                  <div class="nestedmsItem" id="d23e172" style="margin-top:1rem;">
+                     <span class="tei-title">Metrical calendar</span>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Principio Jany</span></div>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                     </div>
+                  
+                  <div class="nestedmsItem" id="d23e184">
+                     <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_1388">Poems</a></span>
+                     
+                     <div class="nestedmsItem" id="d23e189" style="margin-top:1rem;">
+                        
+                        <div class="incipit"><span class="tei-label">Incipit: </span><span>Colluj che parte more et tace in foro</span></div>
+                        </div>
+                     
+                     <div class="nestedmsItem" id="d23e195" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                        
+                        <div class="incipit"><span class="tei-label">Incipit: </span><span>Infelici parenti. infelice hora</span></div>
+                        </div>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Italian</div>
+                     </div>
+                  
+                  <div class="nestedmsItem" id="d23e205" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                     <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_10353">Astrological poem</a></span>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Nil capiti facias, Aries cum Luna refulget</span></div>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                     </div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="measure">96</span> fols. 
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">197</span> × <span class="width">140</span> mm.
+                        
+                        </div>
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (written): </span>
+                        <span class="height">140</span> × <span class="width">c. 75–80</span> mm.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p>1 col., 22 lines.</p>
+                     </div>
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">Rubrics.</p>
+                  
+                  <p class="decoNote">Spaces left for initials.</p>
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">1475</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italian</a></span>, <span class="settlement"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7006739">Rieti</a></span>
+                     
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">Fol. 92v: 'Explicit liber <span class="sic">vuuenalis[<i>sic</i>]</span> Quem ego <span class="persName scr"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_2753">petrus simon constantiny Jacobi Vanderutij de Rieto</a></span> scrypsy et ad ffinem produxy in Ciuitate Rieti ac in escola magistri petri felitiany
+                     de cingulo sub Anno domini MºccccºLxxv [v <i>erased and arabic</i> 2 <i>added</i>] Inditione viija tempore dominy dominy ...Sixty pape quinty... etc. die xxv mensis
+                     Iulij etc.'.</p>
+                  <p class="provenance"><span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_19743305">Guglielmo Libri</a></span>, no. 565 in his sale, 1859.</p>
+                  <p class="acquisition">Purchased by the Bodleian.</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Adapted (2017) from A. G. Watson, <span class="title italic">Catalogue of Dated and Datable Manuscripts</span>, and from the Summary Catalogue (1905). 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0090.gif">Summary Catalogue, Vol. 5, p. 55</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">                         
+                        <div class="bibl">A. G. Watson, <span class="title italic"><a href="https://catalog.hathitrust.org/Record/000310664" target="_blank">Catalogue of Dated and Datable Manuscripts c.435–1600 in Oxford Libraries</a></span> (Oxford, 1984), no. 7</div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 167</h1>
+      <div class="content tei-body" id="manuscript_21">
+         <div class="msDesc" id="MS_Add_A_167-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">24768</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</p>
+               
+               <div class="msItem" id="d24e113">
+                  
+                  <p class="note">Epigram on Terence</p>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Natus in excelsis</span></div>
+                  </div>
+               
+               <div class="msItem" id="d24e122">
+                  
+                  <p class="note">Life of Terence</p>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Terentius genere extitit Afer</span></div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_167-item1">
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_66462384">Terence</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_4666">Comedies</a></span>
+                  
+                  <div class="colophon"><span class="tei-label">Colophon: </span><span>Expliciunt excerpa Terenty Johannis pircheimer Junioris <span class="locus">(fol. 102)</span></span></div>
+                  
+                  <div class="colophon"><span class="tei-label">Colophon: </span><span>Explicit Terentius per Iohannem Pircheimer Ano domini mccccLiiij pasce <span class="locus">(fol. 182v)</span></span></div>
+                  </div>
+               
+               <div class="msItem" id="d24e150">
+                  
+                  <div class="locus">(fol. 183)</div>
+                  
+                  <p class="note">Life of Terence</p>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>De Terentii vita in antiquis libris</span></div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="measure">192</span> fols. 
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">210</span> × <span class="width">150</span> mm.
+                        
+                        </div>
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (written): </span>
+                        <span class="height">155–60</span> × <span class="width">90–5</span> mm.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p>1 col., c. 19–27 lines.</p>
+                     </div>
+                  </div>
+               
+               <div class="handDesc">
+                  <h4>Hand(s)</h4>
+                  
+                  <p class="handNote">Two hands: (a) fol. 1–182v (b) fols. 183–192. Probably <span class="persName scr"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_69338373">Hans</a></span> and <span class="persName scr"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_45097499">Hans-Johann Pirckheimer</a></span>. Hans studied in Padua for several years and was in Rome at the beginning of 1455.
+                     Cf. A. Reimann, <span class="title italic">Die älteren Pirckheimer</span> (1944); N. Holzberg, <span class="title italic">Willibald Pirckheimer: griechischer Humanismus in Deutschland</span> (1981).</p>
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">Coloured initials.</p>
+                  
+                  <p class="decoNote">Rubrics.</p>
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">1454</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italian</a></span> (?)</span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">'Sewolt geuder', fol. 1; 'Sewaldus geuder Est posessor huius libery', fol. 192v: <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_2781">Sebald Geuder</a></span>, grandson of Hans-Johann Pirckheimer.</p>
+                  <p class="provenance"><span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_19743305">Guglielmo Libri</a></span>, no. 986 in his sale, 1859.</p>
+                  <p class="acquisition">Purchased by the Bodleian.</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Adapted (2017) from A. G. Watson, <span class="title italic">Catalogue of Dated and Datable Manuscripts</span>, and from the Summary Catalogue (1905). 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0103.gif">Summary Catalogue, Vol. 5, p. 68</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">                         
+                        <div class="bibl">A. G. Watson, <span class="title italic"><a href="https://catalog.hathitrust.org/Record/000310664" target="_blank">Catalogue of Dated and Datable Manuscripts c.435–1600 in Oxford Libraries</a></span> (Oxford, 1984), no. 8</div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 168</h1>
+      <div class="content tei-body" id="manuscript_22">
+         <div class="msDesc" id="MS_Add_A_168-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">28748</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</p>
+               
+               <div class="msItem" id="MS_Add_A_168-item1">
+                  
+                  <div class="locus"><span class="item-number">1. </span>(fol. 1)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_88342447">Ovid</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_3418">Ex Ponto</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>P. Ouidii Nasonis de Ponto liber primus incipit</span></div>
+                  
+                  <p class="note">The four books</p>
+                  </div>
+               
+               
+               <div class="msItem" id="MS_Add_A_168-item2">
+                  
+                  <div class="locus"><span class="item-number">2. </span>(fol. 60)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100227522">Horace</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_2094">Ars Poetica</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Flacci Horatii Ars poetica incipit</span></div>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               
+               <div class="msItem" id="MS_Add_A_168-item3">
+                  
+                  <div class="locus"><span class="item-number">3. </span>(fol. 69)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100219266">Tibullus</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_4867">Elegies</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Albii Tibulli poete illustris liber primus...</span></div>
+                  
+                  <p class="note">The four books, but after II.5.114 the handwriting changes to one less calligraphic</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               
+               <div class="msItem" id="MS_Add_A_168-item4">
+                  <div class="item-number">4. </div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_69276384">Domitius Marsus</a></span>, 
+                  
+                  <span class="tei-title">The 4-line epitaph of <span class="persName"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100219266">Tibullus</a></span></span>
+                  
+                  </div>
+               
+               
+               <div class="msItem" id="MS_Add_A_168-item5">
+                  <div class="item-number">5. </div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_88342447">Ovid</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_3415">Amores III.9</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Ouidius de sine titulo</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Memnona si mater</span></div>
+                  </div>
+               
+               
+               <div class="msItem" id="MS_Add_A_168-item6">
+                  <div class="item-number">6. </div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_5102">Paulus Porcius</a></span>, 
+                  <span class="tei-title">A poem about the Virgin Mary</span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Hac quocunque uia transis</span></div>
+                  
+                  <p class="note">From a chapel at Terni (Interamna)
+                     </p>
+                  </div>
+               
+               
+               <div class="msItem" id="MS_Add_A_168-item7">
+                  <div class="item-number">7. </div>
+                  <span class="tei-title">An epitaph on Laudacia Philocatta</span>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment, paper</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>i + <span class="measure">113</span> leaves. Fols 69-98 are parchment; the rest are paper
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">9.25</span> × <span class="width">6.75</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century, second half</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">'V. c. 4'</p>
+                  <p class="acquisition">Purchased for £2 8<i>s</i> at Sotheby's on 20-21 June 1860, lot 258, along with <a href="https://medieval.bodleian.ox.ac.uk/?utf8=%E2%9C%93&amp;q=%22Sotheby%27s+on+20-21+June+1860%22" target="_blank">eight other manuscripts</a> 
+                     'formerly in the archives of two princely Roman families'</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (June 2025) by Stewart J. Brookes from the Summary Catalogue (1905)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0539.gif">Summary Catalogue, Vol. 5, p. 504</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-06-20: Description revised to incorporate all the information in the Summary Catalogue (1905)
+               and other printed sources</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 169</h1>
+      <div class="content tei-body" id="manuscript_23">
+         <div class="msDesc" id="MS_Add_A_169-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">28749</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_A_169-item1">
+                  
+                  <div class="locus"><span class="item-number">1. </span>(fol. 1)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100227522">Horace</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_2097">Carmina</a></span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_169-item2">
+                  
+                  <div class="locus"><span class="item-number">2. </span>(fol. 87)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100227522">Horace</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_2096">Epodi</a></span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_169-item3">
+                  
+                  <div class="locus"><span class="item-number">3. </span>(fol. 105)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100227522">Horace</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_2092">Carmen saeculare</a></span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="measure">110</span> fols. 
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">200</span> × <span class="width">137</span> mm.
+                        
+                        </div>
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (written): </span>
+                        <span class="height">140</span> × <span class="width">c. 70</span> mm.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p>1 col., 18 lines.</p>
+                     </div>
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">Coloured initial.</p>
+                  
+                  <p class="decoNote"> Spaces left for other initials.</p>
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">1477</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>, <span class="region">North-east</span>
+                     
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">Fol. 107: 'finis .M.CCCC.L.XXVII'. Ruling is on the versos of leaves only, which suggests
+                     an origin in north-east Italy.</p>
+                  <p class="provenance">Pressmark 'Kk. d. 21', fol. 110v and back pastedown; in the same series as the pressmark
+                     'V. c. 4' in MS. Add. A. 168, also of Italian origin.</p>
+                  <p class="acquisition">Purchased for £1 4<i>s</i> at Sotheby's on 20-21 June 1860, lot 119, along with <a href="https://medieval.bodleian.ox.ac.uk/?utf8=%E2%9C%93&amp;q=%22Sotheby%27s+on+20-21+June+1860%22" target="_blank">eight other manuscripts</a> 
+                     'formerly in the archives of two princely Roman families'</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Adapted (2017) from A. G. Watson, <span class="title italic">Catalogue of Dated and Datable Manuscripts</span>, and from the Summary Catalogue (1905). 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0539.gif">Summary Catalogue, Vol. 5, p. 504</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">                         
+                        
+                        <div class="bibl">A. G. Watson, <span class="title italic"><a href="https://catalog.hathitrust.org/Record/000310664" target="_blank">Catalogue of Dated and Datable Manuscripts c.435–1600 in Oxford Libraries</a></span> (Oxford, 1984), no. 9</div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 170</h1>
+      <div class="content tei-body" id="manuscript_25">
+         <div class="msDesc" id="MS_Add_A_170-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">24709</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_170-item1">
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_79253969">Gualterus Anglicus (attrib.)</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_10114">Aesopus moralisatus</a></span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>(metrical preface) Vt iuuet et prosit.</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Explicit Liber Esopi . Deo gratias . Amen</span></div>
+                  
+                  <p class="note">62 fables in elegiac verse</p>
+                  
+                  <p class="note">The distich beginning 'Fine fruor' is found in this manuscript both at the end of
+                     
+                     the 60th and of the 62nd fable, the two supplementary ones being 'De capone et accipitre'
+                     and 'De pastore et lupo.'</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               
+               <div class="msItem" id="d28e126">
+                  
+                  <p class="note">At the beginning there are prescriptions for making various colours and  at the end
+                     are some medical recipes</p>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>ii + <span class="measure">20</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">8.25</span> × <span class="width">5.75</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  </div>
+               
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="summary"><a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> ii. 928
+                     </p>
+                  
+                  <p class="decoNote"> Good initial<span class="head">
+                        <p>fol. 1r</p></span><ul class="list">
+                        
+                        
+                        <li><b>Type</b> 
+                           <span class="seg">initial U</span>
+                           </li>
+                        
+                        
+                        <li><b>Subject</b> 
+                           <span class="seg">Floral designs</span>
+                           </li>
+                        
+                        </ul>
+                  </p>
+                  
+                  <p class="decoNote">
+                     <span class="head">
+                        <p>fol. 16v</p></span><ul class="list">
+                        
+                        
+                        <li><b>Type</b> 
+                           <span class="seg">drawing, lower margin</span>
+                           </li>
+                        
+                        
+                        <li><b>Subject</b> 
+                           <span class="seg">Human half-figure, emerging from flames, supporting a scroll with catchwords</span>
+                           </li>
+                        
+                        </ul>
+                     </p>
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century, first half</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">Fol. 18v: 'Iste liber est mei <span class="persName fmo">Bertus Nicholai de Rosarmia de Pisis'</span> (15th century)</p>
+                  <p class="acquisition">Purchased by the Bodleian at Sotheby's on 28th March 28th 1859 from the collection
+                     of <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_19743305">Guillaume Libri</a></span>. 
+                     No. 12 in the <a href="https://archive.org/details/CatalogueLibriSothebys/page/n62/mode/1up" target="_blank">sale catalogue</a>
+                     </p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (August) by Stewart J. Brookes from the Summary Catalogue (1905)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0082.gif">Summary Catalogue, Vol. 5, p. 47</a></div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0083.gif">Summary Catalogue, Vol. 5, p. 48</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-08-08: Description revised to incorporate all the information in the Summary Catalogue (1905)</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 171</h1>
+      <div class="content tei-body" id="manuscript_26">
+         <div class="msDesc" id="MS_Add_A_171-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">24710</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</p>
+               
+               <div class="msItem" id="MS_Add_A_171-item1">
+                  <div class="item-number">1. </div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_64013451">Aesop</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_280">Fables</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_171-item2">
+                  <div class="item-number">2. </div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100010336">Prudentius</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_3811">Dittochaeon</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_171-item3">
+                  <div class="item-number">3. </div>
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_12786">Liber cartule</a></span>
+                  <span class="bibl">PL 184, 1307–14</span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_171-item4">
+                  <div class="item-number">4. </div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_56961813">Theodulus</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_4733">Ecloga</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_171-item5">
+                  <div class="item-number">5. </div>
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_11805">Facetus</a></span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Moribus et uita quisquis uult esse facetus</span></div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_171-item6">
+                  <div class="item-number">6. </div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_297475745">John Chrysostom</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_2655">De septem virtutibus</a></span>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">Miniatures (two marginal drawings of Virtues and Vices) <span class="head">
+                        <p>fol. 49r</p></span><ul class="list">
+                        
+                        
+                        <li><b>Type</b> 
+                           <span class="seg">ink drawings, left and right margins</span>
+                           </li>
+                        
+                        
+                        <li><b>Subject</b> 
+                           <span class="seg">Virtues and Vices: two human figures (one seated, wearing a crown and holding a sceptre,
+                              another standing, holding a torch (?)), and two smaller figures of demons.</span>
+                           </li>
+                        
+                        </ul>
+                     </p>
+                  
+                  <p class="decoNote">Penwork initials. (<a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> ii. 183)</p>
+                  </div>
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">Brown calf with gold ornament, etc., about 1830-40 (?), with coloured
+                     capitals.</p>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">14th century, second half</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italian</a></span>
+                     </span>
+                  </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Summary description by Elizabeth Solopova and Matthew Holford, based on the Summary
+                     Catalogue and supplementary sources. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0083.gif">Summary Catalogue, Vol. 5, p. 48</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2022-04-04: Add binding information from Summary Catalogue.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 172</h1>
+      <div class="content tei-body" id="manuscript_27">
+         <div class="msDesc" id="MS_Add_A_172-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">28403</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_172-item1">
+                  <div class="locus"></div>
+                  
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_105100637">Priscian</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_3774">De constructione ( = Institutiones grammaticae XVII-XVIII)</a></span>
+                  
+                  <p class="note">Books 17 and 18 of <span class="title italic">Commentarii grammatici</span> which are the two books on syntax ('de constructione'), here considered 
+                     as a separate work in two books (see fol. 35)</p>
+                  
+                  <p class="note">Some scribbling on fol. 72v gives the title 'Priscianus Minor'</p>
+                  
+                  <p class="note">The date 'MCCCXIIJ' occurs several times on fol. 72</p>
+                  
+                  <p class="note">With a few glosses</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>ii + <span class="measure">74</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">8.375</span> × <span class="width">6.5</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">13th century, late</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">Bought by <span class="persName bsl">Thomas Thorpe</span> at the <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_5314321">Richard Heber</a></span> sale, Part xi (manuscripts), 
+                     10-20 February 1836, for £4</p>
+                  <p class="acquisition">Sold by Thorpe to the Bodleian for £6 6<i>s</i></p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (May 2025) by Stewart J. Brookes from the Summary Catalogue (1905)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0480.gif">Summary Catalogue, Vol. 5, p. 445</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-05-29: Description revised to incorporate all the information in the Summary Catalogue (1905)
+               and other printed sources</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 173</h1>
+      <div class="content tei-body" id="manuscript_28">
+         <div class="msDesc" id="MS_Add_A_173-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">24761</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</p>
+               
+               <div class="msItem" id="MS_Add_A_173-item1">
+                  <div class="locus"></div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_14469">Gregorian fused Sacramentary</a></span>
+                  
+                  <div class="nestedmsItem" id="d31e122" style="margin-top:1rem;">
+                     
+                     <div class="locus"><span class="item-number">1. </span>(fol. 3)</div>
+                     
+                     <p class="note">Notes of Dom Victor Perrin (d.1740) on the manuscript.</p>
+                     </div>
+                  
+                  <div class="nestedmsItem" id="d31e131">
+                     
+                     <div class="locus"><span class="item-number">2. </span>(fol. 1)</div>
+                     
+                     <p class="note">Combined temporale and sanctorale, beginning abruptly at the end of Christmas and
+                        ending in the postcommunion of St Lawrence (10 Aug.).</p>
+                     </div>
+                  
+                  <div class="nestedmsItem" id="d31e140">
+                     <div class="item-number">3. </div>
+                     
+                     <p class="note">Last part of the orationes pro peccatis (38: Da nobis quesumus …), in a different
+                        order.</p>
+                     </div>
+                  
+                  <div class="nestedmsItem" id="d31e146">
+                     
+                     <div class="locus"><span class="item-number">4. </span>(fol. 39)</div>
+                     
+                     <p class="note">Orationes matutinales seu vespertinales.</p>
+                     </div>
+                  
+                  <div class="nestedmsItem" id="d31e156">
+                     <div class="item-number">5. </div>
+                     
+                     <p class="note">Alia oratio ad baptizandum infirmum (fol. 40v: Medellam …); oratio aquae ad baptizandum,
+                        etc. (fols. 40v, 43).</p>
+                     </div>
+                  
+                  <div class="nestedmsItem" id="d31e162">
+                     
+                     <div class="locus"><span class="item-number">6. </span>(fol. 43)</div>
+                     
+                     <p class="note">Benedictio aquae exorcizate in domo, in three different forms, the second of which
+                        is in the Gregorian sacramentary.</p>
+                     </div>
+                  
+                  <div class="nestedmsItem" id="d31e171">
+                     
+                     <div class="locus"><span class="item-number">7. </span>(fol. 44v)</div>
+                     
+                     <p class="note">Oratio ad visitandum infirmum, etc., ending abruptly in the prayer ad capillaturam.</p>
+                     </div>
+                  
+                  <div class="nestedmsItem" id="d31e180">
+                     <div class="item-number">8. </div>
+                     
+                     <p class="note">Part of the ordination service (41, 42, 45r).</p>
+                     </div>
+                  
+                  <div class="nestedmsItem" id="d31e186">
+                     
+                     <div class="locus"><span class="item-number">9. </span>(fol. 45v)</div>
+                     
+                     <p class="note">Votive masses with the epistle and gospel after the postcommunions.</p>
+                     </div>
+                  
+                  <div class="nestedmsItem" id="d31e195" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                     
+                     <div class="locus"><span class="item-number">10. </span>(fol. 52v)</div>
+                     
+                     <p class="note">Beginning of the common.</p>
+                     </div>
+                  
+                  <p class="note">Not written for a monastic community. Some local indications may be found in the series
+                     of collects on fol. 2v.</p>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  <div class="extent"> <span class="seg"><span class="measure">vi</span> + <span class="measure">7</span> + <span class="measure">52</span> + <span class="measure">ii</span></span> fol. 
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">221</span> × <span class="width">155</span> mm.
+                        
+                        </div>
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (written): </span>
+                        <span class="height">190</span> × <span class="width">120</span> mm.
+                        
+                        </div>
+                     </div>
+                  
+                  <div class="collation">
+                     <h4>Collation</h4>
+                     <div class="collation">Leaves missing at the beginning, after fol. 37, and at the end of the volume. One
+                        leaf after fol. 8, 14 and 31; fol. 41, 42 should follow fol. 44.</div>
+                  </div>
+                  
+                  
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p>Text in 25 lines</p>
+                     </div>
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">Simple pen initials. (<a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> i. 423)</p>
+                  
+                  <p class="decoNote">Titles and some rubric in red, often entirely rubbed out, others in black (fol. 41)</p>
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">9th century, second half</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000070">French</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">Belonged in the 18th century to the Benedictine monastery of <span class="orgName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/org_239220402">Luxeuil</a></span></p>
+                  <p class="provenance"><span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_19743305">Guglielmo Libri</a></span>, his sale 2 April 1859, no. 891</p>
+                  <p class="acquisition">Purchased by the Bodleian.</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Adapted (2017) from the following sources. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl">S. J. P. Van Dijk, <span class="title italic">Handlist of the Latin Liturgical Manuscripts in the Bodleian Library Oxford : Vol.
+                              1: Mass Books</span> (typescript, 1957), pp. 9–10 [contents, physical description]</div>
+                        
+                        <div class="bibl">Otto Pächt and J. J. G. Alexander, <span class="title italic"><a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Illuminated Manuscripts in the Bodleian Library, Oxford</a></span>, I (1966), no. 423 [origin, provenance]</div>
+                        </div> Previously described in the Summary Catalogue. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0100.gif">Summary Catalogue, Vol. 5, p. 65</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2018-01-01: Description revised based on printed descriptions listed in the record.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 174</h1>
+      <div class="content tei-body" id="manuscript_29">
+         <div class="msDesc" id="MS_Add_A_174-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29077</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_174-item1">
+                  <div class="locus"></div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_11308">Commissio of the <span class="orgName"><a href="https://medieval.bodleian.ox.ac.uk/catalog/org_167950502">Procurators of St. Mark</a></span></a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Incipiunt capitula commissionis Dominorum procuratorum nostrorum Ecclesie sancti Marci
+                        apostoli et Euangeliste</span></div>
+                  
+                  <p class="note">In fifty-four chapters, dated 1302-1401, and by additions of 1427-1473. All in one
+                     hand</p>
+                  
+                  <p class="note">A leaf is lost after fol. 4, bearing the rubrics and text of the first two chapters</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>i + <span class="measure">32</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">10.125</span> × <span class="width">7.1225</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  </div>
+               
+               
+               <div class="handDesc">
+                  <h4>Hand(s)</h4>
+                  
+                  <p class="handNote">Humanistic script (<a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> ii. 508)</p>
+                  </div>
+               
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="summary"><a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> ii. 508
+                     </p>
+                  
+                  <p class="decoNote">Good initials. Entries up to 1473</p>
+                  </div>
+               
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">Stamped leather on boards, with brass clasp fittings (clasps lost), contemporary Venetian
+                     work</p>
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">after 1473</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>, <span class="settlement"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7018159">Venice</a></span>
+                     
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="acquisition">Bought from <span class="persName">H. T. Wake</span>, bookseller, in Sept. 1874 for £2 10<i>s</i></p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (June 2025) by Stewart J. Brookes from the Summary Catalogue (1905).
+                     Decoration, localization and date follow Pächt and Alexander (1970)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0589.gif">Summary Catalogue, Vol. 5, p. 554</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-06-04: Description revised to incorporate all the information in the Summary Catalogue (1905)</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 175</h1>
+      <div class="content tei-body" id="manuscript_30">
+         <div class="msDesc" id="MS_Add_A_175-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">28684</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_A_175-item1">
+                  <div class="item-number">1. </div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100904338">Statius</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_4603">Thebais</a></span>
+                   <span class="note">(two leaves)</span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_A_175-item2">
+                  <div class="item-number">2. </div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_104162705">Sallust</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_4482">Jugurtha</a></span>
+                   <span class="note">(four leaves)</span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="physDesc-p">two sets of fragments</div>
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">13th century</span>
+                  </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Summary description based on the Summary Catalogue and supplementary sources. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0523.gif">Summary Catalogue, Vol. 5, p. 488</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <div class="bibl">Balázs József Nemes, <span class="title italic">Bibliotheca Cartusiae Erfordiensis : Dokumentation über den überlieferten Buchbestand
+                              der Erfurter Kartause</span>, 3., korrigierte und erweiterte Version (2022) <a href="https://doi.org/10.6094/UNIFR/223370" target="_blank">DOI: 10.6094/UNIFR/223370</a></div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 185</h1>
+      <div class="content tei-body" id="manuscript_32">
+         <div class="msDesc" id="MS_Add_A_185-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">3077</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_A_185-item1">
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_10549">Book of Hours, Use of Nantes</a></span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin and Middle French</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote"> Important miniatures.</p>
+                  
+                  <p class="decoNote"> Important borders. </p>
+                  
+                  <p class="decoNote">Important initials. See also MSS. Rawl. liturg. f. 9 and Rawl. liturg. e. 35. (<a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> i. 669, pl. LII)</p>
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">c. 1440</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000070">French</a></span>, <span class="settlement"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7008482">Nantes</a></span>
+                     
+                     </span>
+                  </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Summary description by Elizabeth Solopova and Matthew Holford, based on the Summary
+                     Catalogue and supplementary sources. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aap/aap0605.gif">Summary Catalogue, Vol. 2 Part 1, p. 584</a></div>
+                        </div>
+                     </div>
+                  
+                  
+                  <h3 id="availability">Availability</h3>
+                  <div class="availability"><?ni?>
+                     
+                     <p>To ensure its preservation, access to this item is restricted, and readers are asked
+                        to work from reproductions and published descriptions as far as possible. If you wish
+                        to apply to see the original, please click the request button above. When your request
+                        is received, you will be asked to contact the relevant curator outlining the subject
+                        of your research, the importance of this item to that research, and the resources
+                        you have already consulted.</p>
+                     <?ni?></div>
+                  </div>
+               
+               <div class="surrogates">
+                  <h3 class="msDesc-heading3">Digital Images</h3>
+                  <p><span class="bibl">
+                        <a href="https://digital.bodleian.ox.ac.uk/objects/756cbac0-12be-49fd-b759-6302e0471bce/" target="_blank">
+                           <span class="title italic">Digital Bodleian</span>
+                           </a>
+                        <span class="note">(51 images from 35mm slides)</span>
+                        </span><br /></p>
+               </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Online resources:</h4>
+                        
+                        <div class="bibl">
+                           <a href="http://jonas.irht.cnrs.fr/manuscrit/78805" target="_blank">
+                              <span class="title italic">JONAS: Répertoire des textes et des manuscrits médiévaux d'oc et d'oïl</span>
+                              </a>
+                           </div>
+                        </span>
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Printed descriptions:</h4>
+                        
+                        <div class="bibl">S. J. P. van Dijk, <span class="title italic">Latin Liturgical Manuscripts in the Bodleian Library, Oxford, vol. 4: Books of Hours</span> (typescript, 1957), <span class="citedRange">p. 61</span>
+                           </div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 187</h1>
+      <div class="content tei-body" id="manuscript_33">
+         <div class="msDesc" id="MS_Add_A_187-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29156</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_A_187-item1">
+                  <div class="locus"></div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_78770305">'Sir John de Mandeville'</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_2741">Travels</a></span>
+                   <span class="note">(in the vulgate Latin translation)</span>
+                  
+                  <div class="colophon"><span class="tei-label">Colophon: </span><span>... Scriptus atque finitus In terra Colla de garderane districtus Verrone trygesimo
+                        die mensis Julij anni Millesimi Quadringentesimi Quadragesimi quinti ... Qui me scribebat
+                        <span class="persName scr"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_2782">Anthonius</a></span> nomen habebat</span></div>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment, paper</div>
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="measure">70</span> fols. 
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">225</span> × <span class="width">150</span> mm.
+                        
+                        </div>
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (written): </span>
+                        <span class="height">150</span> × <span class="width">95</span> mm.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p>1 col., c. 35–8 lines.</p>
+                     </div>
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">Coloured initials.</p>
+                  
+                  <p class="decoNote">Rubrics.</p>
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">1445</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italian</a></span>, <span class="settlement"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7003262">Verona</a></span>
+                     
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">No. 37 in a French 19th cent. sale catalogue.</p>
+                  <p class="acquisition">Bought from Thomas Boone of London, 1879, for £2 2s.</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Adapted (2017) from A. G. Watson, <span class="title italic">Catalogue of Dated and Datable Manuscripts</span>, and from the Summary Catalogue (1905). 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0607.gif">Summary Catalogue, Vol. 5, p. 572</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">                         
+                        <div class="bibl">A. G. Watson, <span class="title italic"><a href="https://catalog.hathitrust.org/Record/000310664" target="_blank">Catalogue of Dated and Datable Manuscripts c.435–1600 in Oxford Libraries</a></span> (Oxford, 1984), no. 10</div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 188</h1>
+      <div class="content tei-body" id="manuscript_34">
+         <div class="msDesc" id="MS_Add_A_188-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29157</span>
+                  </p>
+               </div>
+            <h4 class="msHead">Lectionary/Missal; western Germany, 12th century, second quarter</h4>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_A_188-part2-item1">
+                  
+                  <div class="locus">(fols. 1r–167v)</div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_12559">Lectionary with musical cues </a></span>
+                   <span class="note">(partly adapted into a <span class="title tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_13355">Missal</a></span>)</span>
+                  
+                  <p class="note">In addition to the epistle and gospel readings of a Lectionary, there are the opening
+                     words with superscript musical notation for the introit, gradual, Alleluia versicle
+                     or tractus, offertory and sometimes also of the communion antiphon.</p>
+                  
+                  <div class="nestedmsItem" id="d37e128" style="margin-top:1rem;">
+                     
+                     <div class="locus">(fols. 1r–136v)</div>
+                     <span class="tei-title">Temporale</span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Dominica prima de adventu domini</span></div>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Antiphona. Ad te levavi animam. Ad Romanos. Fratres. Scientes quia hora est</span></div>
+                     
+                     <p class="note">The Passion narratives with superscript letters: t = Christ, c = Narrator, a = the
+                        Jews (cf. K. Young, ‘Observations on the origin of the mediæval Passion-play’, <span class="title italic">PMLA</span>, 25.2 (1910), 309–54 at 316, cites other Bodleian MSS. with this combination of letters,
+                        but not the present MS.): Matthew (fols. 54r–58v), Mark (fols. 60r–63v), Luke (fols.
+                        64v–68r), and John (fols. 69v–72r).</p>
+                     
+                     <p class="note">The Exultet given in full, noted (fols. 72v–73v).</p>
+                     
+                     <p class="note">With the complete baptismal rite on Holy Saturday (fol. 75v–81v), ending with a short
+                        litany. Next to the rubric ‘Hic ponantur cerei ardentes in fontem &amp; insuffletur in
+                        eundem fontem ad similitudinem huius figurę’ is a large marginal Greek letter psi:
+                        Ψ (fol. 80r).</p>
+                     
+                     <p class="note">The volume has been partly adapted into a noted missal by near-contemporary marginal
+                        additions from Easter to the 11th Sunday after Pentecost, but coloured initials and
+                        musical notation are often lacking (fols. 82v–117v).</p>
+                     
+                     <p class="note">The litany (fol. 81r-v) has Severinus (venerated at Cologne and elsewhere) second
+                        among the confessors, after Martin.</p>
+                     </div>
+                  
+                  <div class="nestedmsItem" id="d37e163">
+                     
+                     <div class="locus">(fols. 137r–156v)</div>
+                     <span class="tei-title">Sanctorale, from St. Lucy to St. Nicholas (13 December – 6 December)</span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span><span class="locus">(fol. 136v)</span> In natale sanctę Lucię virginis</span></div>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Antiphona. Dilexi iusticiam. Epistola. Qui gloriatur in domino glorietur </span></div>
+                     
+                     <p class="note"> The feast of the Purification (2 February) with the blessing, lighting, and processing
+                        of the candles (fols. 138r–139v).</p>
+                     
+                     <p class="note">St Severinus’s 23 October feast appears at fol. 153r–v.</p>
+                     </div>
+                  
+                  <div class="nestedmsItem" id="d37e187">
+                     
+                     <div class="locus">(fols. 156v–167v)</div>
+                     <span class="tei-title">Common of the saints</span>
+                     </div>
+                  
+                  <div class="nestedmsItem" id="d37e196" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                     
+                     <div class="locus">(fol. 167v)</div>
+                     
+                     <p class="note">Miscellaneous additions:</p>
+                     
+                     <div class="nestedmsItem" id="d37e204" style="margin-top:1rem;">
+                        
+                        <p class="note">Two Evangeliary readings on Marian themes, 13th-century: ‘In illo tempore. Stabat iuxta crucem Ihesu …’ (John 19:25–27); ‘In illo tempore. Factum est dum loqueretur Ihesus ad turbas …’ (Luke 11:27–28, for the eve of the Assumption, 14 August)</p>
+                        </div>
+                     
+                     <div class="nestedmsItem" id="d37e216">
+                        
+                        <p class="note">Ownership note, 13th-century, of St Mary and St James, Lahneck (see Provenance)</p>
+                        </div>
+                     
+                     <div class="nestedmsItem" id="d37e222" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                        
+                        <p class="note">Old Testament reading, 15th-century: ‘Ab inicio et ante secula …’ (Ecclesiasticus 24:14–16, likely continuing the Marian theme)</p>
+                        </div>
+                     </div>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  <div class="extent"> <span class="seg"><span class="measure">1</span> + <span class="measure">i</span> + <span class="measure">167</span> + <span class="measure">1</span></span> fol. 
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">237</span> × <span class="width">160</span> mm.
+                        
+                        </div>
+                     </div>
+                  
+                  <div class="foliation"><span class="tei-label">Foliation: </span> i–ii, 1–168, in pencil</div>
+                  
+                  <div class="collation">
+                     <h4>Collation</h4>
+                     <div class="collation">Mainly in quires of 8 leaves.</div>
+                  </div>
+                  
+                  
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p>Ruled in plummet for 28 lines; ruled space 
+                        <span class="height">195</span> × <span class="width">115</span> mm.
+                        
+                        </p>
+                     </div>
+                  </div>
+               
+               <div class="handDesc">
+                  <h4>Hand(s)</h4>
+                  
+                  <p class="handNote">Proto-gothic bookhand, accented for reading aloud; the parts with music in smaller
+                     script.</p>
+                  </div>
+               
+               <div class="musicNotation"><span class="tei-label">Musical Notation: </span>
+                  
+                  <p>Adiastematic German neums.</p>
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">One fine large foliate initial drawn in brown ink, embellished with red (fol. 1r).</p>
+                  
+                  <p class="decoNote">Two-line initials in plain red.</p>
+                  </div>
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">17th-century German binding. Sewn on three bands laced into wood (beech?) boards,
+                     covered with red leather, the back cover formerly with corner-pieces and a large centre-piece
+                     and clasp fittings (all now missing), the front cover with simple blind fillets; the
+                     spine with lozenge-shaped gilt ornaments; the edges of the leaves gilt. Extensively
+                     repaired.</p>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">12th century, second quarter</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7000084">German</a></span>, <span class="region">West</span>
+                     
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">Regular canons of <span class="orgName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/org_145">St Mary and St James, Lonnig</a></span> (west of Koblenz), transferred in 1326 to the <span class="orgName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/org_145">regular canons of Mayen</a></span> (west of Koblenz); with 15th century inscription: ‘Notum sit omnibus presens scriptum visuris in perpetuum quod iste liber est ecclesie
+                     sancte Marie virginis sanctique Iacobi apostoli Lůneche quem si quis furto detraxerit
+                     aut in vadio exposuerit …’, and in a 17th(?)-century hand, ‘1326. Hic liber cum caeteri Maioniam <span class="note">[Mayen]</span> translatus sub Baldewino archiepiscopo.’(fol.167v) </p>
+                  <p class="acquisition">Thomas Boone, London bookseller, with his price-code in pencil (fol. 168r, upper left
+                     corner); bought by the Bodleian on 29 October 1879 for £10. Former Bodleian shelfmarks:
+                     ‘MSS. Bodl. Addit. A. 188’ (fol. iir).</p>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_188-endleaves" style="margin-left:2rem;">
+               <h2>MS. Add. A. 188 – lifted pastedowns (fols. i, 168)</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <div class="msItem" id="MS_Add_A_188-part1-item1" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     
+                     <p class="note">Gregory IX, Decretals, with the glossa ordinaria of Bernard of Parma: fragment (first
+                        leaf) </p>
+                     
+                     <div class="nestedmsItem" id="d37e477" style="margin-top:1rem;">
+                        <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_91013639">Gregory IX</a></span>, 
+                        <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_1830">Decretals</a></span>
+                        
+                        <div class="incipit"><span class="tei-label">Incipit: </span><span class="type">(salutation) </span><span>Gregor<span class="supplied">⟨ius episcopus servus servorum⟩</span>
+                              </span></div>
+                        
+                        <div class="incipit"><span class="tei-label">Incipit: </span><span class="type">(text) </span><span>Rex pacificus pia miseratione</span></div>
+                        
+                        <div class="explicit"><span class="tei-label">Explicit: </span><span class="type">(text) </span><span> limitetur per quam genus<span class="defective">||</span></span></div>
+                        </div>
+                     
+                     <div class="nestedmsItem" id="d37e498" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                        <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_88059068">Bernard of Parma</a></span>, 
+                        <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_1061">Glossa ordinaria on Decretales Gregorii</a></span>
+                        
+                        <div class="incipit"><span class="tei-label">Incipit: </span><span><span class="defective">||</span>que materia que utilitas cui parti philosophie supponatur </span></div>
+                        </div>
+                     
+                     <p class="note">The first few lines cropped at the top of the leaf, and further lines cropped at the
+                        lower edge.</p>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     <div class="extent"><span class="tei-label">Extent: </span>most of one folio 
+                        <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                           <span class="height">238</span> × <span class="width">157</span> mm.
+                           
+                           </div>
+                     </div>
+                     
+                     
+                     <div class="layoutDesc">
+                        <h4>Layout</h4>
+                        
+                        <p>Main text in two narrow columns, surrounded by the gloss on all sides; the number
+                           of lines not readily apparent due to cropping at top, bottom, and across the middle.
+                           </p>
+                        </div>
+                     </div>
+                  
+                  <div class="handDesc">
+                     <h4>Hand(s)</h4>
+                     
+                     <p class="handNote">Southern Gothic textualis (Bononiensis)</p>
+                     </div>
+                  
+                  <div class="decoDesc">
+                     <h4>Decoration</h4>
+                     
+                     <p class="summary">Closely related to Vienna, ÖNB, Cod. 2063 and a large group of other MSS. (<a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> ii, no. 122)</p>
+                     
+                     <p class="decoNote">(miniature, fol. i verso) An enthroned pope (Gregory IX?), with a prostrate bishop
+                        touching his feet; another bishop, two tonsured clerics, and two others, stand behind.
+                        To the right, a teacher seated with a book on his desk; in front of him students seated
+                        on benches at desks with open books, two tonsured. Below is a wide shallow panel with
+                        two bishops and a lawyer, flanked by two tonsured scribes writing at desks.</p>
+                     
+                     
+                     <p class="decoNote">
+                        <span class="locus">(fol. 168r)</span> (fol. 168r) Historiated initial ‘R<span class="ex">(ex pacificus)</span>’ with a half-figure of a young man with his hand to his face.</p>
+                     
+                     <p class="decoNote">(fol. 168r, borders): The Creation of light &amp; dark, heaven &amp; earth, etc.?: Christ
+                        holds a gold platter-like disk with concentric circles and areas of highlight and
+                        shade, flanked by two prophets, in a landscape; below is the Creation of Animals(?):
+                        Christ holding and blessing(?) two birds held on his hand.</p>
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">14th century, second quarter</span>
+                     ; <span class="origPlace">
+                        <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italian</a></span>, <span class="settlement"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7004847">Bologna</a></span>
+                        </span>
+                     </div>
+               </div>
+            </div>
+            <h2><?ni?>Additional Information<?ni?></h2>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Description by Peter Kidd (June 2021). For previous descriptions see Bibliography,
+                     below. </div>
+                  
+                  </div>
+               
+               <div class="surrogates">
+                  <h3 class="msDesc-heading3">Digital Images</h3>
+                  <p><span class="bibl">
+                        <a href="https://digital.bodleian.ox.ac.uk/objects/bc8a24da-0731-4f97-bf4d-c8be209b11dd/" target="_blank">
+                           <span class="title italic">Digital Bodleian</span></a>
+                        <span class="note">(full digital facsimile)</span>
+                        </span><br /><span class="bibl">
+                        <a href="https://digital.bodleian.ox.ac.uk/objects/2c34aeef-72ae-4a29-9f29-13d438c623f7/" target="_blank">
+                           <span class="title italic">Digital Bodleian</span></a>
+                        <span class="note">(1 image from 35mm slides)</span>
+                        </span><br /></p>
+               </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Online resources:</h4>
+                        
+                        <div class="bibl"><a href="https://hab.bodleian.ox.ac.uk/en/" target="_blank"><span class="title italic">Manuscripts from German-Speaking Lands – A Polonsky Foundation Digitization Project</span></a></div>
+                        </span>
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Bodleian Library catalogues:</h4>
+                        
+                        <div class="bibl"><a href="https://hdl.handle.net/2027/uc1.32106006446402?urlappend=%3Bseq=31" target="_blank">Otto Pächt and J. J. G. Alexander, <span class="title italic"><a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Illuminated Manuscripts in the Bodleian Library, Oxford</a></span>, II (1970), no. 122 <span class="note">(open access at HathiTrust Digital Library)</span></a></div>
+                        
+                        <div class="bibl"><a href="https://hdl.handle.net/2027/uc1.32106006446410?urlappend=%3Bseq=27" target="_blank">Otto Pächt and J. J. G. Alexander, <span class="title italic"><a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Illuminated Manuscripts in the Bodleian Library, Oxford</a></span>, I (1966), no. 55 <span class="note">(open access at HathiTrust Digital Library)</span></a></div>
+                        
+                        <div class="bibl">S. J. P. Van Dijk, <span class="title italic">Handlist of the Latin Liturgical Manuscripts in the Bodleian Library Oxford : Vol.
+                              1: Mass Books</span> (typescript, 1957)</div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0607.gif"><a href="https://hdl.handle.net/2027/mdp.39015010314634?urlappend=%3Bseq=614" target="_blank"><span class="title italic">A summary catalogue of Western manuscripts in the Bodleian Library at Oxford</span> V (1905) 572 <span class="note">(open access at HathiTrust Digital Library)</span>
+                                 </a></a></div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2021-07-19: Corrected transcription and identification of 'Lůneche' in ex libris, fol. 167v.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 189</h1>
+      <div class="content tei-body" id="manuscript_35">
+         <div class="msDesc" id="MS_Add_A_189-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29158</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_A_189-item1">
+                  <div class="locus"></div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_11663">Dogale</a></span>
+                  
+                  <p class="note">Commissio of <span class="persName"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_50287209">Doge Alvise Mocenigo (1570–7)</a></span> appointing the 'potestas' of <span class="placeName"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7003297">Treviso</a></span></p>
+                  
+                  <div class="colophon"><span class="tei-label">Colophon: </span><span>Datt' Jn nostro Ducali Palatio Die x Maii Indic' prima. MClxxiij.</span></div>
+                  
+                  <p class="note">Fols. 157–64v were written in different hands, fols. 165–167v are blank. The text
+                     is defective at the beginning.</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin and Italian</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="seg"><span class="measure">166</span> + <span class="measure">iii</span></span> fols. 
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">220</span> × <span class="width">160</span> mm.
+                        
+                        </div>
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (written): </span>
+                        <span class="height">165</span> × <span class="width">115</span> mm.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p>1 col., 24 lines.</p>
+                     </div>
+                  </div>
+               
+               <div class="handDesc">
+                  <h4>Hand(s)</h4>
+                  
+                  <p class="summary">Written by the same scribe as MS. Selden Supra 68, <span class="persName scr"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_2784">Aloysius Zambeccari</a></span>, 'secretarius', fol. 156v. Additions by <span class="persName scr"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_34">Agostino Spinelli</a></span> and <span class="persName scr"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_1231">Vincenzo Carbabeno</a></span>, fols. 157r-v.</p>
+                  
+                  <p class="handNote">Humanistica cursiva.</p>
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">Fine miniatures on a separate bifolium, fols. ii, iii. By the same hand as MS. Selden
+                     Supra 68, related to the style of <span class="persName art"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_96635613">Giorgio Colonna</a></span>. (<a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> ii. 1018, pl. LXXXIV)</p>
+                  
+                  <p class="decoNote">(fol. ii verso) miniature: St. Mark, with lion, presenting a volume to the Doge (a
+                     bearded man in red velvet edged with fur); Christ in a cloud above, with loincloth
+                     and banner, in rays of light.</p>
+                  
+                  <p class="decoNote">(fol. iii recto) miniature: Venice as a finely dressed woman with sceptre, seated
+                     on a lion's back; two seated female figures: Justice with sword and scales, and another
+                     allegorical figure with a torch and putto.</p>
+                  </div>
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">Gold-tooled leather, late 16th cent., rebacked.</p>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">1573</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italian</a></span>
+                     <span class="settlement"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7018159">Venice</a></span>
+                     
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">Arms, fol. ii verso, of the <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_2783">Bragadin</a></span> family of Venice.</p>
+                  <p class="acquisition">Bought from Thomas Boone of London, 1879, for £6.</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Adapted (2017) from A. G. Watson, <span class="title italic">Catalogue of Dated and Datable Manuscripts</span>, Pächt and Alexander, and the Summary Catalogue (1905); additional description of
+                     decoration by Elizabeth Solopova, c. 2000. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0608.gif">Summary Catalogue, Vol. 5, p. 573</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <div class="surrogates">
+                  <h3 class="msDesc-heading3">Digital Images</h3>
+                  <p><span class="bibl"><a href="https://digital.bodleian.ox.ac.uk/objects/a640cdb1-113b-403a-8589-4911106e8928/" target="_blank"><span class="title italic">Digital Bodleian</span></a>
+                        <span class="note">(2 images from 35mm slides)</span></span><br /></p>
+               </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">                         
+                        <div class="bibl">A. G. Watson, <span class="title italic"><a href="https://catalog.hathitrust.org/Record/000310664" target="_blank">Catalogue of Dated and Datable Manuscripts c.435–1600 in Oxford Libraries</a></span> (Oxford, 1984), no. 11</div>
+                        
+                        <div class="bibl">Otto Pächt and J. J. G. Alexander, <span class="title italic"><a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Illuminated Manuscripts in the Bodleian Library, Oxford</a></span>, II (1970), no. 1018</div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 196</h1>
+      <div class="content tei-body" id="manuscript_36">
+         <div class="msDesc" id="MS_Add_A_196-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29134</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_196-item1">
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_2353">'Hulderichus Hispanius, episcopus de Toledo'</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_185">Practica</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Hulderichus Hispanius, episcopus de Toledo. Ista est Practica sua, &amp; floruit Anº Domini
+                        1420</span></div>
+                  
+                  <div class="colophon"><span class="tei-label">Colophon: </span><span>Rescriptus fuerat per me anº 1590. TM</span></div>
+                  
+                  <p class="note">This is a medical handbook, chiefly precepts and recipes, in Latin as far as fol.
+                     36, and from that point (on the subject of ores) in English</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>English and Latin</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  </div>
+               
+               <div class="handDesc">
+                  <h4>Hand(s)</h4>
+                  
+                  <p class="handNote">Written by <span class="persName scr"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_9">'T.M.'</a></span> in 1590 (<a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> iii. 1205)</p>
+                  </div>
+               
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="summary"><a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> iii. 1205
+                     </p>
+                  
+                  <p class="decoNote">Borders</p>
+                  
+                  <p class="decoNote">Initials</p>
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">1590</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7002445">England</a></span>
+                     </span>
+                  </div>
+            </div>
+            <div class="msPart" id="Add_A_196" style="margin-left:2rem;">
+               <h2>MS. Add. A. 196, flyleaves</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  
+                  <div class="msItem" id="d39e222" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     
+                     <div class="locus">(flyleaves and cover)</div>
+                     <span class="tei-title">Theological</span>
+                     
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                     </div>
+                  
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>Parchment</div>
+                     
+                     
+                     </div>
+                  
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">13th century</span>
+                     ; <span class="origPlace"><span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7002445">England</a></span></span>
+                     
+                     </div>
+                  <div class="provenance">
+                     <h4>Provenance and Acquisition</h4>
+                     <p class="provenance">Owned by <span class="persName fmo">J. Leonard</span> (18th century?)</p>
+                     <p class="acquisition">'bought with some Collections for History of Lichfield (Harwood) of <span class="persName fmo">Mrs. H. Smith</span> of Swindon, Dudley [in Staffordshire], March 78'</p>
+                  </div>
+               </div>
+            </div>
+            <h2><?ni?>Additional Information<?ni?></h2>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (July 2025) by Stewart J. Brookes from the Summary Catalogue (1905).
+                     Decoration, localization and date follow Pächt and Alexander (1973)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0601.gif">Summary Catalogue, Vol. 5, p. 566</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-07-21: Description revised to incorporate all the information in the Summary Catalogue (1905)</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 197</h1>
+      <div class="content tei-body" id="manuscript_37">
+         <div class="msDesc" id="MS_Add_A_197-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29175</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</p>
+               
+               <div class="msItem" id="MS_Add_A_197-item1">
+                  
+                  <div class="locus">(fol. 1)</div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_11031">Liber usuum (Cistercian consuetudinary)</a></span>
+                   <span class="note">(part 1)</span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Ecclesiastica Officia</span></div>
+                  </div>
+               
+               <div class="msItem" id="d40e138">
+                  
+                  <div class="locus">(fol. 102)</div>
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_16035">Carta caritatis</a></span>
+                   <span class="note">(part 1)</span>
+                  
+                  <p class="note">With the prologue, Antiquam abbacie cisterciensis.</p>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="seg"><span class="measure">i</span> + <span class="measure">105</span></span> fols. 
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">240</span> × <span class="width">c. 163</span> mm.
+                        
+                        </div>
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (written): </span>
+                        <span class="height">c. 170–88</span> × <span class="width">110–15</span> mm.
+                        
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">Coloured initials.</p>
+                  
+                  <p class="decoNote">Rubrics.</p>
+                  
+                  <p class="decoNote">Some flourished initials (fols. 8<sup>v</sup>, 13<sup>v</sup>, 21, 22<sup>v</sup>, 56<sup>v</sup>, 73, 79<sup>v</sup>, etc.)</p>
+                  </div>
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">Blind-stamped white whittawed leather over boards, 14th cent. (?), rebacked.</p>
+                  
+                  </div>
+               
+               <div class="accMat">
+                  <h4>Accompanying Material</h4>
+                  <p>
+                     <span class="head"></span><ul class="list">
+                        
+                        <li class="mslistitem">Fol. 1, fly-leaf from a late 12th-century Latin theological commentary.</li>
+                        
+                        <li class="mslistitem">Fol.105, from a 12th-century missal or sacramentary, contains some votive masses.</li>
+                        </ul>
+                     </p>
+               </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">1203 × 1218</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italian</a></span>
+                     
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">The feast of St Barnabas, ordered 'cum duabus missis' in 1203, appears in the hand
+                     of the original scribe. The feast of SS John and Paul, raised in 1218, was added on
+                     fol. 30. Cf. J.-M. Canivez, <span class="title italic">Statuta capitulorum generalium ordinis cisterciensis</span> I (1933) 284, 485.</p>
+                  <p class="provenance">Cistercian abbey of <span class="orgName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/org_240561051">Acquafredda</a></span>, Lenno, Como, 15th cent. (fol. 1)</p>
+                  <p class="acquisition">Bought at the <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_238406190">William Bragge</a></span> sale (Sotheby's, 10 Nov. 1880), lot. 1359, for £3 10s.</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Adapted (2017) from A. G. Watson, <span class="title italic">Catalogue of Dated and Datable Manuscripts</span>; S. J. P. Van Dijk, <span class="title italic">Handlist of the Latin Liturgical Manuscripts in the Bodleian Library Oxford : Vol.
+                        3: Rituals and Directories</span> (typescript, 1957); and the Summary Catalogue (1905). 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0611.gif">Summary Catalogue, Vol. 5, p. 576</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Printed descriptions:</h4>
+                        
+                        <div class="bibl">A. G. Watson, <span class="title italic">
+                              <a href="https://catalog.hathitrust.org/Record/000310664" target="_blank">Catalogue of Dated and Datable Manuscripts c.435–1600 in Oxford Libraries</a>
+                              </span> (Oxford, 1984), no. 12</div>
+                        
+                        <div class="bibl">S. J. P. van Dijk, <span class="title italic">Latin Liturgical Manuscripts in the Bodleian Library, Oxford, vol. 3: Rituals and
+                              Directories</span> (typescript, 1957), <span class="citedRange">p. 241</span>
+                           </div>
+                        
+                        <div class="bibl">S. J. P. van Dijk, <span class="title italic">Latin Liturgical Manuscripts in the Bodleian Library, Oxford, vol. 5: Fragments -
+                              Mass Books</span> (typescript, 1957), <span class="citedRange">p. 251</span>
+                           </div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 198</h1>
+      <div class="content tei-body" id="manuscript_38">
+         <div class="msDesc" id="MS_Add_A_198-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29176</span>
+                  </p>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="physDesc-p">Composite</div>
+               </div>
+            <div class="msPart" id="MS_Add_A_198-part1" style="padding-left:2rem; margin-top:1rem; border-bottom-color:#C0C0C0; border-top:1px #C0C0C0 solid;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 198 – Part 1</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <div class="msItem" id="MS_Add_A_198-part1-item1" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_10227">Apocalypse</a></span>
+                     
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">13th century, early</span>
+                     </div>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_198-part2" style="padding-left:2rem; border-bottom-color:#C0C0C0;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 198 – Part 2</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <div class="msItem" id="MS_Add_A_198-part2-item1" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_12487">Lamentations of Jeremiah, with gloss</a></span>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">13th century, early</span>
+                     </div>
+               </div>
+            </div>
+            <h2><?ni?>Additional Information<?ni?></h2>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Summary description by Elizabeth Solopova and Matthew Holford based on the Summary
+                     Catalogue and supplementary sources. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0612.gif">Summary Catalogue, Vol. 5, p. 577</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 208</h1>
+      <div class="content tei-body" id="manuscript_41">
+         <div class="msDesc" id="MS_Add_A_208-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29224</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_208-item1">
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_11846">Florilegium from classical Latin poets</a></span>
+                  
+                  <p class="note">A set of short extracts (usually one to ten lines) from the following Latin poets:</p>
+                  
+                  
+                  <div class="nestedmsItem" id="d44e109" style="margin-top:1rem;">
+                     
+                     <div class="locus">(fols 1r-2r)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_88342447">Ovid</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Ouid<span class="ex">(is)</span>. de arte Amandi.</span></div>
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d44e124">
+                     
+                     <div class="locus">(fol. 2r)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100218964">Boethius</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Boiciu<span class="ex">(s)</span></span></div>
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d44e138">
+                     
+                     <div class="locus">(fol. 2v)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_88342447">Ovid</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Ouid<span class="ex">(is)</span>. de remed<span class="ex">(ia)</span> amoris.</span></div>
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d44e157">
+                     
+                     <div class="locus">(fol. 4r)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_88342447">Ovid</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Ouid<span class="ex">(is)</span>. herodium</span></div>
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d44e172">
+                     
+                     <div class="locus">(fol. 8r)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_88342447">Ovid</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Ouid<span class="ex">(is)</span>. de tristib<span class="ex">(us)</span>.</span></div>
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d44e190">
+                     
+                     <div class="locus">(fol. 9r)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_88342447">Ovid</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Ouid<span class="ex">(is)</span>. de ponto.</span></div>
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d44e205">
+                     
+                     <div class="locus">(fol. 12r)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100010336">Prudentius</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>De prudentio.</span></div>
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d44e217">
+                     
+                     <div class="locus">(fol. 13r)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_246763674">Claudian</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Claudianus</span></div>
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d44e229">
+                     
+                     <div class="locus">(fol. 29r)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100902938">Lucan</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Lucanus</span></div>
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d44e242">
+                     
+                     <div class="locus">(fol. 33r)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_8194433">Virgil</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Bucol<span class="ex">(ica)</span></span></div>
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d44e256">
+                     
+                     <div class="locus">(fol. 37r)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100899421">Valerius Flaccus</a></span>
+                     
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Argon<span class="ex">(autica)</span></span></div>
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d44e270">
+                     
+                     <div class="locus">(fol. 37r)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100219266">Tibullus</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Tibullius</span></div>
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d44e282">
+                     
+                     <div class="locus">(fol. 38r)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100212859">Philippus Gualtherus de Castellione</a></span>
+                     
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>De Alexandro</span></div>
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d44e294">
+                     
+                     <div class="locus">(fol. 38v)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100904338">Statius</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Stacius thebaidos</span></div>
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d44e306">
+                     
+                     <div class="locus">(fol. 40r)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100198157">Persius</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Persius</span></div>
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d44e319">
+                     
+                     <div class="locus">(fol. 41r)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100227522">Horace</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>horati<span class="ex">(us)</span> in Poet<span class="ex">(ic)</span>a</span></div>
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d44e337">
+                     
+                     <div class="locus">(fol. 47r)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_83985148">Juvenal</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>hiuenalis.</span></div>
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d44e349">
+                     
+                     <div class="locus">(fol. 53v)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_8099277">Martial</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Marcial<span class="ex">(is)</span> coc<span class="ex">(us)</span></span></div>
+                     </div>
+                  
+                  
+                  <div class="nestedmsItem" id="d44e366" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                     
+                     <div class="locus">(fol. 68v)</div>
+                     
+                     <p class="note">Grammatical notes (late 13th century)
+                        </p>
+                     </div>
+                  
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>ii + <span class="measure">70</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">9.625</span> × <span class="width">6.875</span> in.
+                        
+                        </div>
+                     
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">244</span> × <span class="width">170</span> mm.
+                        
+                        </div>
+                     
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (written): </span>
+                        <span class="height">163</span> × <span class="width">80</span> mm.
+                        
+                        </div>
+                     
+                     </div>
+                  
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">13th century, second half</span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">'<span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_107982066">Cardigan</a></span>' (Thomas Brudenell, 1st Earl of Cardigan) is at fol. 1, and 'No. 3. Cl: 2. Sh: 4'
+                     on the cover. 
+                     Cf. <a href="https://medieval.bodleian.ox.ac.uk/catalog/manuscript_6406" target="_blank">MS. Lat. class. e. 48</a></p>
+                  <p class="acquisition">Purchased at a sale at Sotheby's on 1 August 1882 for £5 5<i>s</i></p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (July 2025) by Stewart J. Brookes from the Summary Catalogue (1905)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0624.gif">Summary Catalogue, Vol. 5, p. 589</a></div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0625.gif">Summary Catalogue, Vol. 5, p. 590</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-07-25: Description revised to incorporate all the information in the Summary Catalogue (1905)
+               and other printed sources</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 228</h1>
+      <div class="content tei-body" id="manuscript_43">
+         <div class="msDesc" id="MS_Add_A_228-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">30198</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_228-item1">
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_14739">Statutes of England (vetera statuta)</a></span>
+                  
+                  <p class="note">
+                     <p>Magna Carta; Marlborough; Westm. I; Gloucester; Westm. 2; Winchester; Exeter; and
+                        Statuta de Scaccario (imperfect at the end)</p>
+                  </p>
+                  
+                  <p class="note">With one leaf of the Capitula in Itinere vetera</p>
+                  
+                  <p class="note">
+                     <p>The latest known date of these is 1285, but the original volume no doubt contained
+                        more statutes</p>
+                  </p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin and Anglo-Norman</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>i + <span class="measure">40</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">9</span> × <span class="width">6.5</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  <div>
+                     <h4>Condition</h4>
+                     <div class="condition">Imperfect</div>
+                  </div>
+                  
+                  
+                  
+                  </div>
+               
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="summary"><a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> iii. 514
+                     </p>
+                  
+                  
+                  <p class="decoNote">Fleuronnée initials</p>
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate"><i>c</i>. 1300</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7002445">England</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="acquisition">Referenced and bound in 1883</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (July 2025) by Stewart J. Brookes from the Summary Catalogue (1905).
+                     Decoration, localization and date follow Pächt and Alexander (1970)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0793.gif">Summary Catalogue, Vol. 5, p. 756</a></div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0794.gif">Summary Catalogue, Vol. 5, p. 757</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-07-21: Description revised to incorporate all the information in the Summary Catalogue (1905)</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 268</h1>
+      <div class="content tei-body" id="manuscript_48">
+         <div class="msDesc" id="MS_Add_A_268-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29387</span>
+                  </p>
+               </div>
+            <h4 class="msHead">Religious pieces in Middle English and Latin</h4>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="physDesc-p">made up of at least three MSS. written early in the 15th
+                  cent.</div>
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment, paper</div>
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="seg"><span class="measure">ii</span> + <span class="measure">164</span></span> leaves 
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">8.75</span> × <span class="width">6.625</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century,
+                     early</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7002445">English</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">The name 'Bradshawe' occurs twice in red in the margin of fols. 63, 65, and may be
+                     the name of the scribe or rubricator.</p>
+                  <p class="provenance">'Constat domino <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_3519">Gylbarto Barton</a></span> viginti dinariorum vel viginti dinarijs a <span class="sic">bibliapolis[<i>sic</i>]</span> cuj erit nomen Thomas' (late 15th cent.: fol. 36v)</p>
+                  <p class="provenance"> '<span class="persName sgn"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_3520">Rich. Wills</a></span>' (16th cent.) is on the old cover (fol. 161).</p>
+                  <p class="provenance"><span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_68971787">Thomas Percy, 1729-1811, Bishop of Dromore, collector of ballads</a></span>; his sale, Sotheby's, 29 April 1884 (lot 83) </p>
+                  <p class="acquisition">Bought for £6.</p>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_268-partA" style="padding-left:2rem; margin-top:1rem; border-bottom-color:#C0C0C0; border-top:1px #C0C0C0 solid;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 268 - part A</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</p>
+                  
+                  <div class="msItem" id="MS_Add_A_268-partA-item1">
+                     
+                     <div class="locus">(fols. 1r-10r)</div>
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_16294">Ars moriendi 'Quamvis secundum philosophum'</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Ars moriendi</span></div>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Quamvis secundum philosophum</span></div>
+                     
+                     <div class="explicit"><span class="tei-label">Explicit: </span><span>miserabiliter periclitantur</span></div>
+                     
+                     <div class="finalRubric"><span class="tei-label">Final rubric: </span><span>Explicit Ars moriendi</span></div>
+                     
+                     <p class="note">The order of tempations is faith, despair, avarice, impatience, vainglory. Fol. 10v
+                        is blank.</p>
+                     <span class="listBibl">
+                        
+                        <div class="bibl">pr. [Cologne, c. 1475] (<a href="https://data.cerl.org/istc/ia01114200" target="_blank">ISTC ia01114200</a>) etc.</div>
+                        </span>
+                     </div>
+                  
+                  <div class="msItem" id="MS_Add_A_268-partA-item2">
+                     
+                     <div class="locus">(fols. 11r-30r)</div>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>De gaudiis celi</span></div>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Notandum circa gaudia tria sunt dicenda scilicet Valor impreciabilis</span></div>
+                     
+                     <div class="explicit"><span class="tei-label">Explicit: </span><span>Ad quam gloriam nos perducat et participes efficiat ductor illis coree Iesus Christus
+                           virginis filius cui cum patre <span class="editorialgap"> […] </span></span></div>
+                     
+                     <div class="finalRubric"><span class="tei-label">Final rubric: </span><span>Explicit</span></div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_166912444">Guilelmus de Lancea</a></span>, 
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_5036">Dieta salutis</a></span>
+                     
+                     <p class="note">Extract: ed. Peltier, <span class="title italic">S. Bonaventurae Opera Omnia</span> (Paris, 1864–71), VIII, pp. ???–??? </p>
+                     </div>
+                  
+                  <div class="msItem" id="MS_Add_A_268-partA-item3">
+                     
+                     <div class="locus">(fols. 30r-36r)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_306415749">Ps.-Bernard</a></span>, 
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_3944">Speculum peccatoris</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Incipit speculum peccatoris secundum Augustinum et secundum
+                           Bernardum</span></div>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Quoniam karissime in huius via vite</span></div>
+                     
+                     <div class="explicit"><span class="tei-label">Explicit: </span><span>tendit et aspirat ad quod nost perducat <span class="editorialgap"> […] </span></span></div>
+                     
+                     <div class="finalRubric"><span class="tei-label">Final rubric: </span><span>Explicit speculum peccatoris</span></div>
+                     
+                     <p class="note">On fol. 36v are contemporary additions, (1) on prayer (2) notes on the nature, position
+                        and size of the moon.</p>
+                     </div>
+                  
+                  <div class="msItem" id="MS_Add_A_268-partA-item4">
+                     
+                     <div class="locus">(fols. 37r-83r)</div>
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_14676">Speculum Christiani</a></span>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin with Middle English</div>
+                     
+                     <p class="note">The latter part of the Latin and English treatise, here imperfect,
+                        beginning in the 'Quarta Tabula' with the words '-tibus superbit non
+                        gladio': ends 'consilia tua in ipso permaneant. Amen. Explicit Speculum
+                        Christiani.' The Latin is interspersed with pieces of English verse and
+                        prose. Some theological notes follow.</p>
+                     
+                     <div class="nestedmsItem" id="d51e337" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                        <div class="rubric"><span class="tei-label">Rubric: </span><span><span class="locus">(fol. 40v)</span> Quinta tabula</span></div>
+                        
+                        <div class="incipit"><span class="tei-label">Incipit: </span><span>My dere frendes I you pray iiij þinges bers in your hert away. One ys what þinge files
+                              a man, anoþer ys what makes a man clene, þe thrid ys what þing kepes hym in clennesse,
+                              þe faurt ys what þing drawes hym to ordeyn his wille to goddes wille.</span></div>
+                        
+                        <div class="explicit"><span class="tei-label">Explicit: </span><span><span class="locus">(fol. 46r)</span> Ne in hell miȝt no man lif for mech sorowe &amp; woo, were not þe riȝtfulnesse &amp; þe miȝt
+                              of god, þat will þat his enemyse þat hatid hym &amp; hisse lawe &amp; wold not kepe his biddynges
+                              in erth ne flee his forbiddynges <span class="pb"></span> haue miȝt &amp; strengthe to last in such horrible payn &amp; woo withouten ende.</span></div>
+                     </div>
+                     
+                     <div class="explicit"><span class="tei-label">Explicit: </span><span>Omnia consilia tua in ipso permaneant. Amen.</span></div>
+                     
+                     <div class="finalRubric"><span class="tei-label">Final rubric: </span><span>Explicit Speculum Christiani</span></div>
+                     </div>
+                  
+                  <div class="msItem" id="MS_Add_A_268-partA-item4a">
+                     
+                     <div class="locus">(fols. 83v-84v)</div>
+                     <span class="tei-title">Theological notes</span>
+                     
+                     </div>
+                  
+                  </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_268-partB" style="padding-left:2rem; border-bottom-color:#C0C0C0;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 268 - part B</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</p>
+                  
+                  <div class="msItem" id="MS_Add_A_268-partB-item1">
+                     
+                     <div class="locus">(fol. 85)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_285275142">Thomas of Hales</a></span>, 
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_6146">Vita Sanctae Mariae</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Genealogia beate Virginis &amp; Infancia Christi
+                           auctenti<span class="supplied">⟨c⟩</span>a a diuersis ortodoxis excerpta</span></div>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Sancta &amp; semper laudabilis</span></div>
+                     
+                     <p class="note">Thomas de Hales, <span class="title italic">The Lyf of Oure Lady: the Middle English Translation of
+                           Thomas of Hales' Vita Sancte Marie</span>, ed, Sarah Horrall, Middle English
+                        Text Series, vol. 17 (Heidelberg: Carl Winter Universitatsverlag, 1985), pp. 12-14</p>
+                     </div>
+                  
+                  <div class="msItem" id="d51e419">
+                     
+                     <div class="locus">(fol. 108v)</div>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span><span class="editorialgap"> […] </span> Incipit Meditacio breuis &amp; ualida
+                           ad excitandum hominem ad timorem Dei <span class="editorialgap"> […] </span></span></div>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Hec est prima racio cum suis causis. Digitus primus. Meditare quod
+                           mortaliter peccaueris</span></div>
+                     </div>
+                  
+                  <div class="msItem" id="d51e433">
+                     
+                     <div class="locus">(fol. 111)</div>
+                     <span class="tei-title">Short theological chapters</span>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     <div class="layoutDesc">
+                        <h4>Layout</h4>
+                        
+                        <p>2 cols.</p>
+                        </div>
+                     </div>
+                  </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_268-partC" style="padding-left:2rem; border-bottom-color:#C0C0C0;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 268 - part C</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English</p>
+                  
+                  <div class="msItem" id="MS_Add_A_268-partC-item1">
+                     
+                     <div class="locus">(fol. 117)</div>
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_16493">'Speculum huius vite'</a></span>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Before that any creature was wrozt</span></div>
+                     <span class="bibl"><a href="https://www.dimev.net/record.php?recID=788" target="_blank">DIMEV 788</a>, 'an abridged and altered text of the Pricke of Conscience'</span>
+                     <span class="bibl">ed. Guy Alan Trudel, DPhil thesis, Oxford, 1999.</span>
+                     </div>
+                  
+                  <div class="msItem" id="d51e493">
+                     
+                     <div class="locus">(fol. 139)</div>
+                     <span class="tei-title italic">The virtues of the mass</span>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>That blessed barn in Bedlem borne</span></div>
+                     <span class="bibl"><a href="https://www.dimev.net/record.php?recID=5128" target="_blank">DIMEV 5128</a></span>
+                     </div>
+                  
+                  <div class="msItem" id="d51e509">
+                     
+                     <div class="locus">(fol. 146)</div>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>All myzty God that all has wrozt</span></div>
+                     
+                     <div class="finalRubric"><span class="tei-label">Final rubric: </span><span>Explicit Historia de Passione Domini etc.</span></div>
+                     
+                     <p class="note">The last leaf hardly legible</p>
+                     <span class="bibl"><a href="https://www.dimev.net/record.php?recID=436" target="_blank">DIMEV 436</a></span>
+                     </div>
+                  
+                  <div class="msItem" id="d51e528">
+                     
+                     <div class="locus">(fols. 152v, 153v)</div>
+                     <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_13203">Medical recipes</a></span>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     <div class="layoutDesc">
+                        <h4>Layout</h4>
+                        
+                        <p>2 cols.</p>
+                        </div>
+                     </div>
+                  </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_268-partD" style="padding-left:2rem; border-bottom-color:#C0C0C0;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 268 - binding fragments (fols. 154-160)</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Old French</p>
+                  
+                  <div class="msItem" id="MS_Add_A_268-partD-item1" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_12495">La Queste del Saint Graal</a></span>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">13th century</span>
+                     </div>
+               </div>
+            </div>
+            <h2><?ni?>Additional Information<?ni?></h2>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Description adapted (May 2022) from the Summary Catalogue (1905) with reference to
+                     other published literature as cited.
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0645.gif">Summary Catalogue, Vol. 5, p.
+                              610</a></div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0646.gif">Summary Catalogue, Vol. 5, p.
+                              611</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Online resources:</h4>
+                        
+                        <div class="bibl"><a href="https://www.dimev.net/Records.php?MSS=BodAddA268" target="_blank">Digital Index of Middle English Verse</a></div></span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2022-05-20: Description revised to incorporate all information in Summary Catalogue.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 279</h1>
+      <div class="content tei-body" id="manuscript_50">
+         <div class="msDesc" id="MS_Add_A_279-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29396</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</p>
+               
+               <div class="msItem" id="MS_Add_A_279-item1">
+                  
+                  <div class="locus"><span class="item-number">1. </span>(fol. 1)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_78769600">Cicero</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_1266">Pro Archia</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>... Pro Aulo Licinio Archia</span></div>
+                  
+                  <p class="note">With argument</p>
+                  </div>
+               
+               
+               <div class="msItem" id="MS_Add_A_279-item2">
+                  
+                  <div class="locus"><span class="item-number">2. </span>(fol. 9)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_78769600">Cicero</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_1269">Pro Marcello</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>... Pro M. Marcello</span></div>
+                  
+                  <p class="note">With argument</p>
+                  </div>
+               
+               
+               <div class="msItem" id="MS_Add_A_279-item3">
+                  
+                  <div class="locus"><span class="item-number">3. </span>(fol. 15v)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_78769600">Cicero</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_1268">Pro Ligario</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>... Pro Q. Ligario</span></div>
+                  </div>
+               
+               
+               <div class="msItem" id="MS_Add_A_279-item4">
+                  
+                  <div class="locus"><span class="item-number">4. </span>(fol. 23)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_78769600">Cicero</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_1267">Pro Deiotaro</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>... Pro rege Deiotaro</span></div>
+                  </div>
+               
+               
+               <div class="msItem" id="MS_Add_A_279-item5">
+                  <div class="item-number">5. </div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_5494">A short ecclesiastical chronology of events from the Creation to 1312</a></span>
+                  </div>
+               
+               
+               <div class="msItem" id="MS_Add_A_279-item6">
+                  <div class="item-number">6. </div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_51580481">Volcatius Sedigitus</a></span>, 
+                  <span class="tei-title italic">Epigram</span>
+                  </div>
+               
+               
+               <div class="msItem" id="d53e186">
+                  
+                  <div class="locus">(fol. 33)</div>
+                  
+                  <p class="note">A collation of the first nine leaves of this manuscript with Heumann's edition (1733)</p>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>ii + <span class="measure">37</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">8.75</span> × <span class="width">6.125</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7002445">England</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="acquisition">Bought from <span class="orgName bsl"><a href="https://medieval.bodleian.ox.ac.uk/catalog/org_141693251">Caspar Haugg</a></span> of Augsburg (Catalogue 69, no. 480) on 20 October 1884 for 6<i>s</i></p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (May 2025) by Stewart J. Brookes from the Summary Catalogue (1905)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0648.gif">Summary Catalogue, Vol. 5, p. 613</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-05-29: Description revised to incorporate all the information in the Summary Catalogue (1905)</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 280</h1>
+      <div class="content tei-body" id="manuscript_51">
+         <div class="msDesc" id="MS_Add_A_280-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29397</span>
+                  </p>
+               </div>
+            <h4 class="msHead">Speculum amatorum mundi; Germany (Erfurt), 1459</h4>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_A_280-item1">
+                  
+                  <div class="locus">(fols. 1r–7v)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_84043189">Dionysius Carthusianus (?)</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_1399">Speculum amatorum mundi</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Speculum amatorum mundi </span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span><i>Videte quomodo caute ambuletis <span class="editorialgap"> […] </span> voluntas dei</i> <span class="note">[Ephesians 5:15–17]</span> Appostolus Paulus conscius consiliorum dei sciens quod infinite sunt delicie celestis
+                        patrie</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>cum sanctis et electis eorum meritis et precibus possideat. Quod nobis prestare dignetur
+                        qui cum patre … secula seculorum. Amen</span></div>
+                  
+                  <div class="colophon"><span class="tei-label">Colophon: </span><span>Explicit est finis Anno domini a nativitate M cccc lviiij sabato post Pasce Erff<span class="ex">(ordie)</span></span></div>
+                  <span class="bibl">On authorship see Kent Emery jr., 'Lovers of the world and lovers of God and neighbor:
+                     spiritual commonplaces and the problem of authorship in the fifteenth century', in
+                     <span class="title italic">Amo te, sacer ordo Carthusiensis</span>, ed. F. Timmermans et al. (2012), 237-280</span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>Paper. Watermark dreiburg with six(?)-petalled flower on a rod of two lines.</div>
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="seg"><span class="measure">ii (19th/20th century paper)</span> + <span class="measure">7</span> + <span class="measure">xxiv (18th(?)-century paper with 'Pro patria' watermark)</span> + <span class="measure">ii (19th/20th century paper)</span></span> leaves. Fols. i-ii, 8-end are blank paper. 
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">215</span> × <span class="width">155</span> mm.
+                        
+                        </div>
+                     </div>
+                  
+                  <div class="foliation"><span class="tei-label">Foliation: </span>19th-century pagination in pencil on rectos: 1–13; incomplete Bodleian foliation in
+                     pencil: i–ii, 1–10, 15, 20, 24, 25, 30, 33</div>
+                  
+                  <div class="collation">
+                     <h4>Collation</h4>
+                     <div class="collation">Apparently 8-1 (last blank cancelled?)</div>
+                  </div>
+                  
+                  
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p>Frame-ruled in plumment; written with 36–8 long lines per page. Ruled space c. 
+                        <span class="height">145</span> × <span class="width">95</span> mm.
+                        
+                        </p>
+                     </div>
+                  </div>
+               
+               <div class="handDesc">
+                  <h4>Hand(s)</h4>
+                  
+                  <p class="handNote">Cursive, with many loopless forms, by one hand.</p>
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">One 7-line initial in plain red.</p>
+                  </div>
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">Late 19th or early 20th century Bodleian binding of blue cloth over pasteboards; the
+                     spine with the shelfmark and ‘Speculum amatorum mundi – 1459.’ in gilt capitals.</p>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">1459</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7000084">German</a></span>, <span class="settlement"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7024031">Erfurt</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">Perhaps from the Carthusian monastery of St Salvator, but not apparently identifiable
+                     in their medieval library catalogue.</p>
+                  <p class="provenance">Not identifiable in the sale catalogue of Friedrich Gottlieb Julius von Bülow (1760–1831)
+                     (<span class="title italic">Bibliotheca Büloviana … Dritter Theil (Handschriften) …</span>, 10 October 1836 and following days), unless bound with another text as lot 548,
+                     'Speculum amatorum mundi. - Tract. de obedientia, humilitate etc.'.</p>
+                  <p class="acquisition">Caspar Haugg (fl. 1875–1893), bookseller of Augsburg, Catalogue 69, no. 477; bought
+                     for 4 marks by the Bodleian Library; inscribed in pencil ‘Haugg Augsburg 1884’ (fol.
+                     1r).</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Description (May 2021) by Peter Kidd, edited by Matthew Holford. Previously described
+                     in the Summary Catalogue (1905) 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0648.gif">Summary Catalogue, Vol. 5, p. 613</a></div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0649.gif">Summary Catalogue, Vol. 5, p. 614</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <div class="surrogates">
+                  <h3 class="msDesc-heading3">Digital Images</h3>
+                  <p><span class="bibl">
+                        <a href="https://digital.bodleian.ox.ac.uk/objects/241ddd67-d9f7-42ea-ad0d-e5818b905106/" target="_blank">
+                           <span class="title italic">Digital Bodleian</span></a>
+                        <span class="note">(full digital facsimile)</span>
+                        </span><br /></p>
+               </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Online resources:</h4>
+                        
+                        <div class="bibl"><a href="https://hab.bodleian.ox.ac.uk/en/" target="_blank"><span class="title italic">Manuscripts from German-Speaking Lands – A Polonsky Foundation Digitization Project</span></a></div>
+                        </span>
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Printed descriptions:</h4>
+                        
+                        <div class="bibl">A. G. Watson, <span class="title italic"><a href="https://catalog.hathitrust.org/Record/000310664" target="_blank">Catalogue of Dated and Datable Manuscripts c.435–1600 in Oxford Libraries</a></span> (Oxford, 1984), no. 13</div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2021-05-17: Revised description by Peter Kidd for Polonsky German digitization project.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 282</h1>
+      <div class="content tei-body" id="manuscript_52">
+         <div class="msDesc" id="MS_Add_A_282-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29399</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_A_282-item1">
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_294141850">Michael de Carchano</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_3207">Quadragesimale de fide et articulis fidei</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Incipit q<span class="ex">(ua)</span>dragesimale de fide et articulis fidei p<span class="ex">(er)</span> fr<span class="ex">(atr)</span>em Michaelem de Mediolano ordinis Mino<span class="ex">(rum)</span> de observantia compilatum</span></div>
+                  
+                  
+                  <p class="note">Sermons for Lent, with an index at fol. 331</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment, paper</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>iii + <span class="measure">333</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">9.75</span> × <span class="width">7</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  
+                  
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p>2 cols
+                        </p>
+                     </div>
+                  
+                  </div>
+               
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="summary"><a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> ii. 912
+                     </p>
+                  
+                  
+                  <p class="decoNote">Good historiated initial<span class="head">
+                        <p>fol. 1r</p></span><ul class="list">
+                        
+                        
+                        <li><b>Type</b> 
+                           <span class="seg"><a href="https://digital.bodleian.ox.ac.uk/objects/aaa742ef-c1ee-4044-9239-c5461462598a/" target="_blank">initial M</a></span>
+                           </li>
+                        
+                        
+                        <li><b>Subject</b> 
+                           <span class="seg">Profile half-figure of the author</span>
+                           </li>
+                        
+                        
+                        <li><b>Type</b> 
+                           <span class="seg">border, upper, left and lower margins</span>
+                           </li>
+                        
+                        
+                        <li><b>Subject</b> 
+                           <span class="seg">Laurel leaves, floral designs; <a href="https://digital.bodleian.ox.ac.uk/objects/aaa742ef-c1ee-4044-9239-c5461462598a/" target="_blank">medallion with skull and bones on rocks</a></span>
+                           </li>
+                        
+                        </ul>
+                     </p>
+                  
+                  <p class="decoNote"><a href="https://digital.bodleian.ox.ac.uk/objects/aaa742ef-c1ee-4044-9239-c5461462598a/" target="_blank">Good historiated border</a>, added (?)</p>
+                  </div>
+               
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">The old binding has been stripped of its leather and the boards covered with canvas</p>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century, end</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>
+                     <span class="region">North-west</span> (?)</span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="acquisition">Bought on 17 November 1884 from <span class="persName fmo">Mr William Durie</span> for £3 13<i>s</i>. 6<i>d</i>. 
+                     On fol. i is a letter from Durie (13 November 1884) in which he accepts E. W. B. Nicholson's
+                     offer of 'three and a half guineas' for the manuscript</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (July 2025) by Stewart J. Brookes from the Summary Catalogue (1905).
+                     Decoration, localization and date follow Pächt and Alexander (1970)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0649.gif">Summary Catalogue, Vol. 5, p. 614</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <div class="surrogates">
+                  <h3 class="msDesc-heading3">Digital Images</h3>
+                  <p><span class="bibl"><a href="https://digital.bodleian.ox.ac.uk/objects/aaa742ef-c1ee-4044-9239-c5461462598a/" target="_blank"><span class="title italic">Digital Bodleian</span></a>
+                        <span class="note">(1 image from 35mm slides)</span></span><br /></p>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-07-21: Description revised to incorporate all the information in the Summary Catalogue (1905)</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 283</h1>
+      <div class="content tei-body" id="manuscript_53">
+         <div class="msDesc" id="MS_Add_A_283-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29400</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_283-item1">
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_13140">Martyrology</a></span>
+                  
+                  <p class="note">Based on and abbreviated from the work of <span class="persName aut"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_264282437">Usuard</a></span></p>
+                  
+                  <p class="note">With six prefatory pieces, the last of which explains the lunar tables prefixed to
+                     each day</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  
+                  <div class="extent">
+                     <span class="seg"> i + <span class="measure">92 (91)</span> + i  leaves, with parchment flyleaves</span>
+                     
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">8.625</span> × <span class="width">6.375</span> in.
+                        
+                        </div>
+                     
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">212</span> × <span class="width">147</span> mm.
+                        
+                        </div>
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (written): </span>
+                        <span class="height">165</span> × <span class="width">105</span> mm.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  </div>
+               
+               
+               <div class="handDesc">
+                  <h4>Hand(s)</h4>
+                  
+                  <p class="handNote">Written by two different hands</p>
+                  </div>
+               
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">
+                     Brown leather on boards, almost plain, injured at the back</p>
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate"><i>c</i>. 1500</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7000084">Germany,</a></span>
+                     <span class="region">Westphalia,</span> <span class="orgName fmo">Hamm, convent</span>
+                     
+                     
+                                       
+                     
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance"><span class="orgName fmo">Westphalia, Hamm, convent</span>: fol. 92: 'Istud martirologium scribi fecit et 
+                     disposuit humilis et inutilis frater <span class="persName scr">Henricus de Bercka</span> [v.d. Berghe] ordinis 
+                     minorum de observantia immeritus gardianus pro illo tempore conventus in Hammone pro
+                     usu huius loci. Et idem, 
+                     ex caritate quam semper ad hanc domum habuit, procuravit et solicitavit consensum
+                     domine terre et totius 
+                     capituli pro conservatione huius capelle cum longa et frequenti instantia. Quapropter
+                     petit idem frater rectori 
+                     huius domus et socio suo et universis devotis sororibus presentibus et futuris in
+                     vita et in morte haberi commendatus' (<i>c</i>. 1500)</p>
+                  <p class="provenance">Fol. 1v: 'Hic libellus pertinet ad templum consecratum in honorem sancte et individue
+                     trinitatis 
+                     et beate Marie Virginis atque omnium [sanctorum] quod germanice yn <span class="orgName fmo">Heilbeck</span> [= Hilbeck] 
+                     nominatur in quo Henricus Geriseim misam quod et ferme quinque annos fecerat cantabat
+                     cum Henrico et Johanne Coloniensibus atque alter 
+                     quidam quos dominus in viam suam dirigat. amen. Anno M<sup>o</sup> V<sup>o</sup> XXIX in die Oculi mei et cetera'. 
+                     There are many names of 'cantatores huius ecclesie', etc., chiefly from Cologne. (Hilbeck
+                     is near Hamm in Westphalia)</p>
+                  <p class="provenance"><span class="persName fmo">Richard de M. Lawson</span>, London, February xxiii. MDCCCLVII</p>
+                  <p class="acquisition">Bought from <span class="persName bsl">William George</span>, bookseller of Bristol (Catalogue 117, no. 392), on 4 December, 1884 for £2 10<i>s</i></p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (July 2025) by Stewart J. Brookes from the Summary Catalogue (1905).
+                     Extent, leaf dimensions and layout from van Dijk (1957)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0649.gif">Summary Catalogue, Vol. 5, p. 614</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Printed descriptions:</h4>
+                        
+                        <div class="bibl">S. J. P. van Dijk, <span class="title italic">Latin Liturgical Manuscripts in the Bodleian Library, Oxford, vol. 2: Office Books</span> (typescript, 1957), <span class="citedRange">p. 205</span>
+                           </div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-07-22: Description revised to incorporate all the information in the Summary Catalogue (1905)
+               and other printed sources</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 286</h1>
+      <div class="content tei-body" id="manuscript_54">
+         <div class="msDesc" id="MS_Add_A_286-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29403</span>
+                  </p>
+               </div>
+            <h4 class="msHead">Vita beate virginis Marie et Salvatoris rhythmica, etc.; Germany, 14th century, second
+               half</h4>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</p>
+               
+               <div class="msItem" id="MS_Add_A_286-item1">
+                  
+                  <div class="locus">(fols. 1r–84v)</div>
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_16439">Vita beate virginis Marie et Salvatoris rhythmica</a></span>
+                   <span class="note">(lacking most of Book I)</span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span><span class="defective">||</span>Secretaque celestia uel contemplabatur. / Vel manuum laboribus hec operabatur</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span> Quod completum carmen est huius ymnodye. Amen.</span></div>
+                  
+                  <div class="finalRubric"><span class="tei-label">Final rubric: </span><span>Explicit uita dulcissime, piissime, venerande / Laudande, gloriose sponse, diligende
+                        metuende / Venerabilis, et amabilis, virginis Marie, que cum / Ihesu filio suo sit
+                        semper benedicta amen.</span></div>
+                  
+                  <p class="note">See <span class="title italic">Verfasserlexikon</span> 10.436-443 (Kurt Gärtner). Ed. by A. Vögtlin, Bibliothek des Litterarischer vereins
+                     in Stuttgart, 180 (Tübingen, 1888); cf. Max Päpke, ‘Das Marienleben des Schweizers
+                     Wernher, mit Nachträgen zu Vögtlins Ausgabe der Vita Marie rhythmica’, <span class="title italic">Palaestra</span> 81 (Berlin, 1913).</p>
+                  
+                  <p class="note">The text of the present MS. starting at line 1436 on p. 53 of the edition. At 41 lines
+                     per page, the 1435 missing lines text would have occupied exactly 35 pages, or one
+                     quire of eight and one of ten leaves if the text began on the first verso.</p>
+                  </div>
+               
+               <div class="msItem" id="d57e141">
+                  
+                  <div class="locus">(fols. 84v–85v)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_64799221">Hugo de Trimberg</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_6645">Epilogus in Vita beatae virginis Mariae rhythmica</a></span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Librum hunc illuminauit quidam dei verna / Qui et scribi procurauit editus de Werna
+                        / Villa cis Herbipolim nomen eius Hugo </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span> Et maiora scandala taliter vitemus.</span></div>
+                  
+                  <p class="note">Consisting of 61 lines of verse; ed. K. Langosch, <span class="title italic">Das 'Registrum multorum Auctorum' des Hugo von Trimberg</span>, Germanische Studien 235 (1942, repr. 1969), 259-269. See <span class="title italic">Verfasserlexikon</span> 4.268-82 (G. Schweikle), at 280-1, not listing this copy.</p>
+                  </div>
+               
+               <div class="msItem" id="d57e169">
+                  
+                  <div class="locus">(fol. 86v)</div>
+                  
+                  <p class="note">Polyphonic music, added later fourteenth century. 4 lines of text (ending incomplete),
+                     each below music in score in Hufnagel notation on two five-line staves:</p>
+                  
+                  <p class="note">Marginal note:</p>
+                  
+                  <blockquote class="quote">"Hec dies plena glorie consodales canite … Ergo lector incipe dic iube benedicere"</blockquote>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Iube domine silencium fieri in aures audiencium ut possim intellegere et nos benedicere.
+                        Primo tempore alleuiata est terra Zabulon … [Isaiah 9:1]</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>… Et nouissima aggrauata est via</span></div>
+                  
+                  <p class="note">Part of the second lection at Matins on Monday after the third Sunday in Advent.</p>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment, of generally good quality but with holes and uneven edges; the lower outer
+                     corner of fol. 49 attached with blue sewing thread</div>
+                  
+                  <div class="extent"><span class="seg"><span class="measure">i (paper)</span> + <span class="measure">ii (old paper)</span> + <span class="measure">85</span> + <span class="measure">ii (old paper)</span> + <span class="measure">i (paper)</span></span> 
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">205</span> × <span class="width">145</span> mm.
+                        
+                        </div>
+                  </div>
+                  
+                  <div class="foliation"><span class="tei-label">Foliation: </span>i–iii, 1–88 in 19th-century pencil</div>
+                  
+                  <div class="collation">
+                     <h4>Collation</h4>
+                     <div class="collation">[Quires signed ‘i’–‘ii’ missing, probably one of 8 and one of 10 leaves], iii–iiii<sup>8</sup>, v<sup>10</sup>, vi<sup>12-3</sup> (7-9 cancelled, presumably blank as no apparent loss of text), vii–xi<sup>10</sup>.</div>
+                  </div>
+                  
+                  
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p>Ruled in ink for 41 lines of text. Ruled space 
+                        <span class="height">160–5</span> × <span class="width">75–80</span> mm.
+                        
+                        </p>
+                     </div>
+                  </div>
+               
+               <div class="handDesc">
+                  <h4>Hand(s)</h4>
+                  
+                  <p class="handNote">Gothic bookhand.</p>
+                  </div>
+               
+               <div class="musicNotation"><span class="tei-label">Musical Notation: </span>
+                  
+                  <p>Hufnagel notation on two five-line staves, added on fol. 86v.</p>
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">Initials in plain red, usually three lines high, some with minimal ornament.</p>
+                  </div>
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">Three-quarter dark blue leather and black cloth over pasteboards; the spine with title
+                     in gilt capitals ‘Vita Christi | rubricated by | Hugo de Werna’.</p>
+                  
+                  <p class="binding-p">A 17th/18th(?)-century paper label, perhaps removed from the spine of the previous
+                     binding and now stuck to the front pastedown, is inscribed ‘Vita Chri | rhythmice
+                     | descripta’.</p>
+                  
+                  <p class="binding-p">Inscribed ‘The whole of the parchment and paper which composed the binding of this
+                     volume is in a blue envelope among the printed fragments [dated:] 1885’; these pieces
+                     had been mislaid by the time the SC was published.</p>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">14th century, second half</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7000084">Germany</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">The <span class="orgName"><a href="https://medieval.bodleian.ox.ac.uk/catalog/org_152326866">Carthusian monastery of Buxheim</a></span>: ‘Cartusiæ Buxiæ’ <span class="locus">(fol. 1r)</span>; inscribed in a large bold hand in ink ‘N.201.’ <span class="locus">(fol. ii verso)</span>. In 1803 the charterhouse was dissolved and its property, including the library,
+                     was given to:</p>
+                  <p class="provenance">The Counts of Ostein, and in 1810 inherited by:</p>
+                  <p class="provenance">The Counts of Waldbott-Bassenheim; with a purple ‘G.W.B.D.’ ink stamp <span class="locus">(fol. 1r)</span>, probably ‘Gräflich von Waldbott-Bassenheim’sche Domanialverwaltung’ (see Volker
+                     Honemann, ‘The Buxheim collection and its dispersal’, <span class="title italic">Renaissance Studies</span>, 9.2: <span class="title italic">Incunabula: Books, Texts and Owners</span> (June 1995), pp. 166–88).</p>
+                  <p class="provenance"><span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_89876881">Hugo graf von Waldbott-Bassenheim</a></span> (1820–1895); sold at his Buxheim sale by Carl Förster, Munich, Catalogue 30, 30 Sept.
+                     1883 and following days, lot 2798.</p>
+                  <p class="acquisition"><span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_32753361">Albert Cohn</a></span>, Berlin, Catalogue 162, no. 1372; bought by the Bodleian for 60 marks on 27 Dec.
+                     1884; inscribed in pencil ‘Cohn | 1884’ <span class="locus">(fol. iiir)</span>.</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Description by Peter Kidd (April 2021). Previously described in the Summary Catalogue.
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0650.gif">Summary Catalogue, Vol. 5, p. 615</a></div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0651.gif">Summary Catalogue, Vol. 5, p. 616</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <div class="surrogates">
+                  <h3 class="msDesc-heading3">Digital Images</h3>
+                  <p><span class="bibl">
+                        <a href="https://digital.bodleian.ox.ac.uk/objects/ca575b02-f27e-44b3-b1cf-7230621dbc99/" target="_blank">
+                           <span class="title italic">Digital Bodleian</span></a>
+                        <span class="note">(full digital facsimile)</span>
+                        </span><br /></p>
+               </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Online resources:</h4>
+                        
+                        <div class="bibl"><a href="https://hab.bodleian.ox.ac.uk/en/" target="_blank"><span class="title italic">Manuscripts from German-Speaking Lands – A Polonsky Foundation Digitization Project</span></a></div>
+                        
+                        <div class="bibl"><a href="https://www.diamm.ac.uk/sources/483/" target="_blank"><span class="title italic">DIAMM: Digital Image Archive of Medieval Music</span></a></div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2021-04-21: <span class="persName">Andrew Dunning</span> New description by Peter Kidd.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 288</h1>
+      <div class="content tei-body" id="manuscript_55">
+         <div class="msDesc" id="MS_Add_A_288-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29494</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_A_288-item1">
+                  <div class="locus"></div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_14573">Sermons</a></span>
+                  
+                  <p class="note">Thirty sermons by various authors on St Mary the Virgin.</p>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span><span class="note">(first sermon)</span> Hier begint een seer schoon Cappittel vander grooter goedertierentjz enn werdichz
+                        van Maria. Sinte Ambrosius seet, alzo ghenadig was Maria</span></div>
+                  
+                  <div class="colophon"><span class="tei-label">Colophon: </span><span>Desen boeck heeft ghescreuen Suster <span class="persName scr"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_2797">lysbeth lenaerts</a></span> ... ende is voleynt Jnt Jaer ons heeren Anno xv<sup>c</sup> lxxviij Den xv<sup>en</sup> dach Junij ...</span></div>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Dutch</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="measure">144</span> fols. 
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">215</span> × <span class="width">160</span> mm.
+                        
+                        </div>
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (written): </span>
+                        <span class="height">160–5</span> × <span class="width">115–20</span> mm.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p>1 col., c. 26–31 lines.</p>
+                     </div>
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">Coloured initials and headings.</p>
+                  </div>
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">Blind-stamped leather over boards, late 16th century.</p>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origPlace"><span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7016845">Netherlands</a></span></span>; 
+                  <span class="origDate">1578</span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="acquisition">Bought from H. Grevel on Feb. 19 1885 for £1 1s.</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Adapted (2017) from A. G. Watson, <span class="title italic">Catalogue of Dated and Datable Manuscripts</span>, and the Summary Catalogue (1905). 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0671.gif">Summary Catalogue, Vol. 5, p. 636</a></div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0672.gif">Summary Catalogue, Vol. 5, p. 637</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">                         
+                        <div class="bibl">A. G. Watson, <span class="title italic"><a href="https://catalog.hathitrust.org/Record/000310664" target="_blank">Catalogue of Dated and Datable Manuscripts c.435–1600 in Oxford Libraries</a></span> (Oxford, 1984), no. 14</div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 365</h1>
+      <div class="content tei-body" id="manuscript_58">
+         <div class="msDesc" id="MS_Add_A_365-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29616</span>
+                  </p>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="physDesc-p">Composite: two parts</div>
+               </div>
+            <div class="msPart" id="MS_Add_A_365-part1" style="padding-left:2rem; margin-top:1rem; border-bottom-color:#C0C0C0; border-top:1px #C0C0C0 solid;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 365 – Part 1</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <div class="msItem" id="MS_Add_A_365-part1-item1">
+                     <div class="item-number">1. </div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_98031958">Walter Map</a></span>, 
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_4964">Epistola Valerii ad Rufinum ne ducat uxorem</a></span>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                     </div>
+                  
+                  <div class="msItem" id="MS_Add_A_365-part1-item2">
+                     <div class="item-number">2. </div>
+                     <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_13886">Poems</a></span>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     </div>
+                  
+                  <div class="decoDesc">
+                     <h4>Decoration</h4>
+                     
+                     <p class="decoNote">Penwork.</p>
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">15th century, early</span>
+                     ; <span class="origPlace">
+                        <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7002445">English</a></span>
+                        </span>
+                     </div>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_365-part2" style="padding-left:2rem; border-bottom-color:#C0C0C0;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 365 – Part 2</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <div class="msItem" id="MS_Add_A_365-part2-item1" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     <div class="item-number">1. </div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100902725">Guido de Columnis</a></span>, 
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_1907">Historia destructionis Troiae</a></span>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     </div>
+                  
+                  <div class="decoDesc">
+                     <h4>Decoration</h4>
+                     
+                     <p class="decoNote">Penwork.</p>
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">15th century, early</span>
+                     ; <span class="origPlace">
+                        <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7002445">English</a></span>
+                        </span>
+                     </div>
+               </div>
+            </div>
+            <h2><?ni?>Additional Information<?ni?></h2>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Summary description by Elizabeth Solopova and Matthew Holford, based on the Summary
+                     Catalogue and supplementary sources. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0691.gif">Summary Catalogue, Vol. 5, p. 656</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 367</h1>
+      <div class="content tei-body" id="manuscript_59">
+         <div class="msDesc" id="MS_Add_A_367-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29618</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_367-item1">
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_11737">Evangelium Nicodemi</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>... Incipiunt Gesta Saluatoris Domini nostri Ihesu Christi quę inuenit Theodosius
+                        magnus imperator 
+                        in Ierusalem in pretorio Poncii Pilati in codicibus publicis</span></div>
+                  
+                  <div class="finalRubric"><span class="tei-label">Final rubric: </span><span>Expliciunt Gesta de Christo filio Dei ...</span></div>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span>i + <span class="measure">100</span> leaves. Fols i, 26-end are blank paper
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">8.5</span> × <span class="width">5.125</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">12th century</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span> (?)</span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="acquisition">Bought from <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_32753361">Albert Cohn</a></span> of Berlin (Catalogue 175, no. 363) on 12 April 1886 for £9</p>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_367_flyleaves" style="margin-left:2rem;">
+               <h2>MS. Add. A. 367, flyleaves</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  
+                  <div class="msItem" id="d62e200" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     
+                     <div class="locus">(fol. 1)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_66462384">Terence, etc.</a></span>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Natus in excelsis</span></div>
+                     
+                     <p class="note">Six-line elegiac epitaph on Terence</p> 
+                     
+                     <p class="note">Other Terentian fragments and some scribbling in Italian</p>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin and Italian</div>
+                     </div>
+                  
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>Parchment</div>
+                     
+                     
+                     </div>
+                  
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     
+                     <span class="origDate">15th century</span>
+                     ; <span class="origPlace"><span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7002445">Italy</a></span></span>
+                     
+                     </div>
+               </div>
+            </div>
+            <h2><?ni?>Additional Information<?ni?></h2>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (September 2025) by Stewart J. Brookes from the Summary Catalogue
+                     (1905)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0691.gif">Summary Catalogue, Vol. 5, p. 656</a></div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0692.gif">Summary Catalogue, Vol. 5, p. 657</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-09-11: Description revised to incorporate all the information in the Summary Catalogue (1905)</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 369</h1>
+      <div class="content tei-body" id="manuscript_60">
+         <div class="msDesc" id="MS_Add_A_369-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29620</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_369-item1">
+                  
+                  <div class="locus">(fols 14v-121v)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_54143112">Palladius</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_3435">De re rustica</a></span>
+                   <span class="note">(15th-century English verse translation, <span class="bibl">
+                        <abbr style="cursor:default;"><span class="title italic"><a href="https://www.dimev.net/record.php?recID=2983" target="_blank">DIMEV</a></span></abbr>
+                        <span class="num">1071</span></span>, <span class="bibl">
+                        <abbr style="cursor:default;"><span class="title italic">NIMEV</span></abbr>
+                        <span class="num">654</span></span>)</span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>De preceptis rei rustice</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Consideraunce is taken atte prudence/ 
+                        What mon me moost enfourme and husbondrie/ 
+                        No rethorik doo teche or eloquence. 
+                        As sum haue doon hemself to magnifie</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Doon in and dreynt a cruste vpon it make/ 
+                        And fille it to the brinke vntil it take</span></div>
+                  
+                  <p class="note">'rhyme royal' stanzas (rhyming <i>ababbcc</i>)</p>
+                  
+                  <p class="note">An alphabetical <a href="https://babel.hathitrust.org/cgi/pt?id=inu.30000112944933&amp;seq=27" target="_blank">index of subjects</a> ('tabula') precedes, 
+                     in which the references appear to be to the leaves of the manuscript which was before
+                     the scribe, rendering the index of little use. 
+                     Daniel Wakelin notes that the 'finding aid is a form without real function', made
+                     without thought as to readers mgiht use it 
+                     (<span class="title italic">Designing English: Early Literature on the Page</span> (Bodleian, 2018), p. 85</p>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="measure">125</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">9.875</span> × <span class="width">7.5</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  <div>
+                     <h4>Condition</h4>
+                     <div class="condition">A-B are wanting, a leaf being lost. Two leaves are also wanting after fol. 92; fols
+                        93 and 97 should 
+                        follow fols 94 and 98. Fol. 121 has lost the upper part; and the last forty- three
+                        lines of Book xii, with all of Book xiii, are lost, 
+                        the manuscript ending abruptly.</div>
+                  </div>
+                  
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century, middle</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7002445">England</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">'<span class="persName sgn">Thomas Nevet</span>' and' '<span class="persName sgn">William Nevet</span>' (16th century) occur on fol. 122v</p>
+                  <p class="provenance">Kept in the Library at Colchester Castle where it had been 'lying long unnoticed'
+                     and still in Colchester Castle when the manuscript was 
+                     edited by Barton Lodge from 1873-1879: <a href="https://babel.hathitrust.org/cgi/pt?id=inu.30000112944933&amp;seq=15&amp;q1=Colchester" target="_blank">see p. vii</a> of 
+                     <span class="title italic">Palladius on Husbondrie</span>, ed. by Barton Lodge and Sidney J. H. Herrtage, Early English Text Society, O. S.
+                     52 and 72 (1873 and 1879; 
+                     reprinted as one vol. in 1973)</p>
+                  <p class="acquisition">Bought for £40 in September 1886 from <span class="persName bsl">B. Quaritch</span> (whose letter of 14 September is at fol. 2). 
+                     <a href="https://babel.hathitrust.org/cgi/pt?id=uc2.ark:/13960/t4sj1rf0v&amp;seq=25&amp;q1=35680" target="_blank">No. 35680</a> in Quaritch's <span class="title italic">General Catalogue</span> (1887)</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (July 2025) by Stewart J. Brookes from the Summary Catalogue (1905)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0692.gif">Summary Catalogue, Vol. 5, p. 657</a></div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0693.gif">Summary Catalogue, Vol. 5, p. 658</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               
+               <div class="surrogates">
+                  <h3 class="msDesc-heading3">Digital Images</h3>
+                  <p><span class="bibl"><a href="https://digital.bodleian.ox.ac.uk/objects/61120deb-7b6b-409d-bd8d-461dc3432a00/" target="_blank"><span class="title italic">Digital Bodleian</span></a>
+                        <span class="note">(1 image from 35mm slides)</span></span><br /></p>
+                  <h3 class="msDesc-heading3">Surrogates</h3>
+                  <p><span class="bibl">
+                        Wakelin, Daniel, <span class="title italic">Designing English: Early Literature on the Page</span> (Bodleian, 2018), p. 84, reproduces fol. 8v in colour
+                        </span><br /></p>
+               </div>
+               
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Online resources:</h4>
+                        
+                        <div class="bibl">
+                           <a href="https://quod.lib.umich.edu/c/cme/CME00114/1:4.9.8?rgn=div3;view=fulltext" target="_blank">
+                              <span class="title italic">Corpus of Middle English Prose and Verse
+                                 </span>
+                              </a>
+                           </div>
+                        
+                        </span>
+                     
+                     </ul>
+               </div>
+               
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-07-22: Description revised to incorporate all the information in the Summary Catalogue (1905)
+               and other printed sources</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 370</h1>
+      <div class="content tei-body" id="manuscript_61">
+         <div class="msDesc" id="MS_Add_A_370-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29621</span>
+                  </p>
+               </div>
+            <h4 class="msHead">Aristotelian commentaries and logical works; A-B Italy, 15th century; C England, 1425</h4>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="physDesc-p">three parts</div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance"><span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_19743305">Libri</a></span> sale, 29 March 1859, lot 198.</p>
+                  <p class="provenance">Perhaps bought by Thomas Kerslake, bookseller of Bristol.</p>
+                  <p class="provenance">J. E. Cornish, Manchester bookseller, nephew of Kerslake.</p>
+                  <p class="acquisition">Purchased from him by the Bodleian for £9 9s., 1886..</p>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_370-part1" style="padding-left:2rem; margin-top:1rem; border-bottom-color:#C0C0C0; border-top:1px #C0C0C0 solid;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 370 – Part 1</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</p>
+                  
+                  <div class="msItem" id="d64e196">
+                     
+                     <div class="locus">(fol. 3)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_264344179">Thomas Aquinas</a></span>, 
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_5614">Commentary on Aristotle’s De interpretatione (Peri hermeneias)</a></span>
+                      <span class="note">(on bk. 1)</span>
+                     </div>
+                  
+                  <div class="msItem" id="d64e211">
+                     
+                     <div class="locus">(fol. 25v)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_99944105">Gratiadei of Ascoli</a></span>, 
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_5620">Commentary on Aristotle’s De interpretatione (Peri hermeneias)</a></span>
+                      <span class="note">(on bk. 2)</span>
+                     </div>
+                  
+                  <div class="msItem" id="d64e226">
+                     
+                     <div class="locus">(fol. 38v)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_99944105">Gratiadei of Ascoli</a></span>, 
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_5621">Commentary on Ps.-Aristotle, Liber sex principiorum</a></span>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                     
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">15th century</span>
+                     ; <span class="origPlace">
+                        <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italian</a></span>
+                        </span>
+                     </div>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_370-part2" style="padding-left:2rem; border-bottom-color:#C0C0C0;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 370 – Part 2</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</p>
+                  
+                  <div class="msItem" id="d64e283">
+                     
+                     <div class="locus">(fol. 62)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_97777789">Dominicus de Flandria</a></span>, 
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_5617">Recollectio super libros De anima tradita Bononiae in convento sancti Dominici</a></span>
+                     </div>
+                  
+                  <div class="msItem" id="d64e295">
+                     
+                     <div class="locus">(fol. 104)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_97777789">Dominicus de Flandria</a></span>, 
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_5618">Expositio super tractatum Thomae de Aquino De fallaciis</a></span>
+                     </div>
+                  
+                  <div class="msItem" id="d64e307">
+                     
+                     <div class="locus">(fol. 124v)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_97777789">Dominicus de Flandria</a></span>, 
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_5619">Tractatus de suppositionibus</a></span>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                     
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">15th century</span>
+                     ; <span class="origPlace">
+                        <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italian</a></span>
+                        </span>
+                     </div>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_370-part3" style="padding-left:2rem; border-bottom-color:#C0C0C0;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 370 – Part 3 (fols. 126–226)</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</p>
+                  
+                  <div class="msItem" id="d64e364">
+                     
+                     <div class="locus">(fol. 128)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_79258484">John Sharpe OCarm</a></span>, 
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_5615">Formalitates</a></span>
+                     </div>
+                  
+                  <div class="msItem" id="d64e376">
+                     
+                     <div class="locus">(fol. 143)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_86734224">Walter Burley</a></span>, 
+                     <span class="tei-title italic">Tractatus XI</span>
+                     
+                     <div class="nestedmsItem" id="d64e387" style="margin-top:1rem;">
+                        
+                        <div class="locus">(fol. 143)</div>
+                        <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_5677">De formis</a></span>
+                        </div>
+                     
+                     <div class="nestedmsItem" id="d64e396">
+                        
+                        <div class="locus">(fol. 167)</div>
+                        <span class="tei-title italic">De secundis intentionibus</span>
+                        
+                        </div>
+                     
+                     <div class="nestedmsItem" id="d64e408">
+                        
+                        <div class="locus">(fol. 168)</div>
+                        <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_5683">De tribus in toto universo per se agentibus (Notabilia de logicis ix)</a></span>
+                        </div>
+                     
+                     <div class="nestedmsItem" id="d64e417">
+                        
+                        <div class="locus">(fol. 170)</div>
+                        <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_5682">De diffinitione siue de modo diffiniendi (Notabilia de logicis xi)</a></span>
+                        </div>
+                     
+                     <div class="nestedmsItem" id="d64e426">
+                        
+                        <div class="locus">(fol. 171v)</div>
+                        <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_5681">De qualitatibus (Notabilia de logicis viii)</a></span>
+                        </div>
+                     
+                     <div class="nestedmsItem" id="d64e435">
+                        
+                        <div class="locus">(fol. 173)</div>
+                        <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_5680">De diuisione entis (Notabilia de logicis iii)</a></span>
+                        </div>
+                     
+                     <div class="nestedmsItem" id="d64e444">
+                        
+                        <div class="locus">(fol. 175)</div>
+                        <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_5679">De toto et parte (Notabilia de logicis v)</a></span>
+                        </div>
+                     
+                     <div class="nestedmsItem" id="d64e453">
+                        
+                        <div class="locus">(fol. 176v)</div>
+                        <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_4943">De diuisione potentiae</a></span>
+                        
+                        </div>
+                     
+                     <div class="nestedmsItem" id="d64e465">
+                        
+                        <div class="locus">(fol. 177r)</div>
+                        <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_4945">De potentiis animae</a></span>
+                        </div>
+                     
+                     <div class="nestedmsItem" id="d64e474">
+                        
+                        <div class="locus">(fol. 190v)</div>
+                        
+                        <div class="colophon"><span class="tei-label">Colophon: </span><span>Explicit tractatus de potencijs anime secundum ... Walterum de burley Anglicum scriptus
+                              per manus <span class="persName scr"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_2799">fratris Johannis de gelria Alamani</a></span> in prouincia anglie in villa london</span></div>
+                        
+                        <p class="note">Covering fols. 128–190v.</p>
+                        </div>
+                     
+                     <div class="nestedmsItem" id="d64e489">
+                        
+                        <div class="locus">(fol. 191r)</div>
+                        <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_4949">Expositio libri Meteorum</a></span>
+                        
+                        <div class="nestedmsItem" id="d64e497" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                           
+                           <div class="locus">(fol. 203)</div>
+                           
+                           <div class="colophon"><span class="tei-label">Colophon: </span><span>Explicit quartus liber ... metheororum ... Scripti per manus fratris Johannis de gelria
+                                 completi in die sancti Ignatij martiris Anno domini mºccccºxxvº etc.</span></div>
+                           
+                           <p class="note">Covering fols. 191–203.</p>
+                           </div>
+                        </div>
+                     
+                     <div class="nestedmsItem" id="d64e510" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                        
+                        <div class="locus">(fol. 207r)</div>
+                        <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_5684">Quaestiones de universalibus</a></span>
+                        
+                        <div class="nestedmsItem" id="d64e518" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                           
+                           <div class="locus">(fol. 216v)</div>
+                           
+                           <div class="colophon"><span class="tei-label">Colophon: </span><span>Expliciunt diuersorum diuerse opiniones de vniversalibus ... Scripte anno domini 1425º</span></div>
+                           
+                           <p class="note">Covering fols. 207–216v.</p>
+                           </div>
+                        </div>
+                     </div>
+                  
+                  <div class="msItem" id="d64e532">
+                     
+                     <div class="locus">(fol. 219)</div>
+                     <span class="tei-title">Philosophical text</span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>De presciencia et predestinacione</span></div>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Ab inicio vero nascentis ecclesie</span></div>
+                     
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper (with three parchment leaves)</div>
+                     
+                     <div class="extent"><span class="tei-label">Extent: </span><span class="measure">126–226</span> fols. 
+                        <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                           <span class="height">210</span> × <span class="width">150</span> mm.
+                           
+                           </div>
+                        </div>
+                     
+                     
+                     <div class="layoutDesc">
+                        <h4>Layout</h4>
+                        
+                        <p>1 cols., c. 30–40 lines, written space 
+                           <span class="height">150–60</span> × <span class="width">90–100</span> mm.
+                           
+                           </p>
+                        </div>
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">1425</span>
+                     ; <span class="origPlace">
+                        <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7002445">English</a></span>, <span class="settlement"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7011781">London</a></span>
+                        </span>
+                     </div>
+                  <div class="provenance">
+                     <h4>Provenance</h4>
+                     <p class="provenance">'Ex libris <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_2798">magistri baptiste panteij</a></span> Qui die 27 marcij in <span class="sic">senetucte[<i>sic</i>]</span> bona obiit', fol. 126, in Italian hand of c. 1500.</p>
+                  </div>
+               </div>
+            </div>
+            <h2><?ni?>Additional Information<?ni?></h2>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Adapted (2017) from A. G. Watson, <span class="title italic">Catalogue of Dated and Datable Manuscripts</span>, and the Summary Catalogue (1905), with reference to Thomson (see bibliography).
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0693.gif">Summary Catalogue, Vol. 5, p. 658</a></div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0694.gif">Summary Catalogue, Vol. 5, p. 659</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <div class="bibl">R. M. Thomson, <span class="title italic">Catalogue of Medieval Manuscripts of Latin Commentaries on Aristotle in British Libraries:
+                              1: Oxford</span> (Turnhout, 2011), pp. 25–8.</div>
+                        
+                        <div class="bibl">A. G. Watson, <span class="title italic"><a href="https://catalog.hathitrust.org/Record/000310664" target="_blank">Catalogue of Dated and Datable Manuscripts c.435–1600 in Oxford Libraries</a></span> (Oxford, 1984), no. 15 [part 3]</div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 371</h1>
+      <div class="content tei-body" id="manuscript_62">
+         <div class="msDesc" id="MS_Add_A_371-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29622</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               
+               <div class="msItem" id="MS_Add_A_371-item1">
+                  
+                  <div class="locus"><span class="item-number">1. </span>(fol. 3)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_104162705">Sallust</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_4482">Jugurtha</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>... Prologus Salustij de Iugurtino Bello</span></div>
+                  
+                  <p class="note">Followed by the 'Ystoria Iugurtini Belli'</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               
+               <div class="msItem" id="MS_Add_A_371-item2">
+                  
+                  <div class="locus"><span class="item-number">2. </span>(fol. 49)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_104162705">Sallust</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_4480">Catilina</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Prologus Salustij de Coniuratione Katilinaria</span></div>
+                  
+                  <p class="note">Followed by 'Incipit a natura &amp; moribus Katiline tractare' and the rest of the book</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               
+               <div class="msItem" id="MS_Add_A_371-item3">
+                  
+                  <div class="locus"><span class="item-number">3. </span>(fol. 77)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_104162705">Sallust</a></span>; 
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_92416118">Ps. -Sallust</a></span>; 
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_305360068">Ps.- Cicero</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_4115">Inuectiuae</a></span>
+                  
+                  <p class="note">The four Invectives of Cicero against Catiline</p>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Grauiter et iniquo animo</span></div>
+                  
+                  <p class="note">Followed (fol. 106) by Sallust's Invective against Cicero and Cicero's Answer</p>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Id demull1 magna</span></div>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="measure">113</span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">8.5</span> × <span class="width">6.125</span> in.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  </div>
+               
+               
+               <div class="handDesc">
+                  <h4>Hand(s)</h4>
+                  
+                  <p class="handNote">Humanistic script (<a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> ii. 699)</p>
+                  </div>
+               
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="summary"><a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> ii. 699
+                     </p>
+                  
+                  
+                  <p class="decoNote">Good penwork initials</p>
+                  </div>
+               
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">Mottled calf with gold ornament, late 18th century, not English</p>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century, second quarter</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italy</a></span>
+                     <span class="settlement"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7005903">Milan</a></span> (?)</span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">With the signature and bookplate of the rev. William Maskell, ahout 1840'</p>
+                  <p class="provenance">Owned by <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_70399355">Thomas Kerslake</a></span>, who sold it to his nephew, <span class="persName bsl fmo">J. E. Cornish</span> (see <a href="https://medieval.bodleian.ox.ac.uk/catalog/manuscript_61" target="_blank">MS. Add. A. 370</a>, fol. 227)</p>
+                  <p class="acquisition">'Bought by the Bodleian for £5 5<i>s</i>. from Cornish's advert. in <span class="title italic">Notes and Queries</span> for Oct. 9, 1856.'</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">
+                     Description adapted (July 2025) by Stewart J. Brookes from the Summary Catalogue (1905).
+                     Decoration, localization and date follow Pächt and Alexander (1970)
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0694.gif">Summary Catalogue, Vol. 5, p. 659</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-07-21: Description revised to incorporate all the information in the Summary Catalogue (1905)</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 373</h1>
+      <div class="content tei-body" id="manuscript_63">
+         <div class="msDesc" id="MS_Add_A_373-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29624</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_A_373-item1">
+                  <div class="locus"></div>
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_15156">Liber Quare</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Ratio eorum que frunt in ecclesia per circulum anni <span class="locus">(fol. 1)</span></span></div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Incipiunt Sacramenta <span class="objectType">(fol. 74)</span></span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Consideranda est causa singulorum</span></div>
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Cum multa sint sacramenta</span></div>
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>peccatorum nostrorum uulnera</span></div>
+                  <span class="bibl">ed. G. P. Götz, CCCM 60, this MS. siglum Oa.</span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="seg"><span class="measure">i</span> + <span class="measure">100</span></span> leaves
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (binding): </span>
+                        <span class="height">8.75</span> × <span class="width">5.375</span> in.
+                        
+                        </div>
+                  </div>
+                  
+                  </div>
+               
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">12th century, late</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7000084">German (?)</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">Fol. i once bore an early record of possession, beginning 'Liber ...', but almost
+                     all the leaf is cut off.</p>
+                  <p class="provenance"> 'Fol. 99. d. 1 April 1835. <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_24953683">Bibl. Bülov Beyern<span class="supplied">⟨aumburg⟩</span></a></span>, G. H. Sc̄hr.'</p>
+                  <p class="provenance"> Lot 878 in the Carnaby sale on Nov. 26, 1886.</p>
+                  <p class="acquisition">Bought for the Library for £2 8s.</p>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_373-endleaf" style="margin-left:2rem;">
+               <h2>MS. Add. A. 373, endleaf (fol. 100)</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</p>
+                  
+                  <div class="msItem" id="MS_Add_A_373-endleaf-item1" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_13355">Missal</a></span>
+                     
+                     <p class="note">Fragment of the temporale: portions of the mass of Maundy Thursday and the Washing
+                        of the Feet.</p>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     <div class="extent"><span class="tei-label">Extent: </span>upper part of a leaf
+                        
+                        <div class="dimensions"><span class="tei-label">Dimensions (fragment): </span>
+                           <span class="height">137</span> × <span class="width">215</span> mm.
+                           
+                           </div>
+                     </div>
+                     
+                     
+                     <div class="layoutDesc">
+                        <h4>Layout</h4>
+                        
+                        <p>long lines, originally about 193 mm. width</p>
+                        </div>
+                     </div>
+                  
+                  <div class="musicNotation"><span class="tei-label">Musical Notation: </span>
+                     
+                     <p>Half-diastematic (Aquitanian?) point neums in one place only.</p>
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">11th century (first half (?))</span>
+                     ; <span class="origPlace">
+                        <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000070">France (?)</a></span>
+                        </span>
+                     </div>
+               </div>
+            </div>
+            <h2><?ni?>Additional Information<?ni?></h2>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Description adapted (Oct. 2022) from the following sources  with additional reference
+                     to published literature as cited:
+                     
+                     <div class="listBibl">
+                        
+                        <div class="bibl">S. J. P. van Dijk, <span class="title italic">Latin Liturgical Manuscripts in the Bodleian Library, Oxford, vol. 5: Fragments -
+                              Mass Books</span> (typescript, 1957), <span class="citedRange">p. 130</span> (endleaf)
+                           </div>
+                        
+                        <div class="bibl">Summary Catalogue (1922) </div>
+                        </div> 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0694.gif">Summary Catalogue, Vol. 5, p. 659</a></div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0695.gif">Summary Catalogue, Vol. 5, p. 660</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2022-10: Revised to incorporate all information in printed catalogues.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. A. 263</h1>
+      <div class="content tei-body" id="manuscript_47">
+         <div class="msDesc" id="MS_Add_A_263-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29383</span>
+                  </p>
+               </div>
+            <h4 class="msHead">Guillelmus de Tocco, <span class="title italic">Ystoria sancti Thome de Aquino</span>, with offices for Thomas Aquinas and Corpus Christi. Germany, 14th century (after
+               1318)</h4>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="extent"> <span class="seg"><span class="measure">iii</span> + <span class="measure">48</span> + <span class="measure">16</span> + <span class="measure">i</span></span> leaves 
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">240–5</span> × <span class="width">170–5</span> mm.
+                        
+                        </div>
+                     </div>
+                  
+                  <div class="foliation"><span class="tei-label">Foliation: </span> 1–64 in late 19th-century purple pencil, i–iii and 65v in 20th-century pencil</div>
+                  
+                  </div>
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">Contemporary binding. Sewn on four pairs of twisted parchment bands, laced and pegged
+                     separately into horizontal channels in wood (beech?) boards, covered with undecorated
+                     tawed(?) skin, overlapping the edges of the leaves; two strap-and-pin clasps (closing
+                     from the back to the front board); the front cover inscribed with a shelfmark in bold
+                     15th-century characters ‘Y.22.’; the top of the spine inscribed ‘Legen|da S. | Thom|
+                     <span class="unclear">ae<span class="unclearMarker">(?)</span></span>
+                     <span class="gap">.......</span>
+                     | &amp; | S. Aug. | S. Ambr.’ (worn; readings uncertain; cf. fols. 49–54). </p>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">Contents suggest that the manuscript was written for a Dominican house in Germany;
+                     it was perhaps still there in the 15th century.</p>
+                  <p class="provenance">Annotated in German, 14th(?)-century: ‘in götlicher veruck<span class="gap">..</span>
+                     ’ (fol. 24v, lower margin).</p>
+                  <p class="provenance">Unidentified library, with its 15th century shelfmark ‘Y .22.’ inscribed on the front cover and fol. 1r, the latter altered from ‘M .12.’.</p>
+                  <p class="provenance">Unidentified 19th(?)-century collection, doubtless German: inscribed in ink ‘N XXIV’ and ‘N 24’ (fol. ii r).</p>
+                  <p class="provenance">Unidentified 19th-century German-speaking owner/bookseller: with an inserted slip
+                     inscribed in pencil ‘Beide Theile dieser Codex 14 saec.’ (attached to fol. ii r);
+                     his(?) number ‘173’ inside the back board and on a slip of paper attached to the back
+                     board.</p>
+                  <p class="provenance">H. Grevel &amp; Co., London bookseller: their(?) inventory number ‘9157’ in pencil (fol.
+                     iir upper right; fol. 1r, top left; fol. 64r, lower left); their Catalogue 4, <span class="title italic">Catalogue of rare manuscripts and early printed books …</span> (1884), item 6; pencil price ‘£4’ (fol. iir):</p>
+                  <p class="acquisition">Purchased by the Bodleian on 24 March 1884, for £3 10s; inscribed in pencil ‘Grevel
+                     1884’ (fol. iir). Former Bodleian shelfmarks: ‘MS. Bodl. Adds. A. 263’ (fol. 1r, lower
+                     margin; cancelled by encircling). </p>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_263-part1" style="padding-left:2rem; margin-top:1rem; border-bottom-color:#C0C0C0; border-top:1px #C0C0C0 solid;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 263 – Part A (fols. 1–48)</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</p>
+                  
+                  <div class="msItem" id="MS_Add_A_263-part1-item1">
+                     
+                     <div class="locus"><span class="item-number">1. </span>(fols. 1r–43v)</div>
+                     <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_61535682">Guillelmus de Tocco</a></span>, 
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_6661">Ystoria sancti Thome de Aquino</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Hic incipit legenda sancti Thome</span></div>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span class="type">(prohemium) </span><span>Deus qui dicit de tenebris lumen splendesc<span class="supplied">⟨er⟩</span>e. modernis temporibus quasi ad mundi vesperam </span></div>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>De ortu sancti Thome et quod fuit prophetatus. Secundus capitulum</span></div>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span class="type">(text) </span><span>De predicto stellarum predicatorum ordine oportebat luminare</span></div>
+                     
+                     <div class="explicit"><span class="tei-label">Explicit: </span><span> quod deerat virtuti nature</span></div>
+                     <span class="bibl">ed. C. Le Brun-Gouanvic, <span class="title italic">Ystoria sancti Thome de Aquino de Guillaume de Tocco (1323)</span> (Toronto, 1996), one of 14 MSS. of the third recension, and one of 8 MSS. used for
+                        establishing the text (siglum ‘O’). It seems to have been the (indirect) exemplar
+                        for Munich, BSB, Clm. 18427, which in turn was the exemplar for Karlsruhe, Badische
+                        Landesbibliothek, Karlsruhe Hs. 379. The work survives in four redacations written
+                        between 1318 and 1323.</span>
+                     
+                     <p class="note">At cap. 66 (incipit ‘Post hec autem cogitans predictus abbas. quod notus erat locus
+                        in quo corpus dicti doctoris erat humatum’; fol. 32r) are added marginal notes by
+                        three different hands: ‘De translacione sancti Thome de Aquino ordinis fratrum predicatorum
+                        leccio prima’, ‘translacio sanctus Thom<span class="supplied">⟨as ordi⟩</span>nis predicatorum’ and ‘leccio prima’; the successive passages marked ‘leccio ii’ –
+                        ‘leccio ix’ (fol. 34r). The relics were translated in 1369. </p>
+                     </div>
+                  
+                  <div class="msItem" id="MS_Add_A_263-part1-item2">
+                     
+                     <div class="locus"><span class="item-number">2. </span>(fols. 43v–48r)</div>
+                     <span class="tei-title">Added Offices</span>
+                     
+                     <div class="nestedmsItem" id="d50e348" style="margin-top:1rem;">
+                        
+                        <div class="locus">(fols. 43v–47v)</div>
+                        <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_16444">St Thomas Aquinas</a></span>
+                        
+                        <div class="rubric"><span class="tei-label">Rubric: </span><span>De sancto Thoma. historia. ad vesperas super psalmos. antiphona.</span></div>
+                        
+                        <div class="incipit"><span class="tei-label">Incipit: </span><span>Felix Thomas doctor ecclesie lumen mundi splendor Italie </span></div>
+                        
+                        <div class="incipit"><span class="tei-label">Incipit: </span><span>
+                              <span class="note">(first lection)</span> Sanctus Thomas de Aquino ordinis fratrum predicatorum doctor egregius de illustri
+                              prosapia comitum Aquinorum in confinibus Campanie et regni Sicilie originem duxit
+                              claram </span></div>
+                        
+                        <div class="explicit"><span class="tei-label">Explicit: </span><span>et miserator dominus escam dedit timentibus se</span></div>
+                        
+                        <div class="finalRubric"><span class="tei-label">Final rubric: </span><span>Iste due antiphone dicantur per octavam ad benedictus et ad magnificat</span></div>
+                        
+                        <p class="note">Psalms, capitula, hymns, etc., for first vespers, matins (with nine lessons in three
+                           nocturns), and from lauds to vespers.</p>
+                        </div>
+                     
+                     <div class="nestedmsItem" id="d50e379" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                        
+                        <div class="locus">(fols. 47v–48r)</div>
+                        <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_16378">Corpus Christi</a></span>
+                        
+                        <div class="rubric"><span class="tei-label">Rubric: </span><span>De corpore Christi. ymnus ad vesperas</span></div>
+                        
+                        <div class="incipit"><span class="tei-label">Incipit: </span><span>Pange lingua gloriosi</span></div>
+                        
+                        <p class="note">First vespers, matins to vespers, and the octave.</p>
+                        
+                        <p class="note">Hymns (only) for vespers, matins, and lauds; capitula, responsories, and versicles
+                           for terce, sext, and none; antiphons and psalms for vespers; antiphons for the octave;
+                           compline is omitted and its antiphon is added at the bottom of fol. 48r: ‘O panis
+                           vite veneranda refectio rite. …’</p>
+                        
+                        <p class="note">Fol. 48v ruled, otherwise blank</p>
+                        </div>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     <div class="collation">
+                        <h4>Collation</h4>
+                        <div class="collation"> 1–2(12), 3(10), 4(apparently 10+2, with fol. 43 added after 8 (fol. 42) and fol.
+                           45 added after 9 (fol. 44)) (fols. 35–46), 5(2); quire signatures in red ink, i–iiij
+                           </div>
+                     </div>
+                     
+                     
+                     <div class="layoutDesc">
+                        <h4>Layout</h4>
+                        
+                        <p>Ruled in ink for 34 lines; fols. 44r–48r written in two columns. Ruled space 
+                           <span class="height">190</span> × <span class="width">120–5</span> mm.
+                           
+                           
+                           </p>
+                        </div>
+                     </div>
+                  
+                  <div class="handDesc">
+                     <h4>Hand(s)</h4>
+                     
+                     <p class="handNote"> Formal gothic bookhand; it is common that insufficient space has been left for the
+                        rubrics, which are absent after fol. 26r. </p>
+                     </div>
+                  
+                  <div class="decoDesc">
+                     <h4>Decoration</h4>
+                     
+                     <p class="decoNote"> One 4-line puzzle initial in red and blue, with red and blue penwork, accompanied
+                        by red and blue penwork border in the outer margin (fol. 1r).</p>
+                     
+                     <p class="decoNote">2-line initials in plain red.</p>
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">14th century (after 1318)</span>
+                     ; <span class="origPlace">
+                        <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7000084">German</a></span>
+                        </span>
+                     </div>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_263-part2" style="padding-left:2rem; border-bottom-color:#C0C0C0;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 263 – Part B (fols. 49–64)</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</p>
+                  
+                  <div class="msItem" id="MS_Add_A_263-part2-item1">
+                     
+                     <div class="locus"><span class="item-number">3. </span>(fols. 49r–62v)</div>
+                     <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_16378">Readings for the Office of Corpus Christi</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Lectiones de Corpore Christi</span></div>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span> In mysterio corporis et sanguinis domini nostri Ihesu Christi</span></div>
+                     
+                     <div class="explicit"><span class="tei-label">Explicit: </span><span>Qui semper pecco semper debeo habere medicinam</span></div>
+                     
+                     <p class="note">Nine lessons for the feast day (which was proposed by Thomas Aquinas and falls on
+                        the Thursday after Trinity Sunday); three each for Friday for Saturday; six for Sunday,
+                        with rubric ‘Gregorius in libro iiij dialogi’; three each for Monday, Tuesday, and
+                        Wednesday, the latter with a rubric ‘Ambrosius in primo libro de sacramento’; and
+                        nine for the octave, the sixth with a rubric, ‘Item Ambrosius in secundo libro de
+                        sacramento’, and the ninth with ‘Item Ambrosius in eodem’.</p>
+                     </div>
+                  
+                  <div class="msItem" id="MS_Add_A_263-part2-item2">
+                     
+                     <div class="locus"><span class="item-number">4. </span>(fols. 62v–64r)</div>
+                     <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_16378">Abbreviated Office for Corpus Christi, for vespers, matins, and lauds</a></span>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>De corpore Christi. ad versperas super psalmos antiphona</span></div>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Sacerdos in eternum Christus dominus secundum ordinem Melchisedech panem et vinum
+                           obtulit</span></div>
+                     
+                     <div class="explicit"><span class="tei-label">Explicit: </span><span>si quis manducaverit ex hoc pane vivet in eternum</span></div>
+                     
+                     <div class="finalRubric"><span class="tei-label">Final rubric: </span><span>Quere superius ymnos et cetera ad tale signum ☩</span></div>
+                     
+                     <p class="note">Abbreviated: antiphons, responsories, versicles, capitula, etc; psalms, hymns, etc.
+                        given by cue only.</p>
+                     
+                     <p class="note">Fol. 64v ruled, otherwise blank.</p>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     <div class="collation">
+                        <h4>Collation</h4>
+                        <div class="collation">6(12), 7(4)</div>
+                     </div>
+                     
+                     
+                     <div class="layoutDesc">
+                        <h4>Layout</h4>
+                        
+                        <p>Ruled in ink for mostly 25 lines; ruled space 
+                           <span class="height">175</span> × <span class="width">110–5</span> mm.
+                           
+                           
+                           </p>
+                        
+                        <p>Fols. 63r-64r in 2 cols. of 26-8 lines.</p>
+                        
+                        <p>Fols. 62r-64r written above top line.</p>
+                        </div>
+                     </div>
+                  
+                  <div class="handDesc">
+                     <h4>Hand(s)</h4>
+                     
+                     <p class="handNote">Formal gothic bookhand</p>
+                     </div>
+                  
+                  <div class="decoDesc">
+                     <h4>Decoration</h4>
+                     
+                     <p class="decoNote">1- and 2-line initials in plain red.</p>
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">14th century</span>
+                     ; <span class="origPlace">
+                        <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7000084">Germany</a></span>
+                        </span>
+                     </div>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_263-endleaves-1" style="padding-left:2rem; border-bottom-color:#C0C0C0;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 263 - front pastedown</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <div class="msItem" id="d50e611" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     
+                     <p class="note">Part of a legal document, dated 1318, relating to a dispute involving abbess Hildegund
+                        of ‘Rore’ (the <span class="orgName"><a href="https://medieval.bodleian.ox.ac.uk/catalog/org_234299904">Benedictine nunnery of Rohr</a></span>, about 10km east of Meiningen), concerning the presentation to the vicarage of ‘Kaltensuenthein’
+                        (Kaltensundheim; about 35km west of Meiningen).</p>
+                     
+                     
+                     <p class="note">About 35 lines preserved, trimmed on all four sides, written in cursive documentary
+                        script. </p>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>sheet</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     </div>
+                  
+                  <div class="handDesc">
+                     <h4>Hand(s)</h4>
+                     
+                     <p class="handNote">Cursiva antiquior</p>
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">1318</span>
+                     ; <span class="origPlace">
+                        <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7000084">Germany</a></span>
+                        </span>
+                     </div>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_263-endleaves-2" style="padding-left:2rem; border-bottom-color:#C0C0C0;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 263 - front pastedown</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <div class="msItem" id="d50e676" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     
+                     <p class="note">A narrow vertical parchment strip of a 14th-century document in German, perhaps relating
+                        to a gift to a nunnery: preserving no more a few words per line, apparently including
+                        several personal names: beginning ‘]g die schenk...’; refers to a sub-prioress (suppriorin); the legal term 'selbedritte' occurs frequently.</p>
+                     
+                     <p class="note">Short parts of 31 lines preserved, written in gothic bookhand. </p>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle High German</div>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>sheet</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">14th century </span>
+                     ; <span class="origPlace">
+                        <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7000084">Germany</a></span>
+                        </span>
+                     </div>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_263-endleaves-3" style="padding-left:2rem; border-bottom-color:#C0C0C0;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 263 - fol. ii verso and inside back cover</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <div class="msItem" id="d50e733" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     
+                     <p class="note">Most of an appeal by Matheus de Vriburg, as proctor for the Dominican friars of ‘Zouingen’
+                        (<span class="orgName"><a href="https://medieval.bodleian.ox.ac.uk/catalog/org_211">Zofingen, Aargau</a></span>), written in a neat Italian (?) documentary hand, apparently relating to a dispute
+                        with the collegiate church of <span class="orgName"><a href="https://medieval.bodleian.ox.ac.uk/catalog/org_249124062">St Maurice in Zofingen</a></span> (‘prepositus et capitulum Zouin<span class="supplied">⟨gen⟩</span>’, inside back cover, line 15). The document refers also to ‘fratres predicatores
+                        et minores in Constant.’ (l. 4), ‘ecclesie sancti Stephani’ (the collegiate church
+                        of <span class="orgName"><a href="https://medieval.bodleian.ox.ac.uk/catalog/org_241579670">St Stephan in Constance</a></span>) (ll. 4, 5), ‘domino Io. dei gratia Tusculano episcopo apostolice sedis legati’ (Giovanni
+                        Boccamazza, sedit 1285-1309) (ll. 13, 21), ‘anno domini Mo. CCo. lxxxviijo … in die
+                        sanctorum Innocentium’ (ll. 21–22), C<span class="ex">(onrad)</span>, prior of the <span class="orgName"><a href="https://medieval.bodleian.ox.ac.uk/catalog/org_213">Dominicans in Constance</a></span>, and Hugo, lector of the same, ‘H. de Arbona de Brenburg, fratre C. de Arbona, fratribus
+                        ordinis predicti, domino Walthero sacerdote’ (l. 23), ‘R<span class="supplied">⟨udolf⟩</span> dei gratia Constantiae episcopus [1274–1293]’ (l. 26, cf. l. 3).</p>
+                     
+                     <p class="note">For the short-lived Dominican convent at Zofingen, founded in 1286, immediately in
+                        dispute with the collegiate church of St Maurice, then partly destroyed in 1288, and
+                        apparently permanently dissolved by 1304, see <span class="title italic">Helvetia Sacra 4: Die Orden mit Augustinerregel 5: Die Dominikaner und Dominikanerinnen
+                           in der Schweiz</span> (1999), I.459-465; ibid., I. 415 for Hugo lector of Constance Blackfriars.</p>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>sheet</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     </div>
+                  
+                  <div class="handDesc">
+                     <h4>Hand(s)</h4>
+                     
+                     <p class="handNote">Cursive documentary script.</p>
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">c. 1288</span>
+                     </div>
+               </div>
+            </div>
+            <div class="msPart" id="MS_Add_A_263-endleaves-4" style="padding-left:2rem; border-bottom-color:#C0C0C0;">
+               <h2 style="position:relative; left:-2rem;">MS. Add. A. 263 - fol. iii</h2>
+               <h3><?ni?>Contents<?ni?></h3>
+               <div class="msContents">
+                  
+                  <div class="msItem" id="d50e812" style="border-bottom-color:#FFFFFF; margin-bottom:0px; padding-bottom:0px;">
+                     
+                     <p class="note">A late 14th century slip, sewn to fol. ii verso, with a rhyming verse epitaph for
+                        Thomas Aquinas</p>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Epytap<ins class="above">^h^</ins>ium sancti Thome de <ins class="above">^A^</ins>quino ordinis fratrum predicatorum</span></div>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>In luctu zithare vertuntur flent et amare</span></div>
+                     
+                     <div class="explicit"><span class="tei-label">Explicit: </span><span>Philosophie. theologie. lux tumulatur</span></div>
+                     
+                     <div class="finalRubric"><span class="tei-label">Final rubric: </span><span>Epitaphium superscriptis mortui</span></div>
+                     
+                     <p class="note">18 lines; close to the text pr. by A. Birkenmajer, <span class="title italic">Vermischte Untersuchungen zur Geschichte der mittelalterlichen Philosophie</span> (Münster, 1922), p. 35, lines 1–36.</p>
+                     
+                     <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                     </div>
+                  </div>
+               <h3><?ni?>Physical Description<?ni?></h3>
+               <div class="physDesc">
+                  
+                  <div class="objectDesc">
+                     <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>sheet</div>
+                     
+                     
+                     <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                     
+                     <div class="extent">
+                        
+                        <div class="dimensions"><span class="tei-label">Dimensions (fragment): </span>
+                           <span class="height">c. 103</span> × <span class="width">103</span> mm.
+                           
+                           </div>
+                        </div>
+                     
+                     </div>
+                  
+                  <div class="handDesc">
+                     <h4>Hand(s)</h4>
+                     
+                     <p class="handNote">Formal Gothic bookhand</p>
+                     </div>
+                  </div>
+               <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+               <div class="history">
+                  <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                     <span class="origDate">14th century, late</span>
+                     ; <span class="origPlace">
+                        <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7000084">Germany</a></span>
+                        </span>
+                     </div>
+               </div>
+            </div>
+            <h2><?ni?>Additional Information<?ni?></h2>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Description (June 2021) by Peter Kidd, edited by Matthew Holford. Previously described
+                     in the Summary Catalogue. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0644.gif">Summary Catalogue, Vol. 5, p. 609</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <div class="surrogates">
+                  <h3 class="msDesc-heading3">Digital Images</h3>
+                  <p><span class="bibl">
+                        <a href="https://digital.bodleian.ox.ac.uk/objects/50370974-dffd-478a-bd86-30e9ff74995c/" target="_blank">
+                           <span class="title italic">Digital Bodleian</span>
+                           </a>
+                        <span class="note">(full digital facsimile)</span>
+                        </span><br /></p>
+               </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Online resources:</h4>
+                        
+                        <div class="bibl">
+                           <a href="https://hab.bodleian.ox.ac.uk/en/" target="_blank">
+                              <span class="title italic">Manuscripts from German-Speaking Lands – A Polonsky Foundation Digitization Project</span>
+                              </a>
+                           </div>
+                        </span>
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Printed descriptions:</h4>
+                        
+                        <div class="bibl">S. J. P. van Dijk, <span class="title italic">Latin Liturgical Manuscripts in the Bodleian Library, Oxford, vol. 2: Office Books</span> (typescript, 1957), <span class="citedRange">p. 349</span>
+                           </div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2021-06-07: Description fully revised for Polonksy German digitization project.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+   </body>
+</html>

--- a/processing/previews/Add_B.html
+++ b/processing/previews/Add_B.html
@@ -1,0 +1,2857 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <style type="text/css">body, html 
+{ 
+    font-size: 17px; 
+    font-family: "PT Sans", sans-serif;   
+    padding: 0; 
+    background-color: #ffffff; 
+} 
+ 
+ 
+.individual-item *:not(h5):not(h4):not(h3):not(h2):not(h1) 
+{ 
+    font-size: 17px; 
+} 
+.bold, .tei-label, .label, h5, h4, h3, h2, h1 
+{ 
+    font-weight: 700; 
+} 
+.super 
+{ 
+    position: relative; 
+    display: inline-block; 
+    font-size: small; 
+    top: -9px; 
+} 
+.tei-italic,.italic 
+{ 
+    font-style: italic; 
+} 
+ 
+.layoutDesc 
+{ 
+    margin: 10px 0; 
+} 
+.tei-label 
+{ 
+    height: 18px; 
+} 
+ 
+h4 
+{ 
+    margin-top: 5px; 
+    margin-bottom: 5px; 
+} 
+ 
+h1 
+{ 
+    font-size: 32px; 
+} 
+ 
+.nestedmsItem { 
+    margin-left: 16px; 
+    padding-bottom: 16px; 
+    border-bottom: 1px solid #eaeaea; 
+    margin-bottom: 16px; 
+    text-align: justify; 
+} 
+ 
+p,.seg,.item,.head,.physDesc-p,.tei-title,.locus,.note,.decoNote-list,.decoNote,.item-number 
+{ 
+    margin: 0 0 5px; 
+    text-align: justify; 
+} 
+ 
+.msItem,.msPart,.msSummary 
+{ 
+    border-bottom: 1px solid #eaeaea; 
+    margin-bottom: 16px; 
+    padding-bottom: 16px; 
+} 
+ 
+.secFol .italic 
+{ 
+    font-style: normal; 
+} 
+.support, .form, .extent, .dimensions, .foliation, .condition  
+{ 
+    margin-top: 5px; 
+} 
+p.note:last-of-type { 
+    margin: 0; 
+} 
+ 
+.incipit,.explicit,.rubric, .finalRubric,.textLang, 
+.origPlace,.secFol,.objectDesc,.additional,.colophon,.origin, .msName 
+{ 
+    text-align: justify; 
+    margin-bottom: 5px; 
+} 
+.author,.bibl,.orgName,#zotero-bibliography-text,.origDate,.origPlace,.additions, .coveragewarning 
+{ 
+    margin-bottom: 5px; 
+} 
+.physDesc, .history { 
+    text-align: justify; 
+} 
+ 
+.additional ul.listBibl 
+{ 
+    padding: 0; 
+} 
+ 
+.small-caps, .author, .translator 
+{ 
+    font-variant: small-caps; 
+} 
+ 
+.content.tei-body ul 
+{ 
+    list-style: none; 
+}</style>
+   </head>
+   <body style="padding:2em ! important;">
+      <h1 itemprop="name">MS. Add. B. 1</h1>
+      <div class="content tei-body" id="manuscript_77">
+         <div class="msDesc" id="MS_Add_B_1-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">30208</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_B_1-item1">
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_13218">Medical recipes, prayers in case of illness, and charms or incantations</a></span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Chiefly in English, sometimes in Latin.</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  </div>
+               
+               <div class="musicNotation"><span class="tei-label">Musical Notation: </span>
+                  
+                  <p>Music (see van Dijk 1957).</p>
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">16th century</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7002445">English</a></span>
+                     </span>
+                  </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Summary description by Elizabeth Solopova and Matthew Holford, based on the Summary
+                     Catalogue and supplementary sources. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0796.gif">Summary Catalogue, Vol. 5, p. 759</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Printed descriptions:</h4>
+                        
+                        <div class="bibl">S. J. P. van Dijk, <span class="title italic">Latin Liturgical Manuscripts in the Bodleian Library, Oxford, vol. 6: Fragments -
+                              Office Books, Rituals, Directories</span> (typescript, 1957), <span class="citedRange">p. 227</span>
+                           </div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. B. 3</h1>
+      <div class="content tei-body" id="manuscript_85">
+         <div class="msDesc" id="MS_Add_B_3-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">30210</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_B_3-item1">
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_13994">Private manual of practical devotion for a monk</a></span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">14th century, second half</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000070">French</a></span> (?)</span>
+                  </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Summary description by Elizabeth Solopova and Matthew Holford, based on the Summary
+                     Catalogue and supplementary sources. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0796.gif">Summary Catalogue, Vol. 5, p. 759</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. B. 6</h1>
+      <div class="content tei-body" id="manuscript_89">
+         <div class="msDesc" id="MS_Add_B_6-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">27790</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_B_6-item1">
+                  <div class="item-number">1. </div>
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_13268">Meditations based upon Augustine, <span class="title italic">Soliloquia</span></a></span>
+                  
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle French</div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_B_6-item2">
+                  <div class="item-number">2. </div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_89657091">Bonaventure</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_1146">Lignum vitae</a></span>
+                  
+                  <p class="note">French translation</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle French</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>paper</div>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century, middle</span>
+                  </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Summary description by Elizabeth Solopova and Matthew Holford, based on the Summary
+                     Catalogue and supplementary sources. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0391.gif">Summary Catalogue, Vol. 5, p. 356</a></div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0392.gif">Summary Catalogue, Vol. 5, p. 357</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Online resources:</h4>
+                        
+                        <div class="bibl"><a href="http://jonas.irht.cnrs.fr/manuscrit/39755" target="_blank"><span class="title italic">JONAS: Répertoire des textes et des manuscrits médiévaux d'oc et d'oïl</span></a></div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. B. 15</h1>
+      <div class="content tei-body" id="manuscript_83">
+         <div class="msDesc" id="MS_Add_B_15-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">28938</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_B_15-item1">
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_14814">Summae on the virtues and vices</a></span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">
+                     
+                     <p class="decoNote-p">Illuminated capitals.</p>
+                     </p>
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">14th century, early</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7016845">Netherlandish</a></span> (?)</span>
+                  </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Summary description by Elizabeth Solopova and Matthew Holford, based on the Summary
+                     Catalogue and supplementary sources. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0565.gif">Summary Catalogue, Vol. 5, p. 530</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. B. 17</h1>
+      <div class="content tei-body" id="manuscript_84">
+         <div class="msDesc" id="MS_Add_B_17-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">28967</span>
+                  </p>
+               </div>
+            <h4 class="msHead">Astrology; England, 15th century, second quarter or middle</h4>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="d174e95">
+                  
+                  <div class="locus">(fol. 1r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Tabula ad sciendum quis planeta regnat</span></div>
+                  
+                  <p class="note">Table of planetary hours for a week beginning on Sunday (as, for example, <span class="title italic">The Kalendarium of Nicholas of Lynn</span>, ed. S. Eisner (Athens, GA, 1980), pp. 17-18, 176-7); but with only 23 rows, so the
+                     columns run Sol, Mercurius, Saturnus, Mars, Venus, Luna, Iubiter.</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               <div class="msItem" id="d174e113">
+                  
+                  <div class="locus">(fol. 1r)</div>
+                  <span class="tei-title">Mnemonic verses</span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span><span class="sic">Sol[<i>sic</i>]</span> atque Venus boni Saturnus Marsque maligni | Sol et Mercurius cum Luna <span class="sic">sunt[<i>sic</i>]</span> mediocres</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Ordine retrogrado quisquis sibi vindicat horam</span></div>
+                  
+                  <p class="note">Four verses, the first two as <span class="title italic">Kalendarium</span>, ed. Eisner, p. 177.</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               <div class="msItem" id="d174e143">
+                  
+                  <div class="locus">(fol. 1v)</div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_10338">Lunary: prognostication for a journey</a></span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Whan the mone [image] is in the whethir [image] go out. In the bole [image] abide
+                        for why if þu passe out þu doost thi self gret harm. Whan he is in gem<span class="supplied">⟨i⟩</span>nis that is to sei both man an woman [image] go thi wai for than thu schalt finde
+                        a frende</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Whan he is in the <span class="supplied">⟨signe⟩</span> of fissches go not out for þu schalt be pore in þi going and in thi gein turnyng.
+                        Knowe þu for a certein reule þat whan þe mone is in the signe of an [<i>sic</i>] gode it is to begynne to seke þat þu askest wilfully, and whan he is in that signe
+                        the þinges þat þu sechest as matrimonie and edificacion and oþer swich it betokeneþ.
+                        Whan þe signe of Gemin regneþ hit be tokeneþ þinges double to be don. Whan þe mone
+                        is in þis signe to loke any <span class="unclear">membre<span class="unclearMarker">(?)</span></span> or to touche it is euil.</span></div>
+                  
+                  <p class="note">The rules for the position of the moon in the zodiac are close to those in the text
+                     <span class="title italic">Proportiones competentes in astrorum industria</span>, c. 10 (David Juste, <span class="title italic">Les Alchandreana primitifs : étude sur les plus anciens traités astrologiques latins
+                        d’origine arabe (Xe siècle)</span> (Leiden, 2007), pp. 187-8, 516-7). Similar Middle English texts are printed <span class="title italic">Medieval Lunar Astrology: A Collection of Representative Middle English Texts</span>, ed. Laurel Means (Lewiston etc., 1993), texts L10-L13. </p>
+                  <span class="listBibl">
+                     <div class="bibl">eVK 7934</div>
+                     <div class="bibl">Taavitsainen, <span class="title italic">Middle English Lunaries</span>, p. 83</div>
+                     <div class="bibl">Irma Taavitsainen, ‘The identification of Middle English lunary Mss.’, <span class="title italic">Neuphilologische Mitteilungen</span> 88 (1987), p. 26</div></span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English</div>
+                  </div>
+               
+               <div class="msItem" id="d174e199">
+                  
+                  <div class="locus">(fol. 1v)</div>
+                  <span class="tei-title">Mnemonic verses</span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Versus</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Ignea sunt Aries Leo Sagitarius Taurus, terrea sunt Caper et Vir</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Quattuor sunt elementa scilicet ignis calidus et siccus</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>aqua frigida et humida</span></div>
+                  
+                  <p class="note">Seven verses: five on the signs, two on the elements.</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               <div class="msItem" id="d174e227">
+                  
+                  <div class="locus">(fol. 2r)</div>
+                  <span class="tei-title">Table to find in which sign the moon is located on a given day (?)</span>
+                  
+                  <p class="note">Cf. for example, <span class="title italic">Kalendarium of Nicholas of Lynn</span>, ed. Eisner, pp. 22-24, 182-3, but here miscopied, with 12 columns and 12 rows, and
+                     with Virgo and Libra missing, so that Leo is followed by Scorpio. There is no column
+                     for the age of the moon, and above the columns are added the names of the months from
+                     March to February.</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               <div class="msItem" id="d174e246">
+                  
+                  <div class="locus">(fol. 2v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Duodecim sunt signa scilicet Aries Taurus Gemins Cancer Leo Virgo Libra Scorpio Sagittarius
+                        Caprinus Aquarius Pisses <span class="sic">Aries[<i>sic</i>]</span></span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>In þe first constitucion of þe world toke <span class="sic">virgi[<i>sic</i>]</span> first þe hed of a man. The bole haþ the nekk and þe þrete. Geminis þe armes vn to
+                        þe hand. Cancer þe brest and þe longes. Leo þe stomak. Virgo haþ þe entrayles</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>[penwork] beþ hoot and moyste be n<span class="supplied">⟨a⟩</span>t<span class="ex">(ur)</span>e of Jouis and Veneris [penwork] be cold and moyste by nature of þe mone ilych eyvn</span></div>
+                  
+                  <p class="note">References to genitalia are apparently replaced with blue and red penwork, cf. "Scorpius
+                     haþ [penwork]". </p> 
+                  <span class="listBibl">
+                     <div class="bibl">eVK 2911</div></span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English</div>
+                  
+                  
+                  </div>
+               
+               <div class="msItem" id="MS_Add_B_17-item1">
+                  
+                  <div class="locus">(fols. 3r-10r)</div>
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_10414">The Wise Book of Philosophy and Astronomy</a></span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Here beginneth of Astronomie and of philosophie contriued and y mad of the wisest
+                        philosephers and Astronomers þ<span class="ex">(a)</span>t euer were sitthen þis world was begunne That is for to seie of þe longe of Greke.
+                        For in <ins class="">\þat/</ins> londe an englissch man ful wise and wel vndirstondinge</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>he schal haue prosperyte he schal leue longe but ȝef þe cours of þe mone be more contrarius
+                        to hym </span></div>
+                  <span class="listBibl">
+                     
+                     <div class="bibl">ed. Griffin, sig. B6 (desc. p. xxix)</div>
+                     </span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English</div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_B_17-item2a">
+                  
+                  <div class="locus">(fols. 10r-18v)</div>
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_7471">The Book of Destinary</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Of þe .xij. signes. Aries. March.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Now hit is to declare of the xij signes of ther kyndes which eche man and woman is
+                        iordeyned by wey of kynd and predestinacion. And fyrst y schal determyn of þe signe
+                        of Aries þat regneþ in Marche</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>And sche ascape .xxx. wynter sche schal leue an .C. wynter. Her good days be Mondaye
+                        Thursday Fryday, and Tuesday and Saturday is evell. Now hit is to wete that what man
+                        or woman wol properleche deme the leuyng and þe predestinacion of man or of woman
+                        by þese forseid .xij. signes and .vij. planetes and .iiij. elementes him be houeþ
+                        to be hold and folow þe perilous termes of þe kalendar þenne trewleche and prophitableche
+                        he may þer of ȝeue a dome.</span></div>
+                  
+                  
+                  
+                  <p class="note">On the text see Griffin, pp. xlvii-xlix, with references to earlier literature.</p><span class="listBibl">
+                     <div class="bibl"> eVK 1093, 3752</div></span><div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English</div>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  <div class="extent"><span class="seg">ii (modern paper endleaves) + <span class="measure">18</span> + xii (blank modern paper) + ii (modern paper endleaves)</span>
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">c. 160</span> × <span class="width">c. 120</span> mm.
+                        
+                        </div>
+                  </div>
+                  
+                  <div class="foliation"><span class="tei-label">Foliation: </span>i-ii, 1-32 in modern pencil</div>
+                  
+                  <div class="collation">
+                     <h4>Collation</h4>
+                     <div class="collation">1(8), 2(8), 3(two); catchwords fols. 8v, 16v; one leaf signature '.b.j.', fol. 9r.</div>
+                  </div>
+                  
+                  
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p>Ruled in ink for 32 long lines; ruled space c. 
+                        <span class="height">125</span> × <span class="width">85</span> mm.
+                        
+                        </p>
+                     </div>
+                  </div>
+               
+               <div class="handDesc">
+                  <h4>Hand(s)</h4>
+                  
+                  <p class="handNote">Anglicana formata, one scribe.</p>
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">
+                     "Good miniatures" (<a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> iii. 800): small miniatures of the moon and signs of the zodiac in the lunary on
+                     fol. 1v. The artist has apparently misunderstood 'whethir' and drawn clouds instead
+                     of a ram.</p>
+                  
+                  <p class="decoNote">4- to 2-line blue initials flourished in red (one red initial flourished in blue,
+                     fol. 8r); penwork borders in red and blue (fols. 1v, 3r); line-fillers in red and
+                     blue penwork; rubrics in red; intermittent majuscules in red.</p>
+                  </div>
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">19th-century binding.</p>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century, second quarter or middle</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7002445">England</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">No. 2547 in a 19th cent bookseller's catalogue (cutting, fol. ii verso)</p>
+                  <p class="provenance">"When catalogued in Jan. 1885 the volume bore the modern armorial bookplate of Stephen
+                     Couchman, which has now disappeared" (Summary Catalogue): perhaps Stephen Couchman
+                     of London, printer, fl. 1779-1824 (on whom see Ian Maxsted, '<a href="https://bookhistory.blogspot.com/2007/01/london-1775-1800-c.html" target="_blank">The London book trades 1775-1800: a preliminary checklist of members</a>', Exeter Working Papers in Book History)</p>
+                  <p class="acquisition">Bought from John D. Denman, London bookseller, on May 29, 1869, for £3 3s. </p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Description by Matthew Holford, October 2025. Previously described: 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0570.gif">Summary Catalogue, Vol. 5, p. 535</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-10: Description revised.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. B. 54</h1>
+      <div class="content tei-body" id="manuscript_86">
+         <div class="msDesc" id="MS_Add_B_54-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">24723</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</p>
+               
+               <div class="msItem" id="MS_Add_B_54-item1">
+                  
+                  <div class="locus"><span class="item-number">1. </span>(fol. 2)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100227522">Horace</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_2097">Odes</a></span>
+                  
+                  <p class="note">In four books, fols. 24, 38, 63.</p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_B_54-item2">
+                  
+                  <div class="locus"><span class="item-number">2. </span>(fol. 77)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100227522">Horace</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_2092">Carmen saeculare</a></span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_B_54-item3">
+                  
+                  <div class="locus"><span class="item-number">3. </span>(fol. 79)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100227522">Horace</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_2096">Epodes</a></span>
+                  
+                  <p class="note">Followed by:</p>
+                  
+                  <div class="nestedmsItem" id="d176e176" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                     <span class="tei-title">Life of Horace</span>
+                     
+                     <div class="incipit"><span class="tei-label">Incipit: </span><span>Horatius Q. Flaccus libertino praecone patre natus</span></div>
+                     </div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="seg"><span class="measure">ii</span> + <span class="measure">98</span></span> fols. 
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">160</span> × <span class="width">105</span> mm.
+                        
+                        </div>
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (written): </span>
+                        <span class="height">105</span> × <span class="width">60–5</span> mm.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p>1 col., 21 lines.</p>
+                     </div>
+                  </div>
+               
+               <div class="handDesc">
+                  <h4>Hand(s)</h4>
+                  
+                  <p class="summary">Fol. 95: 'Librum hunc <span class="persName scr"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_754">Laurentius Petrini filius et Ballanteae</a></span> domus suis manibus scripsit. Anno Mo ccccliiij'.</p>
+                  
+                  <p class="handNote">Humanistic script.</p>
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">Fine borders, initials. (<a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> ii. 264, pl. XXIV)</p>
+                  
+                  <p class="decoNote">Coloured initials, gold headings.</p>
+                  
+                  <p class="decoNote">Fol. 2r: initial M: gold initial with white-stem decoration on multicoloured ground.</p>
+                  
+                  <p class="decoNote">Fol. 2r: border, upper, right and lower margins: white-stem decoration on multicoloured
+                     ground. In lower margin two winged putti support the coat of arms of Bellanti of Siena.</p>
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">1454</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italian</a></span>, <span class="settlement"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7011179">Siena</a></span> (?) 
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance"><span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100162294">Celso Cittadini, 1553–1627</a></span>: 'Emi ego Celsus Cittadinus a Fabio Paulinio librorum ueterum uenditore die xx Januarij
+                     1603 iulios duodec.', fol. 95.</p>
+                  <p class="provenance"><span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_19743305">Guglielmo Libri</a></span>, no. 500 in his sale, 1859.</p>
+                  <p class="acquisition">Purchased.</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Adapted (2018) from A. G. Watson, <span class="title italic">Catalogue of Dated and Datable Manuscripts</span>; Pächt and Alexander (see Bibliography); and the Summary Catalogue (1905). Additional
+                     description of decoration by Elizabeth Solopova, c. 2000. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0088.gif">Summary Catalogue, Vol. 5, p. 53</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">                         
+                        <div class="bibl">A. G. Watson, <span class="title italic"><a href="https://catalog.hathitrust.org/Record/000310664" target="_blank">Catalogue of Dated and Datable Manuscripts c.435–1600 in Oxford Libraries</a></span> (Oxford, 1984), no. 16</div>
+                        
+                        <div class="bibl">Otto Pächt and J. J. G. Alexander, <span class="title italic"><a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Illuminated Manuscripts in the Bodleian Library, Oxford</a></span>, II (1970), no. 264</div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. B. 55</h1>
+      <div class="content tei-body" id="manuscript_87">
+         <div class="msDesc" id="MS_Add_B_55-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">28995</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_B_55-item1">
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100907186">Propertius</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_3799">Elegies</a></span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">
+                     
+                     <p class="decoNote-p">Good initials. (<a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> ii. 711)</p>
+                     </p>
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century, middle</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italian</a></span>
+                     <span class="region">Lombardy</span>
+                     
+                     </span>
+                  </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Summary description by Elizabeth Solopova and Matthew Holford, based on the Summary
+                     Catalogue and supplementary sources. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0573.gif">Summary Catalogue, Vol. 5, p. 538</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. B. 59</h1>
+      <div class="content tei-body" id="manuscript_88">
+         <div class="msDesc" id="MS_Add_B_59-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">30216</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_B_59-item1">
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_285771738">Onosander</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_3381">De optimo imperatore</a></span>, 
+                  
+                  <p class="note">tr. <span class="persName trl"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_79117675">Nicolaus Sagundinus</a></span>.</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">
+                     
+                     <p class="decoNote-p">Fine miniature (drawing) with framing ornament perhaps added.  (<a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> ii. 494, pl. XLVII)</p>
+                     <span class="head">
+                        <p>fol. iv verso</p></span><ul class="list">
+                        
+                        
+                        <li><b>Type</b> 
+                           <span class="seg">drawing</span>
+                           </li>
+                        
+                        
+                        <li><b>Subject</b> 
+                           <span class="seg">Frontispiece with arms of Pasquale Malipiero, doge of Venice, framed with floral ornaments,
+                              perhaps added.</span>
+                           </li>
+                        
+                        </ul>
+                     </p>
+                  
+                  <p class="decoNote">Fine initial (faceted capital).</p>
+                  </div>
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">Stamped leather on boards with metal clasp fittings marked S, but clasp
+                     lost, contemporary Italian work, rebacked and mended recent.ly.</p>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">1457–62</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italian</a></span>
+                     <span class="settlement"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7018159">Venice</a></span>
+                     
+                     </span>
+                  </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Summary description by Elizabeth Solopova and Matthew Holford, based on the Summary
+                     Catalogue and supplementary sources. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0797.gif">Summary Catalogue, Vol. 5, p. 760</a></div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0798.gif">Summary Catalogue, Vol. 5, p. 761</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <div class="surrogates">
+                  <h3 class="msDesc-heading3">Digital Images</h3>
+                  <p><span class="bibl">
+                        <a href="https://digital.bodleian.ox.ac.uk/objects/237d98e3-7cee-4113-8de0-0c9a376c1390/" target="_blank">
+                           <span class="title italic">Digital Bodleian</span>
+                           </a>
+                        <span class="note">(3 images from 35mm slides)</span>
+                        </span><br /></p>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2022-04-04: Add binding information from Summary Catalogue.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. B. 62</h1>
+      <div class="content tei-body" id="manuscript_91">
+         <div class="msDesc" id="MS_Add_B_62-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29181</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_B_62-item1">
+                  <div class="locus"></div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_11032">Cistercian Ordinances to 1288, with additions to 1301</a></span>
+                  
+                  <p class="note">Including:</p>
+                  
+                  <div class="nestedmsItem" id="d181e119" style="margin-top:1rem;">
+                     
+                     <div class="locus">(fol. 5)</div>
+                     <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_16035">Carta Caritatis</a></span>
+                     </div>
+                  
+                  <div class="nestedmsItem" id="d181e128">
+                     
+                     <div class="locus">(fol. 9)</div>
+                     
+                     <div class="rubric"><span class="tei-label">Rubric: </span><span>Ordinatio Clementis pape iiii super reformatione ordinis</span></div>
+                     </div>
+                  
+                  <div class="nestedmsItem" id="d181e137" style="border-bottom-color:#FFFFFF; margin-bottom:0px;">
+                     
+                     <div class="locus">(fol. 67v)</div>
+                     
+                     <div class="colophon"><span class="tei-label">Colophon: </span><span>Expliciunt Diffiniciones capituli generalis conpilate mºccºlxxxviii</span></div>
+                     </div>
+                  
+                  <p class="note">In several hands. Fols. 68–80v contain additions from 1289 to 1301 written in more
+                     cursive hands than those of the preceding text, each addition being dated at the top
+                     of the page.</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  <div class="extent"><span class="tei-label">Extent: </span><span class="measure">80</span> fols. 
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">180</span> × <span class="width">133</span> mm.
+                        
+                        </div>
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (written): </span>
+                        <span class="height">135–40</span> × <span class="width">95–102</span> mm.
+                        
+                        </div>
+                     </div>
+                  
+                  
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p>1 col, 27 lines.</p>
+                     
+                     <p>Fols. 68–80: 15–17 lines.</p>
+                     </div>
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">Coloured initials.</p>
+                  <p class="decoNote">Rubrics.</p>
+                  </div>
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">Blind-stamped leather, late 16th century, rebacked.</p>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">1288–1300</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italian</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">Cistercian abbey of <span class="orgName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/org_212968081">Chiaravalle</a></span> de Bagnolo, dioc. Milan: 'Sum Monasterii Clareuallis', fol. 1, 17th cent.</p>
+                  <p class="provenance">Fol. iii: 'Nota che questo libro delle Diffinitioni dell'Ordine e del Monastero di
+                     Chiaraualle di Milano; il quale deuo restituire al prossimi Capitolo 1641'.</p>
+                  <p class="acquisition">Bought at the <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_238406190">William Bragge</a></span> sale, Nov. 1880 (lot 1363) for £3.</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Adapted (2018) from A. G. Watson, <span class="title italic">Catalogue of Dated and Datable Manuscripts</span>; and the Summary Catalogue (1905). 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0614.gif">Summary Catalogue, Vol. 5, p. 579</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">                         
+                        <div class="bibl">A. G. Watson, <span class="title italic"><a href="https://catalog.hathitrust.org/Record/000310664" target="_blank">Catalogue of Dated and Datable Manuscripts c.435–1600 in Oxford Libraries</a></span> (Oxford, 1984), no. 17</div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. B. 65</h1>
+      <div class="content tei-body" id="manuscript_92">
+         <div class="msDesc" id="MS_Add_B_65-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29272</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_B_65-item1">
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_15308">Theological texts</a></span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="physDesc-p">Composite: parts A-H</div>
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">13th century, late to 14th century, early</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italian</a></span>
+                     </span>
+                  </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Summary description by Elizabeth Solopova and Matthew Holford, based on the Summary
+                     Catalogue and supplementary sources. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0632.gif">Summary Catalogue, Vol. 5, p. 597</a></div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0633.gif">Summary Catalogue, Vol. 5, p. 598</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. B. 66</h1>
+      <div class="content tei-body" id="manuscript_93">
+         <div class="msDesc" id="MS_Add_B_66-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29273</span>
+                  </p>
+               </div>
+            <h4 class="msHead"><span class="title italic">Poor Caitiff</span> (selection: Pater Noster, Creed, Ten Commandments), with interpolated Wycliffite
+               texts; devotional verse. England, 15th century, first half </h4>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msSummary"><span class="tei-label">Summary of Contents: </span>Texts on fols. 12v-90v are found in the same order in British Library, Harley MS.
+                  2322: discussions by Brady, Kalvedi and Rice (see bibliography) suggest that the two
+                  manuscripts are closely related textually.</div>
+               <p class="ContentsTextLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English</p>
+               
+               
+               <div class="msItem" id="MS_Add_B_66-item-1">
+                  
+                  <div class="locus"><span class="item-number">1. </span>(fols. 3r-11v)</div>
+                  <span class="tei-title italic">The Fifteen Oes</span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Ihesu Crist Godis sone of heuene</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Ihesu crist godis sone</span></div>
+                  
+                  <span class="listBibl">
+                     <div class="bibl"><a href="https://www.dimev.net/record.php?recID=2804" target="_blank">DIMEV 2804</a> (NIMEV 1672)</div>
+                     
+                     <div class="bibl">John G. Hirsh, 'A Middle English metrical version of "The fifteen oes" from Bodleian
+                        Library MS. Add. B 66', <span class="title italic">Neuphilologische Mitteilungen</span>, 75, No. 1 (1974), pp. 98-114</div></span>
+                  
+                  <p class="note">A poem addressed to Christ in 4-line stanzas rhyming abab.</p>
+                  
+                  <p class="note">Fols. 1-2 are endleaves, blank except for later notes and scribbles, for which see
+                     Provenance.</p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_B_66-item-2">
+                  
+                  <div class="locus"><span class="item-number">2. </span>(fols. 11v-12r)</div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Man sigh &amp; sorw for þi synnes</span></div>
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Almyghti God lord &amp; souereyne. Amen</span></div>   
+                  <p class="note">Rest of fol. 12r blank.</p>
+                  <span class="listBibl">
+                     
+                     <div class="bibl"><a href="https://www.dimev.net/record.php?recID=3377" target="_blank">DIMEV 3377</a> (NIMEV 2073)</div>
+                     
+                     <div class="bibl">C. Brown, ed. <span class="title italic">Religious Lyrics of the XVth Century</span> (Oxford: 1939), 229-30</div>
+                     </span></div>
+               
+               
+               <div class="msItem" id="MS_Add_B_66-item-3">
+                  
+                  <div class="locus"><span class="item-number">3. </span>(fols. 12v-30v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Here bigynneþ a prolog on þe pater noster schortly declarid. Ion. capitulo 14.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Crist Ihesu seiþ in þe gospel þat who so loueþ me, schal kepe my comaundementis, þat
+                        ben his hestis eiþir hise biddingis. And þei þat kepen hem ben his frendis, as he
+                        seiþ in anoþer place. Io. 16. And he wille here hise frendis &amp; graunte hem al resonable
+                        þing þat þei asken of hym nedful to helpe of soule &amp; of bodie</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>And seint Ion Crisostom seiþ, if þou sechinge schalt contynue, þou schal take.</span></div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Now bygynneþ þe pater noster &amp; þe declaracion therof</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>The first axinge of þe pater noster answeriþ to þe fadir of heuene, and is seide on
+                        þis maner, Fadir oure þat art in heuenes, halowid by þi name. Lo, in þat þat þou clepist
+                        him fadir, þou knowlechist þat he is maker &amp; lord of al þingis, and þus þou knowlechist
+                        his miȝt</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>We schullen be herd of god in our praier and be deliuered fro alle yuel, and so to
+                        come to euerelasting liif in heuene. And in to þat blessid liif god bringe vs alle
+                        amen.</span></div>
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_13918">Poor Caitiff: Pater Noster</a></span>
+                  
+                  <p class="note">Lemmata in red. Running heads 'A prolog', 'Pater noster'.</p>
+                  <span class="listBibl">
+                     
+                     <div class="bibl"><span class="title italic">Pore Caitif: A Middle English Manual of Religion and Devotion</span>, ed. K. Moreau-Gilbert (Brepols, 2019)</div>
+                     
+                     <div class="bibl"><span class="title italic">The Poor Caitif: A Modern English Translation</span>, tr. Luke Penkett (Brepols, 2024), who lists 57 manuscripts including the present
+                        one.</div>
+                     
+                     <div class="bibl">Jolliffe B (p. 65 lists the present manuscript)</div>
+                     </span>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_B_66-item-4">
+                  
+                  <div class="locus"><span class="item-number">4. </span>(fols. 30v-35v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Here bigynneþ þe Aue Marie sumwhat declarid &amp; is þus mych to say, Heil Marie ful of
+                        grace, þe lord is wiþ þe, blessid be þou amonge wymmen &amp; blessid be þe fruyt of þi
+                        wombe. Ihesus. Amen.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>The aungel Gabriel was sent fro God to grete our lady Marie wiþ þese wordis, [in red]
+                        Heil ful of grace, þe lord is wiþ þee, blessid be þou amonge wymmen, and þanne he
+                        seide no mo wordis to hir, as þe gospel of Luk telliþ. But Elizabeth þe moder of Ion
+                        Baptist seide þese wordis</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>And þerfore preie we to God hertly to ȝeue vs grace to lyue wel &amp; to ende wel in charite,
+                        &amp; so to resseyue þe blisse of heuene, and to dwelle þerin for euer more. Amen.</span></div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_11170">Wycliffite commentary on Ave Maria</a></span>
+                  
+                  <p class="note">Lemmata in red. Running head 'Aue'.</p>
+                  <span class="listBibl"> 
+                     <div class="bibl"><span class="title italic">English Works of Wyclif</span>, ed. F. D. Matthew, EETS o.s. 74 (1880), pp. 203-8.</div>
+                     
+                     <div class="bibl">IPMEP 276</div>
+                     
+                     <div class="bibl">Wells Rev. 2:529 [58]</div></span>
+                  
+                  
+                  <div class="filiation"><span class="tei-label">Filiation: </span>Other manuscripts: see Rand, IMEP XX, p. 61 [18], listing five copies, to which add
+                     the present manuscript and BL, Harley MS. 2322, fols. 18r-23r</div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_B_66-item-5">
+                  
+                  <div class="locus"><span class="item-number">5. </span>(fols. 35v-47v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Here endiþ þe Aue Marie &amp; bigynneþ þe crede schortly declared</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>The ground of al goodnesse is þe trew bileue, for þer þorouȝ grace &amp; mercy is purchasid
+                        of God. For feiþ was þe principal grounde þat made þe womman of Canaan to purchasse
+                        helþe of bodie &amp; of soule to hir douȝtir of Crist þat was yuel turmentid wiþ a feende
+                        as þe gospel seiþ.</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span><span class="locus">(fol. 37r)</span> Þerfor aftir þe assencion of Crist, þe holy goost tauȝt þe apostlis alle treuþe þat
+                        was needful to hem, and bi techinge of þe holi goost, þe twelue settiden togedir twelue
+                        articlis of þe crede, þe which al þo þat wollen be saued moten stedefastli bileue.
+                        </span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>The first article is seide þus, I bileue in god fadir almiȝti maker of heuene &amp; of
+                        erþe. Oon is to bileue to god, anoþir is to bileue in god. Þe first han boþe good
+                        men &amp; yuel, but þe secounde han noon but good. </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>I bileue þat þere is an euerlastynge liif. And in þat liif &amp; ioie good men &amp; wymen
+                        þat lyuen wel &amp; eenden in parfiit charite schullen dwelle wiþouten ende. In to þat
+                        ioye he vs bringe, þat bouȝt vs wiþ his blood. Amen. </span></div>
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_13918">Poor Caitiff: The Creed</a></span>
+                  
+                  <p class="note">Apparently a distinctive version shared with Harley MS. 2322: see Brady, 1957, 324.
+                     Lemmata in red. Running head 'Crede'.</p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_B_66-item-6">
+                  
+                  <div class="locus"><span class="item-number">6. </span>(fols. 47v-90r)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Here eendiþ þe crede and here bigynneþ a prolog on þe ten comaundementis sumwhat declared
+                        </span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>A man axid of Crist what he <span class="sic">schuldo[<i>sic</i>]</span> to haue euere lastinge liif. And þan Crist seide to him, if þou wilt entre into liif,
+                        kepe þou þe comaundementis. Io. vi. Þis witty answere of Crist, men moun wel vnderstonde</span></div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span><span class="locus">(fol. 49r)</span> i. hest</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>The first heeste of god is þis, for God him silf spake alle þese wordis, I am þe lord
+                        þi god þat ladde þe out of þe lond of Egypt and brouȝt þe out of þe hous of þraldam,
+                        þou schalt not haue aliene goddis bifor me, þou schalt not make to þe an ymage grauen
+                        wiþ mannes honde</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>to graunte grace to alle his peple, þat þei mount leue synne, &amp; fle al þese cursis
+                        and to vse vertu &amp; holy lyuyng to haue þese blessingis &amp; so to dwelle in heuene wiþ
+                        oure lord Ihesu Crist for euremore. Amen.</span></div>
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_13918">Poor Caitiff: Ten Commandments</a></span>
+                  
+                  <p class="note">Trivedi, p. 139, is in error in stating that this version includes the Latin text
+                     of the commandments. Lemmata in the text ink, but underlined in red. Running heads
+                     'i. hest', 'ii. hest', etc. The final section (fol. 88r) with a flourished initial
+                     but no heading.</p>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_B_66-item-7">
+                  
+                  <div class="locus"><span class="item-number">7. </span>(fol. 90r-v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Answeris to hem þat seien we schulden not speke of holy writte</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>First know eche man þat charite is þe principal part of holy writte, &amp; if ony part
+                        of holy writte be taken fro vs, þane a part of charite is taken fro vs, for seint
+                        Poul seiþ, if we kepen charite, we fulfille al þe lawe of god</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>þat letten þe testament of Ihesus Crist <span class="damage">⟨<span class="gap">....</span>⟩</span> his testament is<span class="defective">||</span></span></div>
+                  <span class="tei-title">Short text on Biblical translation</span>
+                  
+                  <p class="note">Imperfect at end, missing the final five lines of the text as printed. Leaves are
+                     lost after fol. 90.</p>
+                  
+                  <p class="note">Other manuscripts: BL, Harley MS. 2322, fols. 87r-88; CUL MS. Ii.6.26, fols. 40v–41v
+                     (IMEP XX, p. 226 [6]). In the second manuscript it occurs as one of twelve tracts
+                     on translations (Wells Rev. 2:528[51]); pr. M. Dove, <span class="title italic">The earliest advocates of the English Bible: the texts of the medieval debate</span> (Exeter, 2010), pp. xlii-xliii and 117 (the present manuscript collated as O3).</p>
+                  </div>
+               
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment of variable type and quality (e.g. fols. 21/24, 29/32, 52/55, 59/62 of different
+                     type); some irregular edges, that on fol. 86 made good with a scarf repair before
+                     the page was ruled</div>
+                  
+                  <div class="extent"><span class="seg">2 + <span class="measure">90</span> leaves</span>
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">c. 150</span> × <span class="width">c. 105</span> mm.
+                        
+                        </div>
+                  </div>
+                  
+                  <div class="foliation"><span class="tei-label">Foliation: </span>19th century: 1-90, including 36a-b, 56a-b.</div>
+                  
+                  <div class="foliation"><span class="tei-label">Foliation: </span>15th-century foliation in roman numerals on the top left corner of versos (moving
+                     from around fol. 50v to the top middle). Through fol. 43v the foliation has been corrected
+                     (apparently to include the endleaves, although these are not themselves foliated),
+                     eg. vj to viij, vij to viiij. The foliation skips 10 from approximately fol. 43. </div>
+                  
+                  <div class="collation">
+                     <h4>Collation</h4>
+                     <div class="collation">Two free endleaves (fols. 1-2); 1(8)-11(8) (fols. 3-88 including 36a-b, 56a-b), 12
+                        (two), structure uncertain: two remaining leaves followed by the stubs of two leaves
+                        which have been cut out, and the upper inner corner of a leaf (apparently ruled but
+                        otherwise largely blank), the rest torn away. <span class="catchwords">Catchwords in decorative scrolls</span>; <span class="signatures">remains of a regular sequence of leaf signatures a-m usually with roman numerals but
+                           with arabic in quires b and k</span></div>
+                  </div>
+                  
+                  
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p>Ruled in ink for 1 col. of 19-20 lines (quires 1-4) or 23 lines (quires 5-12), typically
+                        with single vertical and double horizontal bounding lines. Some leaves, notably in
+                        quires 5 and 6, with double vertical bounding lines suggestive of earlier ruling for
+                        a different purpose. Ruled space 
+                        <span class="height">c. 105-110</span> × <span class="width">c. 70</span> mm.
+                        
+                         Prickings visible; some leaves with earlier sequences of pricking (e.g. fols. 29,
+                        32).</p>
+                     </div>
+                  </div>
+               
+               <div class="handDesc">
+                  <h4>Hand(s)</h4>
+                  
+                  <p class="handNote">Textualis with frequent hair-line strokes on final s, r, t, f</p>
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">2- to 3-line blue initials, flourished in  red.</p>
+                  </div>
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">15th-century inboard binding with a gothic structure, repaired. Sewn on five flat
+                     sewing supports of flat alum-tawed (?) intertwisted split thongs. Wooden oak boards
+                     with squares and external peripheral cushions, wood identified from grain pattern.
+                     The five sewing supports are laced to the boards with parallel two-hole lacing and
+                     secured with wooden pegs at the exit holes. The channels of the two upper and two
+                     lower supports each converge to shared exit holes (see Szirmai, fig. 9.33[E], p. 223).
+                      The current quarter-covering is a modern replacement. Clasp of alum-tawed skin stained
+                     pink closing left-to-right, catchplate and most of strap now lost.</p>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century, first half</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7002445">England</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">On fol. 78r the last line of the text is copied again in a later hand. Fol. 81r 'hunge
+                     (?) meddilton', 'knaff schall be'.</p>
+                  <p class="provenance">Fol. 1r: erased inscription (?) followed by 'lost thys bok', 15th century.</p>
+                  <p class="provenance">Fol. 2r: pen trials ('Item viij &amp; xx ovnes &amp; j qertrone' occurs twice)</p>
+                  <p class="provenance"><span class="persName sgn"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_5149">Oliver Forde</a></span>: fol. 1r, 'Be it sarrtefyett that j oleuere forde geyfes my sayll vn to all myghty
+                     Ihesu &amp; yowr laydy sant Mary &amp; all the sayntes in hevene', late 15th cent.</p>
+                  <p class="provenance">Fol. 1r: 'Chr. Towneley': <span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_309671366">Christopher Towneley (d. 1674)</a></span>, antiquarian, on whom see Oxford DNB; by descent in the Towneley family (see T. Kitto,
+                     'The Towneley family library', <span class="title italic">The Book Collector</span> 59 (2010) 399-416.)</p>
+                  <p class="acquisition">Bought at the Towneley MSS. sale (lot 12), Sotheby's, June 27, 1883, for £10 10s.</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Description by Matthew Holford, February 2026 (with thanks to Andrew Honey for description
+                     of the binding). Previously described in the Summary Catalogue (1897) 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0633.gif">Summary Catalogue, Vol. 5, p. 598</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     
+                     <div class="bibl">Nicole R. Rice, ‘Reformist Devotional Reading: The Pore Caitif in British Library,
+                        MS Harley 2322’, in <span class="title italic">The Medieval Mystical Tradition in England: Papers Read at Charney Manor, July 2011</span> [Exeter Symposium 8], ed. by E. A. Jones, Medieval Mystical Tradition (Boydell &amp;
+                        Brewer, 2013), pp. 177–94 (esp. nn. 22-23, with references)</div>
+                     
+                     <div class="bibl">Kalpen Trivedi, "'Trewe techyng and false heritikys': Some 'Lollard' manuscripts of
+                        the Pore Caitif", in <span class="title italic">In strange countries : Middle English literature and its afterlife : essays in memory
+                           of J.J. Anderson</span>, ed. David Matthews (Cambridge, 2011) 132-158</div>
+                     
+                     <div class="bibl">M. T. Brady, ‘Lollard Interpolation and Omissions in Manuscripts of the Pore Caitif’,
+                        in <span class="title italic">De Cella in Seculum: Religious and Secular Life and Devotion in Late Medieval England;
+                           an Interdisciplinary Conference, 20-22 July, 1986</span>, ed. by Michael G. Sargent (D.S. Brewer, 1989), 183-203</div>
+                     
+                     <div class="bibl">M. T. Brady, 'The Apostles and the Creed in Manuscripts of The Pore Caitif', <span class="title italic">Speculum</span>, 32/2 (Apr., 1957), 323-325 at 324</div>
+                     
+                     <div class="bibl">M. T. Brady, 'The "Pore Caitif": An Introductory Study', <span class="title italic">Traditio</span>, 10 (1954), 529-548 (at 534, 535-6)</div>
+                     </ul>
+               </div>
+               
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2026-02: Matthew Holford: description revised.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. B. 103</h1>
+      <div class="content tei-body" id="manuscript_78">
+         <div class="msDesc" id="MS_Add_B_103-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29422</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_B_103-item1">
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_207244871">Henricus de Hassia</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_1961">Speculum anime</a></span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century</span>
+                  </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Summary description by Elizabeth Solopova and Matthew Holford, based on the Summary
+                     Catalogue and supplementary sources. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0653.gif">Summary Catalogue, Vol. 5, p. 618</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. B. 107</h1>
+      <div class="content tei-body" id="manuscript_79">
+         <div class="msDesc" id="MS_Add_B_107-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29560</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_B_107-item1">
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_86920837">Robert Grosseteste</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_4354">Château d'amour</a></span>
+                   <span class="note">(English translation)</span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">
+                     
+                     <p class="decoNote-p">Illuminated capitals.</p>
+                     </p>
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century, second quarter (?)</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7002445">English</a></span>
+                     </span>
+                  </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Summary description by Elizabeth Solopova and Matthew Holford, based on the Summary
+                     Catalogue and supplementary sources. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0677.gif">Summary Catalogue, Vol. 5, p. 642</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               
+               <div class="surrogates">
+                  <h3 class="msDesc-heading3">Digital Images</h3>
+                  <p><span class="bibl"><a href="https://digital.bodleian.ox.ac.uk/objects/b6f6e693-efa2-4a21-a106-d2abc8010764/" target="_blank"><span class="title italic">Digital Bodleian</span></a>
+                        <span class="note">(1 image from 35mm slides)</span></span><br /></p>
+               </div>
+               
+               <h3 class="msDesc-heading3">Bibliography</h3>
+               <div class="listBibl">
+                  <ul class="listBibl">
+                     <span class="listBibl">
+                        
+                        <h4 class="head">Online resources:</h4>
+                        
+                        <div class="bibl"><a href="https://www.dhi.ac.uk/mwm/browse?type=ms&amp;id=92" target="_blank"><span class="title italic">MWM: Manuscripts of the West Midlands</span></a></div>
+                        </span>
+                     </ul>
+               </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. B. 110</h1>
+      <div class="content tei-body" id="manuscript_80">
+         <div class="msDesc" id="MS_Add_B_110-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29626</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_B_110-item1">
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_191439325">Apicius</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_611">De re coquinaria</a></span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  </div>
+               
+               <div class="handDesc">
+                  <h4>Hand(s)</h4>
+                  
+                  <p class="handNote">Humanistic script. (<a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> ii. 371)</p>
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="summary"><a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> ii. 371:</p>
+                  
+                  <p class="decoNote">Good border (unfinished)</p>
+                  
+                  <p class="decoNote">Good initial.</p>
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century, second half</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italian</a></span>, <span class="settlement"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7004474">Naples</a></span> or <span class="settlement"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7000874">Rome</a></span> (?)</span>
+                  </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Summary description by Elizabeth Solopova and Matthew Holford, based on the Summary
+                     Catalogue and supplementary sources. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0695.gif">Summary Catalogue, Vol. 5, p. 660</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. B. 111</h1>
+      <div class="content tei-body" id="manuscript_81">
+         <div class="msDesc" id="MS_Add_B_111-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29627</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_B_111-item1">
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_100198157">Persius</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_3489">Satires</a></span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  </div>
+               
+               <div class="handDesc">
+                  <h4>Hand(s)</h4>
+                  
+                  <p class="handNote">Humanistic script. (<a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> ii. 426).</p>
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="summary"><a href="https://catalog.hathitrust.org/Record/000468709" target="_blank">Pächt and Alexander</a> ii. 426:</p>
+                  
+                  <p class="decoNote">Fine border.</p>
+                  
+                  <p class="decoNote">Fine initial.</p>
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century, third quarter</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italian</a></span>, <span class="settlement"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7004264">Ferrara</a></span> (?)</span>
+                  </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Summary description by Elizabeth Solopova and Matthew Holford, based on the Summary
+                     Catalogue and supplementary sources. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0696.gif">Summary Catalogue, Vol. 5, p. 661</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. B. 119</h1>
+      <div class="content tei-body" id="manuscript_82">
+         <div class="msDesc" id="MS_Add_B_119-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29635</span>
+                  </p>
+               </div>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msItem" id="MS_Add_B_119-item1">
+                  <div class="item-number">1. </div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_18636329">Sedulius</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_4490">Carmen paschale</a></span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_B_119-item2">
+                  <div class="item-number">2. </div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_18636329">Sedulius</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_4491">Epistola ad Macedonium</a></span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_B_119-item3">
+                  <div class="item-number">3. </div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_18636329">Sedulius</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_4492">Hymn 'Cantemus Domino'</a></span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_B_119-item4">
+                  <div class="item-number">4. </div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_66806872">Augustine</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_760">De disciplina christiana</a></span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment, paper</div>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_1000080">Italian</a></span>
+                     </span>
+                  </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Summary description by Elizabeth Solopova and Matthew Holford, based on the Summary
+                     Catalogue and supplementary sources. 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0696.gif">Summary Catalogue, Vol. 5, p. 661</a></div>
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0697.gif">Summary Catalogue, Vol. 5, p. 662</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2017-07-01: First online publication.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+      <h1 itemprop="name">MS. Add. B. 60</h1>
+      <div class="content tei-body" id="manuscript_90">
+         <div class="msDesc" id="MS_Add_B_60-msDesc1" lang="en">
+            <div class="msIdentifier">
+               
+               
+               
+               
+               
+               
+               
+               <p>Summary Catalogue no.: 
+                  <span class="idno">29179</span>
+                  </p>
+               </div>
+            <h4 class="msHead">Medical recipes and texts, mostly in Middle English; England, 15th century, second
+               half</h4>
+            <h3><?ni?>Contents<?ni?></h3>
+            <div class="msContents">
+               
+               <div class="msSummary"><span class="tei-label">Summary of Contents: </span>The manuscript is a twin of <a href="https://cudl.lib.cam.ac.uk/view/MS-TRINITY-COLLEGE-O-00008-00035/15" target="_blank">Cambridge, Trinity College, MS O.8.35</a>, with identical original contents, written by the same scribe, using the same mise-en-page,
+                  and with the texts in many cases divided in the same way between quires. Almost all
+                  the contents of fols. 1r-83v are also found (not in the same order) in Lambeth Palace
+                  Library MS. 444 (mid 15th century).</div>
+               
+               
+               
+               
+               <div class="msItem" id="d180e107">
+                  
+                  <div class="locus">(fols. iii recto - iv verso)</div>
+                  
+                  <p class="note">Early modern recipes (for bleeding, the stone, cramp, joints, gout and sciatica, a
+                     purgative, falling sickness, eyes (?), and bruising) added on paper endleaves. </p>
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>English</div>
+                  </div>
+               
+               <div class="msItem" id="MS_Add_B_60-item1">
+                  
+                  <div class="locus">(fol. 1r-52r)</div>
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_7492">A Treatise of All Manner of Infirmities of Man's Body</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Here begynneth a tretys of al manere of infirmitees of mannys body, both wythinne
+                        as touchyng to phisyk, and withoute as touchyng to surgere, from the crowne of the
+                        heed to the soole of the foot. And the remedies therwith if god wol. And first we
+                        <span class="sic">wol at[<i>sic</i>]</span> heer of the hede, how it shulde be norisshede and kepte et cetera. </span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>For to make heer to growe. Take withien leues and sethe hem in oyle and hony and anoynte
+                        the heede therwith and it shal make the heer to growe and waxe. Another. Take <span class="sic">bees[<i>sic</i>]</span> and drie hem in a furneys or in a panne, and make therof a pouder and sethe it in
+                        hony and anonynte the pacyent therwith and it shal make the heer to growe. Another.
+                        For to make heer to growe after scalles. There is an oynement that is cleped vnguentum
+                        Aristotilis, thus it must be made.</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>[for the menson] &amp; rest hym wel &amp; tender &amp; ete this pere thus dight last at euene.
+                        Another. Take clene whete &amp; sethe it til it be broke &amp; stampe it waterlees. </span></div>
+                  
+                  <p class="note">Large recipe collection (over 300 recipes) organized head to toe, but apparently ending
+                     incompletely, covering head (including face, eyes, ears, nose, teeth, etc., and 'the
+                     infirmytees of mannys heed wythyn' (fol. 7v), fols. 1r-29v, with a recipe for Gratia
+                     Dei at fols. 13r-14v and 'dwale', fol. 21v), neck (fols. 29v-30v), breast 'and the
+                     spiritualtes withynne the brest' (fols. 30v-39r, with recipes for women's breasts
+                     at 37v-39r), stomach (including back, liver, spleen) (fols. 39r-49r), worms, venom
+                     and bites (fols. 49r-51r), and ending with flux (fols. 51r-52r). </p>
+                  
+                  <p class="note"> The text ends thus in all the known manuscripts, but comparison with other collections
+                     confirms that the final recipe is incomplete (cf. for example <span class="title italic">The Liber de Diversis Medicinis</span>, ed. M. S. Ogden, EETS OS 207 (repr. 1969), p. 31/17).</p>
+                  
+                  <p class="note">Other manuscripts: Trinity O.8.35 fols. 1r-52r (IMEP 11, O.8.35[2]); Lambeth MS. 444
+                     fols. 128r-142r (imperfect at beginning) (IMEP 13, 444[1]). </p>
+                  <span class="listBibl">
+                     
+                     <div class="bibl">eVK 2194, 6541</div>
+                     
+                     <div class="bibl">eVK 6363 (the dwale recipe, fol. 21v)</div>
+                     </span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English </div>
+                  </div>
+               
+               <div class="msItem" id="d180e169">
+                  
+                  <div class="locus">(fols. 52v-57r)</div>
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_7483">The Doom of Urines</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Ad discernendum vrinam humanam ab vrina mulieris et vrinam bestie ab vrina humana
+                        vel muliebri</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Thou shalt vnderstonde that if there be eny trouble in mannys vryne, that troublenes
+                        shewith in the myddes of the vryne, and in a wommannys water it doth not so.</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>it tokeneth reume in the breste &amp; a wickede stomak &amp; a badde lyuere &amp; badde lunges
+                        &amp;c.</span></div>
+                  
+                  <p class="note">Lines 199-214, 215 (the heading only is given), 224-336, 338-379 of the text as printed.</p>
+                  <span class="listBibl">
+                     <div class="bibl">expanded version, ed. M. Teresa Tavormina, EETS O.S. 354 (2019), pp. 30-41, not using
+                        the present manuscript; p. xxviii lists 54 manuscripts, including the present one
+                        and Lambeth MS. 444, fols. 159r-160Ar (IMEP 13, 444[6]), Trinity O.8.35 fols. 52v-57r
+                        (IMEP 11, O.8.35[3]). </div>
+                     <div class="bibl">M. Teresa Tavormina, <span class="title italic">Uroscopy in Middle English: A Guide to the Texts and Manuscripts</span>, Studies in medieval and renaissance history 3rd ser., 11 (2014), 2.2 (p.25)</div>
+                     
+                     <div class="bibl">eVK 7534, 7840, 7812, 7773, 1996</div>
+                     </span> 
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English </div>
+                  
+                  <p class="note">The next item follows directly without any break.</p>
+                  </div>
+               
+               <div class="msItem" id="d180e210">
+                  
+                  <div class="locus">(fols. 57r-59r)</div>
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_7493">The Governance of Signs</a></span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>It is for to wite þat euery moneth in the yere, the mone hath his course in the xij.
+                        signes. In euery sygne þe mone is ij. days and an half almoost. Also it is for to
+                        wite that the signes haue her gouernaunce of euery man &amp; beste in xij. parties of
+                        the bodye <span class="editorialgap"> […] </span> <span class="locus">(fol. 57v)</span> Aries gouernyth the heed and the face. Taurus the neck and the knotte of the throte.
+                        <span class="editorialgap"> […] </span> Piscis only the feet. Also is to for to wite that a medicyne laxatif must be take
+                        whan the mone is in Cancre <span class="editorialgap"> […] </span> <span class="locus">(fol. 58r)</span> Also be ware of these days in blood lettyng that is to say in the caniculer days
+                        the whiche begynnyn xviij days before Lammas <span class="editorialgap"> […] </span> Also it is for to wite <span class="locus">(fol. 58v)</span> that euery day begnneth atte hye none <span class="editorialgap"> […] </span> Firthermore it is for to wite that in the sonne rysynge of euery day is the first
+                        houre of euery day to accounte after the planetes </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>and thoo that ben coleryke and fleumous stonde in mene bewar.</span></div>
+                  
+                  <p class="note"><span class="title italic">Uroscopy in Middle English: A Guide to the Texts and Manuscripts</span>, Appendix A.4 (p. 109) lists six manuscripts, including the present one, Lambeth
+                     MS. 444, fols. 158v-159r (IMEP 13, 444[7, with the following item]), and Trinity O.8.35,
+                     fols. 57r-59r (IMEP 11, O.8.35[4, with the following item]); but the text in one manuscript
+                     (Trinity Cambridge O.7.2a fols. 1r-8r) contains much fuller material on the signs
+                     and lacks the additional material found in the other copies.</p>
+                  <span class="listBibl">
+                     
+                     <div class="bibl">eVK 3137, 0876</div>
+                     </span> 
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English </div>
+                  
+                  </div>
+               
+               <div class="msItem" id="d180e263">
+                  
+                  <div class="locus">(fols. 59r-65v)</div>
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_7494">The Four Elements</a></span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>It is to vnderstonde that euery man is maad of iiij. elementes, is to say that euery
+                        man hath iiij. humours like to the iiij. elementes. These ben the iiij. elementes,
+                        that is to wyte fire, eyre, water, and erthe. Euery body lyuyng hathe somewhat of
+                        hem but not euery body iliche.</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>And fro ix of the klock before mydnyght til iij. of the klock after mydnyght regnyth
+                        fleume that is colde &amp; moiste and so is that partie of the nyght and after begynneth
+                        blood to regne ayen.</span></div>
+                  
+                  
+                  <p class="note">On the four humours, the four ages, the four seasons, the four winds, ending with
+                     the division of twenty-four hours between the humours.</p>
+                  
+                  <p class="note"><span class="title italic">Uroscopy in Middle English</span> 8.2 (pp. 64-6) lists 21 copies containing the full version or extracts; our text
+                     belongs to abbreviated version A (8.2.2a, pp. 65-6), with 12 copies listed. For previous
+                     discussion see IMEP 17, p. 62 (Caius 336/725 [4]).</p>
+                  <span class="listBibl">
+                     
+                     <div class="bibl">eVK 3208</div>
+                     </span> 
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English </div>
+                  </div>
+               
+               <div class="msItem" id="d180e297">
+                  
+                  <div class="locus">(fol. 65v)</div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Here folewith the manere of wrytyng of bylles for receytes. A pound is wryton thus
+                        lj, j half a pound thus lj s'.</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>half an handful thus m. s' or thus m. di. Of eche iliche ana.</span></div>
+                  
+                  <p class="note">Lambeth 444, fol. 160A verso (IMEP 13, 444[8]); Trinity O.8.35, fol. 65v (IMEP 11,
+                     O.8.35[5], q.v. for other copies).</p>
+                  <span class="listBibl">
+                     
+                     <div class="bibl">eVK 0673</div>
+                     </span> 
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English </div>
+                  </div>
+               
+               <div class="msItem" id="d180e324">
+                  
+                  <div class="locus">(fols. 65v-69v)</div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_10338">Astrological lunary</a></span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Aries hoot and drye. Whan the mone is vnder the signe of Aries that Wether, that signe
+                        is mouable, hoot and drye, colerike, of kynde of that fire, than it is good to make
+                        what thynge that longith to mevynge, as for to bathen, to be late blood that tyme
+                        is for to eschewen for to touche the hed of man with iren</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>that signe Piscis makith the feet of man and of womman in his moder wombe, and if
+                        eny man or womman be wounded in the feet whan the mone is vndernethe that signe, vnnethe
+                        or euere he shal be couered </span></div>
+                  
+                  <p class="note">Other manuscripts: Trinity O.8.35, fols. 65v-69v (IMEP 11, O.8.35[6]); Lambeth 444,
+                     fols. 160Av-162r (IMEP 13, 444[9]); the version of <span class="title italic">The Governance of Signs</span> in Trinity Cambridge O.2.7a fols. 1r-8r (see above) is frequently similar in contents
+                     and wording.</p>
+                  <span class="listBibl">
+                     
+                     <div class="bibl">eVK 8042</div>
+                     </span> 
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English </div>
+                  
+                  </div>
+               
+               <div class="msItem" id="d180e357">
+                  
+                  <div class="locus">(fols. 69v-70r)</div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_10409">Astrology: prognostication by birth</a></span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Signum Aquarii dicitur quia sanctus Johannes Baptista baptisatus fuit in flumine Jordani
+                        in mense Januarij quem habet Januarius. Qui nascitur in hoc signo negligens erit.</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>[Capricorn] Qui in hoc signo nascitur diues &amp; amabilis erit valde.</span></div>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  
+                  </div>
+               
+               <div class="msItem" id="d180e378">
+                  
+                  <div class="locus">(fols. 70r-83v)</div>
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_7495">Digestives Simple and Compound</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>This table tellith of digestiues symple &amp; compound of euery humour, that is to say
+                        of colere, fleume, and malencolie. The first chapiter of medicyne symple, digestiues
+                        of coler and compouned.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span><span class="locus">(fol. 72r)</span> For sothe somme good frendes whiche trowed me to haue syght of konnynge praiden me
+                        | to opene to hem in <span class="sic">wryrtynge[<i>sic</i>]</span> shortly medicynes digestiues and euacuatiues or voidynge, symple and compound, the
+                        whiche leches comounly vseden.</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Medicynes symple digestyues of coler ben these. Violet, roses, endyue</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Compound for the same ben þese. Sirupus rodoun with medicines colinge the reynes the
+                        which ben afore said.</span></div>
+                  
+                  <p class="note">Treatise on digestive and evacuative medicines. In 29 chapters, preceded by table
+                     of contents.</p>
+                  
+                  <p class="note">IMEP 17, pp. 62-3 (Caius 336/725 [5]) lists the present manuscript and four others
+                     (including Lambeth 444 (IMEP 13, 444[3]) and Trinity O.8.35 (IMEP 11, O.8.35[7-8])).</p>
+                  <span class="listBibl">
+                     
+                     <div class="bibl">eVK 7482, 1966, 3572</div>
+                     </span> 
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English </div>
+                  
+                  </div>
+               
+               <div class="msItem" id="d180e424">
+                  
+                  <div class="locus">(fols. 83v-84r)</div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_13203">Two added recipes for migraine on originally blank leaves</a></span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>A noble medycyne for the mygreyne in the hede &amp; for the enpostyme yn the hede <span class="editorialgap"> […] </span> Take iiij penny weyght of the rote of pelletre of spayne, j peny weyght of spyknard
+                        <span class="editorialgap"> […] </span> <span class="note">(second recipes)</span> Another for the same. Take the iuse of syngrene &amp; womannys mylke that noryssheth
+                        a knave childe &amp; white wyne</span></div>
+                  <span class="listBibl">
+                     
+                     <div class="bibl">eVK 5387</div>
+                     </span> 
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English </div>
+                  </div>
+               
+               <div class="msItem" id="d180e454">
+                  
+                  <div class="locus">(fol. 84v)</div>
+                  
+                  <p class="note">Added notes on originally blank page: two incomplete 16th-century copies of the text
+                     on Pisces from fol. 69r, and an incomplete note 'Item that I Jhon Thomas viij gortes'.</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>English</div>
+                  </div>
+               
+               <div class="msItem" id="d180e467">
+                  
+                  <div class="locus">(fols. 85r-86v)</div>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Here folowen the entraailes of man and medicines also for certeyn parties of a mannys
+                        body</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>The longe holdith two ouer parties of the brest, and it helith or couerith the herte.
+                        The stomak is bitwene the ouer nesshe ribbes. The litel wombe is vndernethe the stomak.
+                        The gyser or the gyserne is in teh ryght side and he is sprad <span class="sic">for[<i>sic</i>]</span> the nauell to the parte of the wombe</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>If the siknesse be in the <span class="sic">bladde[<i>sic</i>]</span>. Of litel mete thou shalt be sone ful, the vryne shal be foule &amp; hoot, &amp; the colour
+                        shal palle. Take therefore the rotes of fenel and apum &amp; betonicam &amp; sethe it in wyne
+                        &amp; drynke it ix days twies in the day and thou shalt be hool.</span></div>
+                  
+                  <p class="note">Medical text on disorders of the internal organs.</p>
+                  
+                  <p class="note">Trinity O.8.35, fols. 85r-86v (IMEP 11, O.8.35[9], indexing fols. 85r-112r)</p>
+                  
+                  <span class="listBibl">
+                     
+                     <div class="bibl">eVK 6894, 6895</div>
+                     </span> 
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English </div>
+                  </div>
+               
+               
+               <div class="msItem" id="d180e506">
+                  
+                  <div class="locus">(fols. 86v-87r)</div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Now begynnen the iiij. tymes of the yere. Wynter is moist &amp; colde &amp; like vnto þe ayre
+                        &amp; in that tyme waxith the blood. | And it profitith that tyme thynge that be temporat &amp; euen of complexion as chikens
+                        </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>And from the myddes of <ins class="">\December in to the myddes of/</ins> Marche is hiemps that is to say wynter.</span></div>
+                  
+                  <p class="note">Dietary according to the season.</p>
+                  
+                  <p class="note">Trinity O.8.35, fols. 86v-87r (IMEP 11, O.8.35[9], indexing fols. 85r-112r)</p>
+                  <span class="listBibl">
+                     
+                     <div class="bibl">eVK 8173</div>
+                     </span> 
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English </div>
+                  </div>
+               
+               <div class="msItem" id="d180e541">
+                  
+                  <div class="locus">(fols. 87v-112r)</div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_13203">Medical recipes</a></span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Here folewen now after trew and proued medicynes good and prophetable cures for dyuerse
+                        infirmitees, greuaunces and siknesses of mannys or wommannes or childes body</span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>For the goute, a souerayn medicyn proued. Take a gander of vij yere old of oo coloure
+                        that is fatte ... (second recipe) Another good medicyne for the goute. Take culuerfoot
+                        and stampe it and ley it vpon the goute ... (third recipe) Another souereyn medicyne
+                        for the same. Take walwort a good handful and iiij. vnces of barowes grece</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>[laxative] but lete it not lye ther to longe for it wol thanne make hym haue the flyxe.</span></div>
+                  
+                  <p class="note">Various recipes (approximately 80), beginning with a group for gout, followed by hemorrhoids,
+                     sore breasts, migraine, eyes, burns, flux, stone, to know if a sick man shall live
+                     or die, freckles, childbirth, palsy, etc., and including recipes for oleum benedictum,
+                     'methe eglyn', aqua vitae, and 'baume artificial'. Includes recipes 'proued by <span class="sic">on one[<i>sic</i>]</span> Exceter of Brystowe', 'by one John Blake' (both fol. 88v), 'wel proued by John Berkham'
+                     (fols. 89v, 98r), 'proued by John Welyngton' (fol. 90v), 'by John Laurence', 'by John
+                     Chitterne' (both fol. 91r), 'by oon Snelle' or 'John Snell' or 'Snell of Wynchestre
+                     and other dyuerse' (fols. 96r, 98v, 101r), 'by a knyght of Rodys' (fol. 102v).</p> 
+                  
+                  <p class="note">Trinity O.8.35, fols. 87v-112r (IMEP 11, O.8.35[9], indexing fols. 85r-112r).</p>
+                  <span class="listBibl">
+                     
+                     <div class="bibl">eVK 2322 (prol.), 4684 (recipes), 2022 (metheglin)</div>
+                     
+                     </span> 
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English </div>
+                  
+                  <p class="note">The following item continues without a break.</p>
+                  </div>
+               
+               <div class="msItem" id="d180e584">
+                  
+                  <div class="locus">(fol. 112r-121v)</div>
+                  <span class="tei-title">On apostemes, etc.</span>
+                  
+                  <div class="rubric"><span class="tei-label">Rubric: </span><span>Modo aliqua sunt breviter dicenda de quibusdam apostematibus et eorum sygnis atque
+                        curis eorundem et medicynis </span></div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Sciendum est primo quod omnia apostemata exteriora que tumescunt siue inflantur siue
+                        sint parua siue magna, si magna sint nascuntur a quatuor humoribus peccantibus</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>et de eodem fac emplastrum &amp; pone desuper</span></div>
+                  
+                  <p class="note">A text on apostemes and cankers followed by related recipes, and recipes for wounds
+                     and plasters. Fols. 112r-116r (line 5 from bottom) correspond to the Middle English
+                     text in Wellcome Collection MS. fols. 188r-v (and partly in MS. Selden Supra 73, fols.
+                     30r-34v). At fol. 119r is a recipe for Gratia dei followed by notes on cankers and
+                     other recipes ('Hic incipit tractatus breuis de emplastris &amp; vnguentibus entraccio
+                     cerotis &amp; oleis pertinentibus ad cirurgiam, et primo de gratia dei maiori'). The final
+                     rubric, on fol. 121v, is in French.</p>
+                  
+                  <p class="note">Trinity O.8.35 fols. 112r-122v</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin with one rubric in French</div>
+                  
+                  </div>
+               
+               <div class="msItem" id="d180e614">
+                  
+                  <div class="locus">(fols. 121v-122v)</div>
+                  <span class="tei-title"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_13203">Medical recipes</a></span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>For bytynge of any hownde. Take the browne brede cromes and blake snayles and bray
+                        hem togedyr lyke paste and lay it to þe sore. (second recipe) For to make a precious
+                        and souereyn water for thilke eyen that ben faire and clere to se and to loke on and
+                        be blynde. Take smalache, redde fenel, rue, verueyne, beteyne, egrimoyne, quintfoyle
+                        ... (third recipe) For the dropesye in the vysage or hondes or feet either in eny
+                        other parte or membre þat it be, so that it be not withinne the bely, and also though
+                        it be in partie within þe body. Take lyuerwort &amp; grynde it smale and streyne oute
+                        clene the ius therof </span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>(last recipe, 'for a webbe or pynne that is in a mannys eye ...') the webbe shal go
+                        a way or pynne whethir that it be. This hathe be proued by men and women.</span></div> 
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English </div>
+                  
+                  <p class="note">Five recipes (the fourth for nosebleeds). Trinity College O.8.35 fols. 122v-124r (IMEP
+                     11, O.8.35[10]).</p> <span class="listBibl">
+                     
+                     <div class="bibl">eVK 6058</div>
+                     </span>
+                  </div>
+               
+               <div class="msItem" id="d180e642">
+                  
+                  <div class="locus">(fols. 122v–124r)</div>
+                  <span class="author"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_22158282">John Lydgate</a></span>, 
+                  <span class="tei-title italic"><a href="https://medieval.bodleian.ox.ac.uk/catalog/work_2722">Dietary</a></span>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>For helthe of body covyr for colde thyne hede</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>To all indeferente richeste dyatary. Explicit.</span></div>
+                  
+                  <p class="note">Written as prose. Added in a different but contemporary hand.</p>
+                  <span class="bibl"><a href="https://www.dimev.net/record.php?recID=1356" target="_blank"><span class="title italic">DIMEV</span> 1356</a></span> 
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English </div>
+                  </div>
+               
+               <div class="msItem" id="d180e673">
+                  
+                  <div class="locus">(fol. 124v)</div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>To make conserua roseado, take rosewater &amp; annes sede &amp; suger &amp; a lytle lucras &amp; put
+                        it in a podynger ... (second recipe) To make conserua rosearo take redde wyne &amp; roses
+                        drye or grene &amp; clarefid hony or suger ... (third recipe) To make orynges in seryp,
+                        take the rynes or orynges and boyle hem wel in oone water or too</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>To kype quynce &amp; wardes al þe yere, take a good pyce of new level bred &amp;c. [breaks
+                        off]</span></div>
+                  
+                  <p class="note">Five culinary recipes (the fourth for nuts in syrup) added in a contemporary hand.</p>
+                  <span class="listBibl">
+                     
+                     <div class="bibl">eVK 5908</div>
+                     </span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English </div>
+                  </div>
+               
+               <div class="msItem" id="d180e698">
+                  
+                  <div class="locus">(fol. 125r)</div>
+                  
+                  <p class="note">Added early-modern recipes (for the weakness of the back) on a previously blank page.</p>
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>English</div>
+                  </div>
+               
+               
+               
+               <div class="msItem" id="d180e709">
+                  
+                  <div class="locus">(fols. 125v-126v)</div>
+                  
+                  <div class="incipit"><span class="tei-label">Incipit: </span><span>Be thou pacient in thyn aduersite</span></div>
+                  
+                  <div class="explicit"><span class="tei-label">Explicit: </span><span>Thynkyng when god wyll better may be</span></div>
+                  
+                  <div class="colophon"><span class="tei-label">Colophon: </span><span>Amen Jhesus Marie filius quod <span class="persName">I. G.</span></span></div>
+                  
+                  <p class="note">Added in a contemporary hand. Preceded by a couplet ('Ihesu for thy precius blod &amp;
+                     thy bitter pascion Make my later endyng good &amp; the childe of saluacion')</p>
+                  <span class="listBibl">
+                     
+                     <div class="bibl">Kurt Bühler, “Patience in adversity”, <span class="title italic">Anglia</span> 78 (1960), 417-21.</div>
+                     
+                     <div class="bibl">DIMEV 780</div>
+                     
+                     <div class="bibl">NIMEV 478</div>
+                     </span>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Middle English</div>
+                  </div>
+               
+               <div class="msItem" id="d180e749">
+                  
+                  <div class="locus">(fol. 127r)</div>
+                  
+                  <p class="note">Diagram of Christ's side wound ('hec est vera mensura vulneris Christi'), contemporary
+                     addition, with early modern note 'Mendax es'.</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>Latin</div>
+                  </div>
+               
+               <div class="msItem" id="d180e761">
+                  
+                  <div class="locus">(fol. 127v-129v)</div>
+                  
+                  <p class="note">Early-modern recipes for noli me tangere, gout, 'any kind of ach', 'the French poxe',
+                     ulcers and cankers, added on the verso of a former pastedown (fol. 127) and on the
+                     paper endleaves of an earlier binding (fols. 128-9).</p>
+                  
+                  <div class="textLang"><span class="tei-label"><?ni?>Language(s):<?ni?> </span>English</div>
+                  </div>
+               </div>
+            <h3><?ni?>Physical Description<?ni?></h3>
+            <div class="physDesc">
+               
+               <div class="objectDesc">
+                  <div class="form"><span class="tei-label"><?ni?>Form:<?ni?> </span>codex</div>
+                  
+                  
+                  <div class="support"><span class="tei-label"><?ni?>Support:<?ni?> </span>parchment</div>
+                  
+                  <div class="extent"><span class="seg">ii + ii + <span class="measure">127</span> + ii + ii leaves</span>
+                     
+                     <div class="dimensions"><span class="tei-label">Dimensions (leaf): </span>
+                        <span class="height">c. 190</span> × <span class="width">c. 150</span> mm.
+                        
+                        </div>
+                     </div>
+                  
+                  <div class="foliation"><span class="tei-label">Foliation: </span>i-iv, 1-131</div>
+                  
+                  <div class="collation">
+                     <h4>Collation</h4>
+                     <div class="collation">1(8)-10(8) (fols. 1-80), 11(8-1, but structure unclear) (fols. 81-87) | 12(8)-16(8)
+                        
+                        (fols. 88-127). 
+                        Catchwords survive on fols. 24v, 32v, 40v, 48v, 56v, 64v,
+                        72v, 80v, erased on fol. 88v?, 95v. No surviving leaf signatures.</div>
+                  </div>
+                  
+                  
+                  <div class="layoutDesc">
+                     <h4>Layout</h4>
+                     
+                     <p>Frame-ruled (verticals only?) in very fine, barely visible leadpoint; one column of
+                        
+                        typically 22 lines. Written space typically 
+                        <span class="height">c. 140</span> × <span class="width">c. 95</span> mm.
+                        
+                        </p>
+                     </div>
+                  </div>
+               
+               <div class="handDesc">
+                  <h4>Hand(s)</h4>
+                  
+                  <p class="handNote">Written in a single mixed hand, predominantly secretary.</p>
+                  
+                  <p class="handNote">Additions in probably more than one contemporary hand (fols. 122r-124v; fols. 124v,
+                     125v-126v) and in several 16th- and 17th-century hands (fols. iii recto - iv verso,
+                     125v, 127v-129v)</p>
+                  </div>
+               
+               <div class="decoDesc">
+                  <h4>Decoration</h4>
+                  
+                  <p class="decoNote">Fols. 1r-83v: headings written in a larger module and underlined in red. </p>
+                  
+                  <p class="decoNote">Fols. 87r-122v: headings in red. </p>
+                  
+                  <p class="decoNote">Fols. 1r-122v: calligraphic initials in red or in the ink of the text.</p>
+                  
+                  <p class="decoNote">Fol. 122v: 3-line initial in blue.</p>
+                  
+                  <p class="decoNote">Fol. 127r: Diagram of Christ's side wound.</p>
+                  </div>
+               
+               <div class="bindingDesc">
+                  <h4>Binding</h4>
+                  
+                  
+                  <p class="binding-p">17th-century binding of blind-tooled leather over pasteboard, with the panel design
+                     on both covers later reworked; 'Treatise on Physic' on the spine.</p>
+                  
+                  <p class="binding-p">The left pastedown, fols. i-ii and 130-1, and the right pastedown are separate paper
+                     endleaves from the current binding. Fols. iii-iv, 128-129 are separate paper endleaves
+                     from an earlier binding. Fol. 127, an integral endleaf, was a pastedown in a further
+                     earlier binding of tanned leather.</p>
+                  
+                  </div>
+               </div>
+            <h3 class="msDesc-heading3"><?ni?>History<?ni?></h3>
+            <div class="history">
+               <div class="origin"><span class="tei-label"><?ni?>Origin:<?ni?> </span>
+                  <span class="origDate">15th century, second half</span>
+                  ; <span class="origPlace">
+                     <span class="country"><a href="https://medieval.bodleian.ox.ac.uk/catalog/place_7002445">England</a></span>
+                     </span>
+                  </div>
+               <div class="provenance">
+                  <h4>Provenance and Acquisition</h4>
+                  <p class="provenance">Extensive signs of use including numerous marginal annotations of recipe topics.</p>
+                  <p class="provenance">Erased early-modern ownership inscription (?), illegible, fol. iii verso; erased early-modern
+                     name (Thomas ...), fol. 126v.</p>
+                  <p class="provenance">Possibly first day, lot 74 in the sale of the library of Sir William Hamilton (1730-1803),
+                     8 June 1809 and two following days (<span class="title italic">Catalogue of the Very Choice and Extremely Valuable Library ...</span>, p. 9).</p>
+                  <p class="provenance"><span class="persName fmo"><a href="https://medieval.bodleian.ox.ac.uk/catalog/person_120696480">Adam Clarke (1762-1832)</a></span>, Irish minister and scholar, MS. 151, in <span class="title italic"><a href="https://wellcomecollection.org/works/y6ku25hb/items?canvas=100" target="_blank">A historical and descriptive catalogue of the European and Asiatic manuscripts in
+                           the library of the late Dr. Adam Clarke, F.S.A., M.R.I.A., etc.</a></span> (1835) (cf. Madan's note 'No. CLI in some collection' on the pastedown; no such mark
+                     apparently extant); no. 120 in his sale (<span class="title italic">A List of Manuscripts ... Formerly in the Possession of the late Dr. Adam Clarke;
+                        On Sale ... by Baynes And Son</span> (London, 1836), p. 11; cutting from the catalogue pasted to fol. i recto.</p>
+                  <p class="provenance">'J. H. from J. N. R. March 1841'.</p>
+                  <p class="provenance">'Lot 167 in some sale' (Madan's note, left pastedown; evidence for this no longer
+                     present)</p>
+                  <p class="acquisition">'Bought from J. E. Cornish, bookseller, 33 Piccadilly, Manchester, 1880' (left pastedown).</p>
+               </div>
+            </div>
+            <div class="additional">
+               
+               <div class="adminInfo">
+                  
+                  
+                  <h3><?ni?>Record Sources<?ni?></h3>
+                  <div class="source">Description by Matthew Holford, December 2025. Previously described: 
+                     <div class="listBibl">
+                        
+                        <div class="bibl"><a href="https://medieval.bodleian.ox.ac.uk/images/ms/aam/aam0613.gif">Summary Catalogue, Vol. 5, p. 578</a></div>
+                        </div>
+                     </div>
+                  
+                  </div>
+               </div>
+         </div>
+         <div class="abbreviations"><?ni?>
+            <h3>Abbreviations</h3>
+            <p>View <a href="https://github.com/bodleian/medieval-mss/wiki/Abbreviations" target="_blank">list of abbreviations</a> and <a href="https://github.com/bodleian/medieval-mss/wiki/Conventions" target="_blank">editorial conventions</a>.
+               </p>
+            <?ni?></div>
+         <div class="revisionDesc"><?ni?>
+            <h3>Last Substantive Revision</h3>
+            <p class="change">2025-12: Description revised.</p>
+            <?ni?></div>
+         <div class="data"><?ni?>
+            <h3>Data</h3>
+            <p>The TEI-XML file for this record can be viewed in a <a href="https://github.com/bodleian/medieval-mss" target="_blank">GitHub repository</a>.
+               </p>
+            <p>Tabular data derived from the TEI-XML files is available in a <a href="https://github.com/digital-Scholarship-Oxford/enabling-digital-research/" target="_blank">GitHub repository</a>.
+               </p>
+            <?ni?></div>
+      </div>
+   </body>
+</html>


### PR DESCRIPTION
this creates one html file per collection (two samples are in the preview folder). It could be a useful way of making records available when the catalogue is down. (could we even create a backup static site just from these html files?)

@irv @clairedaywork I suggest this as one possible workaround when the catalogue goes down - the script would need to be run each week at indexing, ideally - does that make any sense or are their other better alternatives?