### PR TITLE
Disable workflows

### DIFF
--- a/.github/workflows/check-entity-keys.yml
+++ b/.github/workflows/check-entity-keys.yml
@@ -1,17 +1,18 @@
 name: Check Entity Keys
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - "**.xml"
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - "**.xml"
-  schedule:
-    - cron: "0 3 * * 1" # Every Monday at 03:00 UTC
+  workflow_dispatch:
+  # push:
+  #   branches:
+  #     - master
+  #   paths:
+  #     - "**.xml"
+  # pull_request:
+  #   types: [opened, synchronize, reopened, ready_for_review]
+  #   paths:
+  #     - "**.xml"
+  # schedule:
+  #   - cron: "0 3 * * 1" # Every Monday at 03:00 UTC
 
 permissions:
   contents: read

--- a/.github/workflows/validate-xml.yml
+++ b/.github/workflows/validate-xml.yml
@@ -1,16 +1,16 @@
 name: Validate XML
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - "**/*.xml"
-  pull_request:
-    paths:
-      - "**/*.xml"
-  schedule:
-    - cron: "0 3 * * 1"
+  # push:
+  #   branches:
+  #     - master
+  #   paths:
+  #     - "**/*.xml"
+  # pull_request:
+  #   paths:
+  #     - "**/*.xml"
+  # schedule:
+  #   - cron: "0 3 * * 1"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This will hopefully disable the automatic triggering of the two workflows, but will still allow manual triggering.

It does not stop dependabot, which may need an admin to update the settings.